### PR TITLE
feat: run user code during initialize

### DIFF
--- a/apps/campfire/__tests__/initialize.test.ts
+++ b/apps/campfire/__tests__/initialize.test.ts
@@ -27,4 +27,25 @@ describe('initialize', () => {
     expect(result).toBeUndefined()
     expect(useStoryDataStore.getState().storyData).toEqual({})
   })
+
+  it('applies user styles and runs user script', () => {
+    const el = doc.createElement('tw-storydata')
+    const style = doc.createElement('style')
+    style.id = 'twine-user-stylesheet'
+    style.textContent = 'body { color: green; }'
+    el.appendChild(style)
+    const script = doc.createElement('script')
+    script.id = 'twine-user-script'
+    script.textContent = 'globalThis.initTest = 99'
+    el.appendChild(script)
+    doc.body.appendChild(el)
+
+    initialize(doc)
+
+    const applied = doc.head.querySelector('style[data-twine-user-stylesheet]')
+    expect(applied?.textContent).toBe('body { color: green; }')
+    expect((globalThis as { initTest?: number }).initTest).toBe(99)
+
+    delete (globalThis as { initTest?: number }).initTest
+  })
 })

--- a/apps/campfire/lib/index.ts
+++ b/apps/campfire/lib/index.ts
@@ -28,6 +28,12 @@ export function extractStoryData(tree: Root): Element | undefined {
   return found
 }
 
+/**
+ * Executes the contents of the <code>#twine-user-script</code> element.
+ *
+ * @warning This will run arbitrary JavaScript using the <code>Function</code>
+ * constructor in the global scope. Only use this with trusted content.
+ */
 export function evaluateUserScript(
   doc: Document | undefined = typeof document === 'undefined'
     ? undefined
@@ -77,6 +83,8 @@ export function initialize(
   const tree = fromDom(el)
   const story = extractStoryData(tree as Root)
   extractPassages(tree as Root)
+  applyUserStyles(doc)
+  evaluateUserScript(doc)
   const start = story?.properties?.startnode as string | undefined
   if (start) {
     useStoryDataStore.getState().setCurrentPassage(start)


### PR DESCRIPTION
## Summary
- run `applyUserStyles` and `evaluateUserScript` inside `initialize`
- warn about executing arbitrary JS in `evaluateUserScript`
- test that initialization runs script and styles

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_688bc8f21ec083208dbc4d87527d19cd