### PR TITLE
Add setOnce directive

### DIFF
--- a/packages/remark-campfire/__tests__/set-once.test.tsx
+++ b/packages/remark-campfire/__tests__/set-once.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
+import { unified } from 'unified'
+import remarkParse from 'remark-parse'
+import remarkDirective from 'remark-directive'
+import remarkRehype from 'remark-rehype'
+import rehypeStringify from 'rehype-stringify'
+import remarkCampfire from '../index'
+import { useGameStore } from '@/packages/use-game-store'
+
+function createProcessor(stringify = true) {
+  const processor = (unified() as any)
+    .use(remarkParse)
+    .use(remarkDirective)
+    .use(remarkCampfire)
+    .use(remarkRehype)
+
+  if (stringify) {
+    processor.use(rehypeStringify)
+  }
+
+  return processor
+}
+
+beforeEach(() => {
+  useGameStore.setState({ gameData: {}, _initialGameData: {}, locale: 'en-US' })
+})
+
+afterEach(() => {
+  useGameStore.setState({ gameData: {}, _initialGameData: {}, locale: 'en-US' })
+})
+
+describe('remarkCampfire setOnce directive', () => {
+  it('prevents future sets of the same key', async () => {
+    const processor = createProcessor()
+    const md = '::setOnce{health=10}\n::set{health=20}\n:get[health]'
+    const result = await processor.process(md)
+    expect(result.toString().trim()).toBe('<p>10</p>')
+    expect(useGameStore.getState().gameData.health).toBe('10')
+  })
+
+  it('allows setting again after unset', async () => {
+    const processor = createProcessor()
+    const md =
+      '::setOnce{health=10}\n::unset{key="health"}\n::set{health=5}\n:get[health]'
+    const result = await processor.process(md)
+    expect(result.toString().trim()).toBe('<p>5</p>')
+    expect(useGameStore.getState().gameData.health).toBe('5')
+  })
+})

--- a/packages/remark-campfire/directives.ts
+++ b/packages/remark-campfire/directives.ts
@@ -22,7 +22,7 @@ export function handleDirective(
   parent: Parent | undefined,
   index: number | undefined
 ): number | [typeof SKIP, number] | void {
-  if (directive.name === 'set') {
+  if (directive.name === 'set' || directive.name === 'setOnce') {
     const typeParam = (toString(directive).trim() || 'string').toLowerCase()
     const attrs = directive.attributes
     const safe: Record<string, unknown> = {}
@@ -97,7 +97,13 @@ export function handleDirective(
     }
 
     if (Object.keys(safe).length > 0) {
-      useGameStore.getState().setGameData(safe)
+      const state = useGameStore.getState()
+      state.setGameData(safe)
+      if (directive.name === 'setOnce') {
+        for (const key of Object.keys(safe)) {
+          state.lockKey(key)
+        }
+      }
     }
 
     if (parent && typeof index === 'number') {


### PR DESCRIPTION
## Summary
- introduce `setOnce` directive for remark-campfire
- track locked state keys in `use-game-store`
- test that `setOnce` prevents further updates until `unset`

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_688b6a0514d48320aea4b39d55a2b5ef