### PR TITLE
Add custom directive handlers to remark-campfire

### DIFF
--- a/packages/remark-campfire/__tests__/custom-handler.test.tsx
+++ b/packages/remark-campfire/__tests__/custom-handler.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
+import { unified } from 'unified'
+import remarkParse from 'remark-parse'
+import remarkDirective from 'remark-directive'
+import remarkRehype from 'remark-rehype'
+import rehypeStringify from 'rehype-stringify'
+import remarkCampfire, { type RemarkCampfireOptions } from '../index'
+import { useGameStore } from '@/packages/use-game-store'
+
+const createProcessor = (opts: RemarkCampfireOptions, stringify = true) => {
+  const processor = (unified() as any)
+    .use(remarkParse)
+    .use(remarkDirective)
+    .use(remarkCampfire, opts)
+    .use(remarkRehype)
+
+  if (stringify) {
+    processor.use(rehypeStringify)
+  }
+
+  return processor
+}
+
+beforeEach(() => {
+  useGameStore.setState({ gameData: {}, _initialGameData: {}, locale: 'en-US' })
+})
+
+afterEach(() => {
+  useGameStore.setState({ gameData: {}, _initialGameData: {}, locale: 'en-US' })
+})
+
+describe('remarkCampfire custom handlers', () => {
+  it('uses a custom handler when provided', async () => {
+    const customGet = (directive: any, parent: any, index: any) => {
+      if (parent && typeof index === 'number') {
+        parent.children.splice(index, 1, { type: 'text', value: 'CUSTOM' })
+        return index
+      }
+    }
+    const processor = createProcessor({ handlers: { get: customGet } })
+    const result = await processor.process(':get[any]')
+    expect(result.toString().trim()).toBe('<p>CUSTOM</p>')
+  })
+})

--- a/packages/remark-campfire/directives.ts
+++ b/packages/remark-campfire/directives.ts
@@ -17,11 +17,15 @@ import {
   removeNode
 } from './helpers'
 import type { RangeValue, DirectiveNode } from './helpers'
-export function handleDirective(
+
+export type DirectiveHandlerResult = number | [typeof SKIP, number] | void
+
+export type DirectiveHandler = (
   directive: DirectiveNode,
   parent: Parent | undefined,
   index: number | undefined
-): number | [typeof SKIP, number] | void {
+) => DirectiveHandlerResult
+export const handleDirective: DirectiveHandler = (directive, parent, index) => {
   if (directive.name === 'set' || directive.name === 'setOnce') {
     const typeParam = (toString(directive).trim() || 'string').toLowerCase()
     const attrs = directive.attributes

--- a/packages/remark-campfire/index.ts
+++ b/packages/remark-campfire/index.ts
@@ -2,23 +2,32 @@ import { visit } from 'unist-util-visit'
 import type { Root, Parent } from 'mdast'
 import type { Node } from 'unist'
 import type { DirectiveNode } from './helpers'
-import { handleDirective } from './directives'
+import { handleDirective, type DirectiveHandler } from './directives'
 
-const remarkCampfire = () => (tree: Root) => {
-  visit(
-    tree,
-    (node: Node, index: number | undefined, parent: Parent | undefined) => {
-      if (
-        node &&
-        (node.type === 'textDirective' ||
-          node.type === 'leafDirective' ||
-          node.type === 'containerDirective')
-      ) {
-        const directive = node as DirectiveNode
-        return handleDirective(directive, parent, index)
-      }
-    }
-  )
+export interface RemarkCampfireOptions {
+  handlers?: Record<string, DirectiveHandler>
 }
+const remarkCampfire =
+  (options: RemarkCampfireOptions = {}) =>
+  (tree: Root) => {
+    visit(
+      tree,
+      (node: Node, index: number | undefined, parent: Parent | undefined) => {
+        if (
+          node &&
+          (node.type === 'textDirective' ||
+            node.type === 'leafDirective' ||
+            node.type === 'containerDirective')
+        ) {
+          const directive = node as DirectiveNode
+          const handler = options.handlers?.[directive.name]
+          if (handler) {
+            return handler(directive, parent, index)
+          }
+          return handleDirective(directive, parent, index)
+        }
+      }
+    )
+  }
 
 export default remarkCampfire


### PR DESCRIPTION
## Summary
- allow providing directive handlers to remark-campfire
- expose handler type and return type
- test custom handler usage

## Testing
- `bun x prettier --write packages/remark-campfire/index.ts packages/remark-campfire/directives.ts packages/remark-campfire/__tests__/custom-handler.test.tsx`
- `bun tsc`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_688bdc221b7c8320b17acbe462e2529e