### PR TITLE
Fix GlobalRegistrator cleanup

### DIFF
--- a/happydom.ts
+++ b/happydom.ts
@@ -3,6 +3,6 @@ import { afterAll } from 'bun:test'
 
 GlobalRegistrator.register()
 
-afterAll(() => {
-  GlobalRegistrator.unregister()
+afterAll(async () => {
+  await GlobalRegistrator.unregister()
 })


### PR DESCRIPTION
## Summary
- ensure `GlobalRegistrator.unregister` is awaited in test setup

## Testing
- `bun test`
- `bun tsc`

------
https://chatgpt.com/codex/tasks/task_b_688adb2bfa1083209aaa415bc15fb7d1