### PR TITLE
Add lang directive to change locale

### DIFF
--- a/apps/campfire/__tests__/Passage.test.tsx
+++ b/apps/campfire/__tests__/Passage.test.tsx
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach } from 'bun:test'
 import { render, screen, waitFor } from '@testing-library/react'
+import i18next from 'i18next'
+import { initReactI18next } from 'react-i18next'
 import type { Element } from 'hast'
 import { Passage } from '../src/Passage'
 import { useStoryDataStore } from '@/packages/use-story-data-store'
@@ -20,9 +22,14 @@ const resetStore = () => {
 }
 
 describe('Passage', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     document.body.innerHTML = ''
     resetStore()
+    if (!i18next.isInitialized) {
+      await i18next.use(initReactI18next).init({ lng: 'en-US', resources: {} })
+    } else {
+      await i18next.changeLanguage('en-US')
+    }
   })
 
   it('renders the current passage', async () => {
@@ -320,8 +327,9 @@ describe('Passage', () => {
 
     render(<Passage />)
 
-    await waitFor(() =>
+    await waitFor(() => {
       expect(useStoryDataStore.getState().locale).toBe('fr-FR')
-    )
+      expect(i18next.language).toBe('fr-FR')
+    })
   })
 })

--- a/apps/campfire/__tests__/Passage.test.tsx
+++ b/apps/campfire/__tests__/Passage.test.tsx
@@ -317,7 +317,7 @@ describe('Passage', () => {
       type: 'element',
       tagName: 'tw-passagedata',
       properties: { pid: '1', name: 'Start' },
-      children: [{ type: 'text', value: ':lang{fr-FR}' }]
+      children: [{ type: 'text', value: ':lang{locale=fr-FR}' }]
     }
 
     useStoryDataStore.setState({

--- a/apps/campfire/__tests__/Passage.test.tsx
+++ b/apps/campfire/__tests__/Passage.test.tsx
@@ -304,4 +304,24 @@ describe('Passage', () => {
     expect(text).toBeInTheDocument()
     expect(document.body.textContent).not.toContain('Hidden')
   })
+
+  it('changes locale with lang directive', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [{ type: 'text', value: ':lang{fr-FR}' }]
+    }
+
+    useStoryDataStore.setState({
+      passages: [passage],
+      currentPassageId: '1'
+    })
+
+    render(<Passage />)
+
+    await waitFor(() =>
+      expect(useStoryDataStore.getState().locale).toBe('fr-FR')
+    )
+  })
 })

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -308,19 +308,17 @@ export const useDirectiveHandlers = () => {
   const handleLang: DirectiveHandler = (directive, parent, index) => {
     const raw = toString(directive).trim()
     const attrs = (directive.attributes || {}) as Record<string, unknown>
-    let locale = raw
+    let locale = raw || (typeof attrs.locale === 'string' ? attrs.locale : '')
     if (!locale) {
-      const attrLocale = attrs.locale
-      if (typeof attrLocale === 'string') {
-        locale = attrLocale
-      } else {
-        const firstKey = Object.keys(attrs)[0]
-        if (typeof firstKey === 'string') locale = firstKey
-      }
+      // When using the shorthand `:lang{en-US}` mdast parses `en-US` as an
+      // attribute key. In that case we grab the first attribute key as the
+      // locale value.
+      const firstKey = Object.keys(attrs)[0]
+      if (typeof firstKey === 'string') locale = firstKey
     }
     if (locale) {
       setLocale(locale)
-      if (i18next.isInitialized && i18next.language !== locale) {
+      if (i18next.isInitialized && i18next.resolvedLanguage !== locale) {
         void i18next.changeLanguage(locale)
       }
     }

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import i18next from 'i18next'
 import { SKIP } from 'unist-util-visit'
 import { compile } from 'expression-eval'
 import { toString } from 'mdast-util-to-string'
@@ -319,6 +320,9 @@ export const useDirectiveHandlers = () => {
     }
     if (locale) {
       setLocale(locale)
+      if (i18next.isInitialized && i18next.language !== locale) {
+        void i18next.changeLanguage(locale)
+      }
     }
     return removeNode(parent, index)
   }

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -306,16 +306,8 @@ export const useDirectiveHandlers = () => {
   }
 
   const handleLang: DirectiveHandler = (directive, parent, index) => {
-    const raw = toString(directive).trim()
     const attrs = (directive.attributes || {}) as Record<string, unknown>
-    let locale = raw || (typeof attrs.locale === 'string' ? attrs.locale : '')
-    if (!locale) {
-      // When using the shorthand `:lang{en-US}` mdast parses `en-US` as an
-      // attribute key. In that case we grab the first attribute key as the
-      // locale value.
-      const firstKey = Object.keys(attrs)[0]
-      if (typeof firstKey === 'string') locale = firstKey
-    }
+    const locale = typeof attrs.locale === 'string' ? attrs.locale : undefined
     if (locale) {
       setLocale(locale)
       if (i18next.isInitialized && i18next.resolvedLanguage !== locale) {

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -35,6 +35,7 @@ export const useDirectiveHandlers = () => {
   const gameData = useGameStore(state => state.gameData)
   const setGameData = useGameStore(state => state.setGameData)
   const unsetGameData = useGameStore(state => state.unsetGameData)
+  const setLocale = useStoryDataStore(state => state.setLocale)
   const handleSet = (
     directive: DirectiveNode,
     parent: Parent | undefined,
@@ -303,6 +304,25 @@ export const useDirectiveHandlers = () => {
     return [SKIP, index]
   }
 
+  const handleLang: DirectiveHandler = (directive, parent, index) => {
+    const raw = toString(directive).trim()
+    const attrs = (directive.attributes || {}) as Record<string, unknown>
+    let locale = raw
+    if (!locale) {
+      const attrLocale = attrs.locale
+      if (typeof attrLocale === 'string') {
+        locale = attrLocale
+      } else {
+        const firstKey = Object.keys(attrs)[0]
+        if (typeof firstKey === 'string') locale = firstKey
+      }
+    }
+    if (locale) {
+      setLocale(locale)
+    }
+    return removeNode(parent, index)
+  }
+
   let handlers: Record<string, DirectiveHandler>
 
   const getPassageById = useStoryDataStore(state => state.getPassageById)
@@ -378,6 +398,7 @@ export const useDirectiveHandlers = () => {
       ) => handleIncrement(d, p, i, -1),
       unset: handleUnset,
       if: handleIf,
+      lang: handleLang,
       include: handleInclude
     }
     return handlers

--- a/packages/remark-campfire/index.ts
+++ b/packages/remark-campfire/index.ts
@@ -31,12 +31,12 @@ export interface IncludeDirective extends Omit<LeafDirective, 'attributes'> {
 
 export interface LangAttributes {
   /** Locale code to activate */
-  locale?: string
+  locale: string
 }
 
 export interface LangDirective extends Omit<LeafDirective, 'attributes'> {
   name: 'lang'
-  attributes?: LangAttributes
+  attributes: LangAttributes
 }
 const remarkCampfire =
   (options: RemarkCampfireOptions = {}) =>

--- a/packages/remark-campfire/index.ts
+++ b/packages/remark-campfire/index.ts
@@ -28,6 +28,16 @@ export interface IncludeDirective extends Omit<LeafDirective, 'attributes'> {
   name: 'include'
   attributes?: IncludeAttributes
 }
+
+export interface LangAttributes {
+  /** Locale code to activate */
+  locale?: string
+}
+
+export interface LangDirective extends Omit<LeafDirective, 'attributes'> {
+  name: 'lang'
+  attributes?: LangAttributes
+}
 const remarkCampfire =
   (options: RemarkCampfireOptions = {}) =>
   (tree: Root) => {


### PR DESCRIPTION
## Summary
- support `:lang` in remark plugin
- implement `lang` directive in campfire app
- test locale directive functionality

## Testing
- `bun tsc`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_688cea2bd55883209a23c42f9f876f2b