### PR TITLE
feat(remark-campfire): support increment and decrement directives

### DIFF
--- a/packages/remark-campfire/__tests__/increment.test.tsx
+++ b/packages/remark-campfire/__tests__/increment.test.tsx
@@ -59,4 +59,13 @@ describe('remarkCampfire increment and decrement directives', () => {
       value: 0
     })
   })
+
+  it('evaluates expressions for the amount value', async () => {
+    const processor = createProcessor()
+    const md =
+      '::set[number]{score=5}\n::increment{variable="score" amount="score * 2"}\n:get[score]'
+    const result = await processor.process(md)
+    expect(result.toString().trim()).toBe('<p>15</p>')
+    expect(useGameStore.getState().gameData.score).toBe(15)
+  })
 })

--- a/packages/remark-campfire/__tests__/increment.test.tsx
+++ b/packages/remark-campfire/__tests__/increment.test.tsx
@@ -7,7 +7,7 @@ import rehypeStringify from 'rehype-stringify'
 import remarkCampfire from '../index'
 import { useGameStore } from '@/packages/use-game-store'
 
-function createProcessor(stringify = true) {
+const createProcessor = (stringify = true) => {
   const processor = (unified() as any)
     .use(remarkParse)
     .use(remarkDirective)

--- a/packages/remark-campfire/__tests__/increment.test.tsx
+++ b/packages/remark-campfire/__tests__/increment.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
+import { unified } from 'unified'
+import remarkParse from 'remark-parse'
+import remarkDirective from 'remark-directive'
+import remarkRehype from 'remark-rehype'
+import rehypeStringify from 'rehype-stringify'
+import remarkCampfire from '../index'
+import { useGameStore } from '@/packages/use-game-store'
+
+function createProcessor(stringify = true) {
+  const processor = (unified() as any)
+    .use(remarkParse)
+    .use(remarkDirective)
+    .use(remarkCampfire)
+    .use(remarkRehype)
+
+  if (stringify) {
+    processor.use(rehypeStringify)
+  }
+
+  return processor
+}
+
+beforeEach(() => {
+  useGameStore.setState({ gameData: {}, _initialGameData: {}, locale: 'en-US' })
+})
+
+afterEach(() => {
+  useGameStore.setState({ gameData: {}, _initialGameData: {}, locale: 'en-US' })
+})
+
+describe('remarkCampfire increment and decrement directives', () => {
+  it('increments numeric values', async () => {
+    const processor = createProcessor()
+    const md =
+      '::set[number]{score=5}\n::increment{variable="score" amount=3}\n:get[score]'
+    const result = await processor.process(md)
+    expect(result.toString().trim()).toBe('<p>8</p>')
+    expect(useGameStore.getState().gameData.score).toBe(8)
+  })
+
+  it('decrements numeric values', async () => {
+    const processor = createProcessor()
+    const md =
+      '::set[number]{health=10}\n::decrement{variable="health" amount=4}\n:get[health]'
+    const result = await processor.process(md)
+    expect(result.toString().trim()).toBe('<p>6</p>')
+    expect(useGameStore.getState().gameData.health).toBe(6)
+  })
+
+  it('clamps range values when applying changes', async () => {
+    const processor = createProcessor()
+    const md = `::set[range]{hp='{"lower":0,"upper":10,"value":5}'}\n::decrement{variable="hp" amount=7}\n:get[hp]`
+    const result = await processor.process(md)
+    expect(result.toString().trim()).toBe('<p>0</p>')
+    expect(useGameStore.getState().gameData.hp).toEqual({
+      lower: 0,
+      upper: 10,
+      value: 0
+    })
+  })
+})

--- a/packages/remark-campfire/helpers.ts
+++ b/packages/remark-campfire/helpers.ts
@@ -28,6 +28,12 @@ export const isRange = (v: unknown): v is RangeValue => {
 export const clamp = (n: number, min: number, max: number) =>
   Math.min(Math.max(n, min), max)
 
+export const parseNumericValue = (value: unknown, defaultValue = 0): number => {
+  if (typeof value === 'number') return value
+  const num = parseFloat(String(value))
+  return Number.isNaN(num) ? defaultValue : num
+}
+
 export const parseRange = (input: unknown): RangeValue => {
   let obj: unknown = input
   if (typeof input === 'string') {
@@ -143,14 +149,23 @@ export const resolveIf = (node: ContainerDirective): RootContent[] => {
   return []
 }
 
+export const removeNode = (
+  parent: Parent | undefined,
+  index: number | undefined
+): number | undefined => {
+  if (parent && typeof index === 'number') {
+    parent.children.splice(index, 1)
+    return index
+  }
+  return undefined
+}
+
 export const ensureVariable = (
   raw: unknown,
   parent: Parent | undefined,
   index: number | undefined
 ): string | undefined => {
   if (typeof raw === 'string') return raw
-  if (parent && typeof index === 'number') {
-    parent.children.splice(index, 1)
-  }
+  removeNode(parent, index)
   return undefined
 }

--- a/packages/remark-campfire/helpers.ts
+++ b/packages/remark-campfire/helpers.ts
@@ -142,3 +142,15 @@ export const resolveIf = (node: ContainerDirective): RootContent[] => {
   if (next.name === 'elseif') return resolveIf(next)
   return []
 }
+
+export const ensureVariable = (
+  raw: unknown,
+  parent: Parent | undefined,
+  index: number | undefined
+): string | undefined => {
+  if (typeof raw === 'string') return raw
+  if (parent && typeof index === 'number') {
+    parent.children.splice(index, 1)
+  }
+  return undefined
+}


### PR DESCRIPTION
## Summary
- add `increment` and `decrement` directive support
- test increment/decrement logic

## Testing
- `bun tsc`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_688aea1ae2248320b39327df2f434cce