### PR TITLE
Fix directive key attribute

### DIFF
--- a/packages/remark-campfire/__tests__/increment.test.tsx
+++ b/packages/remark-campfire/__tests__/increment.test.tsx
@@ -33,7 +33,7 @@ describe('remarkCampfire increment and decrement directives', () => {
   it('increments numeric values', async () => {
     const processor = createProcessor()
     const md =
-      '::set[number]{score=5}\n::increment{variable="score" amount=3}\n:get[score]'
+      '::set[number]{score=5}\n::increment{key="score" amount=3}\n:get[score]'
     const result = await processor.process(md)
     expect(result.toString().trim()).toBe('<p>8</p>')
     expect(useGameStore.getState().gameData.score).toBe(8)
@@ -42,7 +42,7 @@ describe('remarkCampfire increment and decrement directives', () => {
   it('decrements numeric values', async () => {
     const processor = createProcessor()
     const md =
-      '::set[number]{health=10}\n::decrement{variable="health" amount=4}\n:get[health]'
+      '::set[number]{health=10}\n::decrement{key="health" amount=4}\n:get[health]'
     const result = await processor.process(md)
     expect(result.toString().trim()).toBe('<p>6</p>')
     expect(useGameStore.getState().gameData.health).toBe(6)
@@ -50,7 +50,7 @@ describe('remarkCampfire increment and decrement directives', () => {
 
   it('clamps range values when applying changes', async () => {
     const processor = createProcessor()
-    const md = `::set[range]{hp='{"lower":0,"upper":10,"value":5}'}\n::decrement{variable="hp" amount=7}\n:get[hp]`
+    const md = `::set[range]{hp='{"lower":0,"upper":10,"value":5}'}\n::decrement{key="hp" amount=7}\n:get[hp]`
     const result = await processor.process(md)
     expect(result.toString().trim()).toBe('<p>0</p>')
     expect(useGameStore.getState().gameData.hp).toEqual({
@@ -63,7 +63,7 @@ describe('remarkCampfire increment and decrement directives', () => {
   it('evaluates expressions for the amount value', async () => {
     const processor = createProcessor()
     const md =
-      '::set[number]{score=5}\n::increment{variable="score" amount="score * 2"}\n:get[score]'
+      '::set[number]{score=5}\n::increment{key="score" amount="score * 2"}\n:get[score]'
     const result = await processor.process(md)
     expect(result.toString().trim()).toBe('<p>15</p>')
     expect(useGameStore.getState().gameData.score).toBe(15)

--- a/packages/remark-campfire/__tests__/random.test.tsx
+++ b/packages/remark-campfire/__tests__/random.test.tsx
@@ -34,7 +34,7 @@ describe('remarkCampfire random directive', () => {
     const processor = createProcessor()
     const originalRandom = Math.random
     Math.random = () => 0.5
-    const md = '::random{variable="roll" min=1 max=10}\n:get[roll]'
+    const md = '::random{key="roll" min=1 max=10}\n:get[roll]'
     const result = await processor.process(md)
     Math.random = originalRandom
     expect(result.toString().trim()).toBe('<p>6</p>')
@@ -46,7 +46,7 @@ describe('remarkCampfire random directive', () => {
     const originalRandom = Math.random
     Math.random = () => 0.25
     const md =
-      '::random{variable="loot" options="gold,silver,gems,artifact"}\n:get[loot]'
+      '::random{key="loot" options="gold,silver,gems,artifact"}\n:get[loot]'
     const result = await processor.process(md)
     Math.random = originalRandom
     expect(result.toString().trim()).toBe('<p>silver</p>')

--- a/packages/remark-campfire/__tests__/unset.test.tsx
+++ b/packages/remark-campfire/__tests__/unset.test.tsx
@@ -32,7 +32,7 @@ afterEach(() => {
 describe('remarkCampfire unset directive', () => {
   it('removes a value from the store', async () => {
     const processor = createProcessor()
-    const md = '::set{health=10}\n::unset{variable="health"}\n:get[health]'
+    const md = '::set{health=10}\n::unset{key="health"}\n:get[health]'
     const result = await processor.process(md)
     expect(result.toString().trim()).toBe('<p></p>')
     expect(useGameStore.getState().gameData.health).toBeUndefined()

--- a/packages/remark-campfire/directives.ts
+++ b/packages/remark-campfire/directives.ts
@@ -13,7 +13,7 @@ import {
   parseRange,
   getRandomItem,
   getRandomInt,
-  ensureVariable,
+  ensureKey,
   removeNode
 } from './helpers'
 import type { RangeValue, DirectiveNode } from './helpers'
@@ -127,12 +127,8 @@ export function handleDirective(
     }
   } else if (directive.name === 'random') {
     const attrs = directive.attributes || {}
-    const variable = ensureVariable(
-      (attrs as Record<string, unknown>).variable,
-      parent,
-      index
-    )
-    if (!variable) return index
+    const key = ensureKey((attrs as Record<string, unknown>).key, parent, index)
+    if (!key) return index
 
     let value: unknown
 
@@ -171,19 +167,15 @@ export function handleDirective(
     }
 
     if (value !== undefined) {
-      useGameStore.getState().setGameData({ [variable]: value })
+      useGameStore.getState().setGameData({ [key]: value })
     }
 
     const removed = removeNode(parent, index)
     if (typeof removed === 'number') return removed
   } else if (directive.name === 'increment' || directive.name === 'decrement') {
     const attrs = directive.attributes || {}
-    const variable = ensureVariable(
-      (attrs as Record<string, unknown>).variable,
-      parent,
-      index
-    )
-    if (!variable) return index
+    const key = ensureKey((attrs as Record<string, unknown>).key, parent, index)
+    if (!key) return index
     const amountRaw = (attrs as Record<string, unknown>).amount
 
     let amount: number = 1
@@ -208,31 +200,31 @@ export function handleDirective(
     }
 
     const state = useGameStore.getState()
-    const current = state.gameData[variable]
+    const current = state.gameData[key]
     if (isRange(current)) {
       state.setGameData({
-        [variable]: {
+        [key]: {
           ...current,
           value: clamp(current.value + amount, current.lower, current.upper)
         }
       })
     } else {
       const base = parseNumericValue(current, 0)
-      state.setGameData({ [variable]: base + amount })
+      state.setGameData({ [key]: base + amount })
     }
 
     const removed = removeNode(parent, index)
     if (typeof removed === 'number') return removed
   } else if (directive.name === 'unset') {
     const attrs = directive.attributes || {}
-    const variable = ensureVariable(
-      (attrs as Record<string, unknown>).variable ?? toString(directive),
+    const key = ensureKey(
+      (attrs as Record<string, unknown>).key ?? toString(directive),
       parent,
       index
     )
-    if (!variable) return index
+    if (!key) return index
 
-    useGameStore.getState().unsetGameData(variable)
+    useGameStore.getState().unsetGameData(key)
 
     return removeNode(parent, index)
   } else if (directive.name === 'if') {

--- a/packages/remark-campfire/helpers.ts
+++ b/packages/remark-campfire/helpers.ts
@@ -160,7 +160,7 @@ export const removeNode = (
   return undefined
 }
 
-export const ensureVariable = (
+export const ensureKey = (
   raw: unknown,
   parent: Parent | undefined,
   index: number | undefined


### PR DESCRIPTION
## Summary
- rename `ensureVariable` helper to `ensureKey`
- update `increment`, `random` and `unset` directives to use `key` attribute
- update tests for new attribute name

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_688b581cb6648320b6d6e44879ed8ac0