### PR TITLE
Add tabbed debug window

### DIFF
--- a/apps/campfire/__tests__/DebugWindow.test.tsx
+++ b/apps/campfire/__tests__/DebugWindow.test.tsx
@@ -25,20 +25,20 @@ describe('DebugWindow', () => {
   })
 
   it('does not render when debug option is false', () => {
-    useStoryDataStore.setState({ storyData: { options: { debug: false } } })
+    useStoryDataStore.setState({ storyData: { options: 'nope' } })
     render(<DebugWindow />)
     expect(document.body.textContent).toBe('')
   })
 
   it('renders when debug option is true', () => {
-    useStoryDataStore.setState({ storyData: { options: { debug: true } } })
+    useStoryDataStore.setState({ storyData: { options: 'debug' } })
     render(<DebugWindow />)
     const header = screen.getByText('Debug')
     expect(header).toBeInTheDocument()
   })
 
   it('can be dismissed', () => {
-    useStoryDataStore.setState({ storyData: { options: { debug: true } } })
+    useStoryDataStore.setState({ storyData: { options: 'debug' } })
     render(<DebugWindow />)
     const close = screen.getByRole('button', { name: 'Close' })
     act(() => {
@@ -49,7 +49,7 @@ describe('DebugWindow', () => {
 
   it('shows game data by default and switches tabs', () => {
     useStoryDataStore.setState({
-      storyData: { options: { debug: true }, foo: 'bar' }
+      storyData: { options: 'debug', foo: 'bar' }
     })
     useGameStore.setState(state => ({
       ...state,

--- a/apps/campfire/__tests__/DebugWindow.test.tsx
+++ b/apps/campfire/__tests__/DebugWindow.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach } from 'bun:test'
+import { render, screen, act } from '@testing-library/react'
+import { DebugWindow } from '../src/DebugWindow'
+import { useStoryDataStore } from '@/packages/use-story-data-store'
+import { useGameStore } from '@/packages/use-game-store'
+
+const resetStores = () => {
+  useStoryDataStore.setState({
+    storyData: {},
+    passages: [],
+    currentPassageId: undefined
+  })
+  useGameStore.setState({
+    gameData: {},
+    _initialGameData: {},
+    locale: 'en-US',
+    lockedKeys: {}
+  })
+}
+
+describe('DebugWindow', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    resetStores()
+  })
+
+  it('does not render when debug option is false', () => {
+    useStoryDataStore.setState({ storyData: { options: { debug: false } } })
+    render(<DebugWindow />)
+    expect(document.body.textContent).toBe('')
+  })
+
+  it('renders when debug option is true', () => {
+    useStoryDataStore.setState({ storyData: { options: { debug: true } } })
+    render(<DebugWindow />)
+    const header = screen.getByText('Debug')
+    expect(header).toBeInTheDocument()
+  })
+
+  it('can be dismissed', () => {
+    useStoryDataStore.setState({ storyData: { options: { debug: true } } })
+    render(<DebugWindow />)
+    const close = screen.getByRole('button', { name: 'Close' })
+    act(() => {
+      close.click()
+    })
+    expect(document.body.textContent).toBe('')
+  })
+
+  it('shows game data by default and switches tabs', () => {
+    useStoryDataStore.setState({
+      storyData: { options: { debug: true }, foo: 'bar' }
+    })
+    useGameStore.setState(state => ({
+      ...state,
+      gameData: { x: 1 }
+    }))
+
+    render(<DebugWindow />)
+    expect(screen.getByText(/"x": 1/)).toBeInTheDocument()
+
+    const storyTab = screen.getByRole('button', { name: 'Story Data' })
+    act(() => {
+      storyTab.click()
+    })
+    expect(screen.getByText(/"foo": "bar"/)).toBeInTheDocument()
+  })
+})

--- a/apps/campfire/__tests__/DebugWindow.test.tsx
+++ b/apps/campfire/__tests__/DebugWindow.test.tsx
@@ -40,7 +40,7 @@ describe('DebugWindow', () => {
   it('can be dismissed', () => {
     useStoryDataStore.setState({ storyData: { options: 'debug' } })
     render(<DebugWindow />)
-    const close = screen.getByRole('button', { name: 'Close' })
+    const close = screen.getByRole('button', { name: 'Close debug window' })
     act(() => {
       close.click()
     })

--- a/apps/campfire/src/DebugWindow.tsx
+++ b/apps/campfire/src/DebugWindow.tsx
@@ -1,9 +1,14 @@
-import { useState } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import {
   useStoryDataStore,
   type StoryDataState
 } from '@/packages/use-story-data-store'
 import { useGameStore } from '@/packages/use-game-store'
+
+const DEBUG_OPTION = 'debug' as const
+const TAB_GAME = 'game' as const
+const TAB_STORY = 'story' as const
+type Tab = typeof TAB_GAME | typeof TAB_STORY
 
 export const DebugWindow = () => {
   const storyData = useStoryDataStore(
@@ -12,21 +17,53 @@ export const DebugWindow = () => {
   const gameData = useGameStore(state => state.gameData)
   const [visible, setVisible] = useState(true)
   const [minimized, setMinimized] = useState(false)
-  const [tab, setTab] = useState<'game' | 'story'>('game')
+  const [tab, setTab] = useState<Tab>(TAB_GAME)
+  const containerRef = useRef<HTMLDivElement>(null)
 
-  const debugEnabled = storyData?.options === 'debug'
+  const debugEnabled = storyData?.options === DEBUG_OPTION
+
+  useEffect(() => {
+    if (debugEnabled && visible) {
+      containerRef.current?.focus()
+      const handleKey = (e: KeyboardEvent) => {
+        if (e.key === 'Escape') {
+          setVisible(false)
+        }
+      }
+      window.addEventListener('keydown', handleKey)
+      return () => {
+        window.removeEventListener('keydown', handleKey)
+      }
+    }
+  }, [debugEnabled, visible])
 
   if (!debugEnabled || !visible) return null
 
   return (
-    <div className='fixed right-0 top-0 bottom-0 w-80 bg-white text-black shadow-lg text-xs overflow-y-auto'>
+    <div
+      ref={containerRef}
+      tabIndex={-1}
+      role='dialog'
+      aria-labelledby='debug-window-title'
+      className='fixed right-0 top-0 bottom-0 w-80 bg-white text-black shadow-lg text-xs overflow-y-auto'
+    >
       <div className='flex items-center justify-between p-2 border-b'>
-        <span className='font-bold'>Debug</span>
+        <span id='debug-window-title' className='font-bold'>
+          Debug
+        </span>
         <div className='space-x-2'>
-          <button type='button' onClick={() => setMinimized(m => !m)}>
+          <button
+            type='button'
+            aria-expanded={!minimized}
+            onClick={() => setMinimized(m => !m)}
+          >
             {minimized ? 'Expand' : 'Minimize'}
           </button>
-          <button type='button' onClick={() => setVisible(false)}>
+          <button
+            type='button'
+            aria-label='Close debug window'
+            onClick={() => setVisible(false)}
+          >
             Close
           </button>
         </div>
@@ -36,21 +73,21 @@ export const DebugWindow = () => {
           <div className='flex border-b'>
             <button
               type='button'
-              className={`flex-1 p-2 ${tab === 'game' ? 'font-bold' : ''}`}
-              onClick={() => setTab('game')}
+              className={`flex-1 p-2 ${tab === TAB_GAME ? 'font-bold' : ''}`}
+              onClick={() => setTab(TAB_GAME)}
             >
               Game Data
             </button>
             <button
               type='button'
-              className={`flex-1 p-2 ${tab === 'story' ? 'font-bold' : ''}`}
-              onClick={() => setTab('story')}
+              className={`flex-1 p-2 ${tab === TAB_STORY ? 'font-bold' : ''}`}
+              onClick={() => setTab(TAB_STORY)}
             >
               Story Data
             </button>
           </div>
           <div className='p-2'>
-            {tab === 'game' ? (
+            {tab === TAB_GAME ? (
               <pre className='whitespace-pre-wrap'>
                 {JSON.stringify(gameData, null, 2)}
               </pre>

--- a/apps/campfire/src/DebugWindow.tsx
+++ b/apps/campfire/src/DebugWindow.tsx
@@ -14,8 +14,7 @@ export const DebugWindow = () => {
   const [minimized, setMinimized] = useState(false)
   const [tab, setTab] = useState<'game' | 'story'>('game')
 
-  const options = (storyData?.options ?? {}) as Record<string, unknown>
-  const debugEnabled = options.debug === true
+  const debugEnabled = storyData?.options === 'debug'
 
   if (!debugEnabled || !visible) return null
 

--- a/apps/campfire/src/DebugWindow.tsx
+++ b/apps/campfire/src/DebugWindow.tsx
@@ -1,0 +1,68 @@
+import { useState } from 'react'
+import {
+  useStoryDataStore,
+  type StoryDataState
+} from '@/packages/use-story-data-store'
+import { useGameStore } from '@/packages/use-game-store'
+
+export const DebugWindow = () => {
+  const storyData = useStoryDataStore(
+    (state: StoryDataState) => state.storyData
+  )
+  const gameData = useGameStore(state => state.gameData)
+  const [visible, setVisible] = useState(true)
+  const [minimized, setMinimized] = useState(false)
+  const [tab, setTab] = useState<'game' | 'story'>('game')
+
+  const options = (storyData?.options ?? {}) as Record<string, unknown>
+  const debugEnabled = options.debug === true
+
+  if (!debugEnabled || !visible) return null
+
+  return (
+    <div className='fixed right-0 top-0 bottom-0 w-80 bg-white text-black shadow-lg text-xs overflow-y-auto'>
+      <div className='flex items-center justify-between p-2 border-b'>
+        <span className='font-bold'>Debug</span>
+        <div className='space-x-2'>
+          <button type='button' onClick={() => setMinimized(m => !m)}>
+            {minimized ? 'Expand' : 'Minimize'}
+          </button>
+          <button type='button' onClick={() => setVisible(false)}>
+            Close
+          </button>
+        </div>
+      </div>
+      {!minimized && (
+        <div>
+          <div className='flex border-b'>
+            <button
+              type='button'
+              className={`flex-1 p-2 ${tab === 'game' ? 'font-bold' : ''}`}
+              onClick={() => setTab('game')}
+            >
+              Game Data
+            </button>
+            <button
+              type='button'
+              className={`flex-1 p-2 ${tab === 'story' ? 'font-bold' : ''}`}
+              onClick={() => setTab('story')}
+            >
+              Story Data
+            </button>
+          </div>
+          <div className='p-2'>
+            {tab === 'game' ? (
+              <pre className='whitespace-pre-wrap'>
+                {JSON.stringify(gameData, null, 2)}
+              </pre>
+            ) : (
+              <pre className='whitespace-pre-wrap'>
+                {JSON.stringify(storyData, null, 2)}
+              </pre>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/campfire/src/Story.tsx
+++ b/apps/campfire/src/Story.tsx
@@ -5,6 +5,7 @@ import {
   type StoryDataState
 } from '@/packages/use-story-data-store'
 import { Passage } from './Passage'
+import { DebugWindow } from './DebugWindow'
 
 export const Story = () => {
   const passage = useStoryDataStore((state: StoryDataState) =>
@@ -17,6 +18,7 @@ export const Story = () => {
   return (
     <div className={'absolute inset-0 overflow-y-auto overflow-x-hidden'}>
       {passage ? <Passage /> : null}
+      <DebugWindow />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- update `DebugWindow` to show tabs for Game and Story data
- default to Game Data and allow switching
- extend DebugWindow tests for tab functionality

## Testing
- `bun x prettier --write apps/campfire/src/DebugWindow.tsx apps/campfire/__tests__/DebugWindow.test.tsx`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_688b717e5e448320942a25b99ece1137