### PR TITLE
Add random directive to remark-campfire

### DIFF
--- a/packages/remark-campfire/__tests__/random.test.tsx
+++ b/packages/remark-campfire/__tests__/random.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
+import { unified } from 'unified'
+import remarkParse from 'remark-parse'
+import remarkDirective from 'remark-directive'
+import remarkRehype from 'remark-rehype'
+import rehypeStringify from 'rehype-stringify'
+import remarkCampfire from '../index'
+import { useGameStore } from '@/packages/use-game-store'
+
+function createProcessor(stringify = true) {
+  const processor = (unified() as any)
+    .use(remarkParse)
+    .use(remarkDirective)
+    .use(remarkCampfire)
+    .use(remarkRehype)
+
+  if (stringify) {
+    processor.use(rehypeStringify)
+  }
+
+  return processor
+}
+
+beforeEach(() => {
+  useGameStore.setState({ gameData: {}, _initialGameData: {}, locale: 'en-US' })
+})
+
+afterEach(() => {
+  useGameStore.setState({ gameData: {}, _initialGameData: {}, locale: 'en-US' })
+})
+
+describe('remarkCampfire random directive', () => {
+  it('generates a random number within the range', async () => {
+    const processor = createProcessor()
+    const originalRandom = Math.random
+    Math.random = () => 0.5
+    const md = '::random{variable="roll" min=1 max=10}\n:get[roll]'
+    const result = await processor.process(md)
+    Math.random = originalRandom
+    expect(result.toString().trim()).toBe('<p>6</p>')
+    expect(useGameStore.getState().gameData.roll).toBe(6)
+  })
+
+  it('selects a value from a list', async () => {
+    const processor = createProcessor()
+    const originalRandom = Math.random
+    Math.random = () => 0.25
+    const md =
+      '::random{variable="loot" from="gold,silver,gems,artifact"}\n:get[loot]'
+    const result = await processor.process(md)
+    Math.random = originalRandom
+    expect(result.toString().trim()).toBe('<p>silver</p>')
+    expect(useGameStore.getState().gameData.loot).toBe('silver')
+  })
+})

--- a/packages/remark-campfire/directives.ts
+++ b/packages/remark-campfire/directives.ts
@@ -115,6 +115,64 @@ export function handleDirective(
       parent.children.splice(index, 1, textNode)
       return index
     }
+  } else if (directive.name === 'random') {
+    const attrs = directive.attributes || {}
+    const variableRaw = (attrs as Record<string, unknown>).variable
+    if (typeof variableRaw !== 'string') {
+      if (parent && typeof index === 'number') {
+        parent.children.splice(index, 1)
+        return index
+      }
+      return
+    }
+
+    let value: unknown
+
+    const from = (attrs as Record<string, unknown>).from
+    if (typeof from === 'string') {
+      const options = from
+        .split(',')
+        .map(s => s.trim())
+        .filter(Boolean)
+      if (options.length > 0) {
+        const idx = Math.floor(Math.random() * options.length)
+        value = options[idx]
+      }
+    } else {
+      const minRaw = (attrs as Record<string, unknown>).min
+      const maxRaw = (attrs as Record<string, unknown>).max
+      const min =
+        typeof minRaw === 'number'
+          ? minRaw
+          : minRaw == null
+            ? undefined
+            : parseFloat(String(minRaw))
+      const max =
+        typeof maxRaw === 'number'
+          ? maxRaw
+          : maxRaw == null
+            ? undefined
+            : parseFloat(String(maxRaw))
+      if (
+        typeof min === 'number' &&
+        !Number.isNaN(min) &&
+        typeof max === 'number' &&
+        !Number.isNaN(max)
+      ) {
+        const low = Math.min(min, max)
+        const high = Math.max(min, max)
+        value = Math.floor(Math.random() * (high - low + 1)) + low
+      }
+    }
+
+    if (value !== undefined) {
+      useGameStore.getState().setGameData({ [variableRaw]: value })
+    }
+
+    if (parent && typeof index === 'number') {
+      parent.children.splice(index, 1)
+      return index
+    }
   } else if (directive.name === 'if') {
     if (!parent || typeof index !== 'number') return
     const ifDirective = directive as ContainerDirective


### PR DESCRIPTION
## Summary
- add `random` directive implementation
- test `random` directive for numeric ranges and lists

## Testing
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_688ad102c86883208a89313acf0dc1a8