### PR TITLE
Update README with i18next info

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,11 @@ The directives below let you control languages and add translation data.
   ```md
   :t{key=hello ns=ui}
   ```
+
+To use plural forms, add separate `_one` and `_other` keys and supply a `count`
+attribute:
+
+```md
+:translations{ns=ui apple_one="1 apple" apple_other="{{count}} apples"}
+:t{key=apple count=2 ns=ui}
+```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,108 @@
 # twine-campfire
 
-A cozy story format for Twine
+A cozy story format for Twine.
+
+## Markdown Directives
+
+Campfire extends standard Markdown with [remark-directive](https://github.com/remarkjs/remark-directive) syntax. Directives begin with a colon and let passages interact with the game state.
+
+Directives come in two forms:
+
+- **Leaf/Text** – `:name[Label]{attr=value}` inline directives.
+- **Container** –
+
+  ```
+  :::name{attr=value}
+  content
+  :::
+  ```
+
+### Supported directives
+
+- `set` – update game data
+
+  ```md
+  :set[number]{hp=5}
+  ```
+
+- `setOnce` – like `set` but locks the key after first use
+
+  ```md
+  :setOnce{visited=true}
+  ```
+
+- `get` – insert a value from the game data
+
+  ```md
+  HP: :get{hp}
+  ```
+
+- `random` – store a random number or choice in a key
+
+  ```md
+  :random{key=loot,min=1,max=5}
+  ```
+
+- `increment` – increase a numeric value
+
+  ```md
+  :increment{key=score amount=2}
+  ```
+
+- `decrement` – decrease a numeric value
+
+  ```md
+  :decrement{key=hp amount=1}
+  ```
+
+- `unset` – remove a key
+
+  ```md
+  :unset{key=tempFlag}
+  ```
+
+- `if`/`elseif`/`else` – conditional blocks
+
+  ```md
+  :::if{hp > 0}
+  You live!
+  :::else
+  Game over
+  :::
+  ```
+
+- `include` – insert another passage
+
+  ```md
+  :include[Intro]
+  ```
+
+### Localization
+
+Campfire uses [i18next](https://www.i18next.com/) to manage translations. For a
+full introduction, read the [i18next documentation](https://www.i18next.com/overview/introduction).
+The directives below let you control languages and add translation data.
+
+- `lang` – switch the active locale
+
+  ```md
+  :lang{locale=fr}
+  ```
+
+- `namespace` – register a translation namespace
+
+  ```md
+  :namespace{ns=ui locale=fr data={"hello":"Bonjour"}}
+  ```
+
+- `translations` – add multiple translations
+
+  ```md
+  :translations{ns=ui locale=fr hello="Bonjour" bye="Au revoir"}
+  ```
+
+- `t` – output a translated string
+
+  ```md
+  :t{key=hello ns=ui}
+  ```

--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ Directives come in two forms:
   :include[Intro]
   ```
 
+### Harlowe-style links
+
+Campfire recognizes Twine's `[[Link]]` syntax. The text inside becomes a button
+that jumps to the target passage. Use an arrow to specify a different target:
+
+```md
+[[Display text->Passage name]]
+```
+
 ### Localization
 
 Campfire uses [i18next](https://www.i18next.com/) to manage translations. For a
@@ -105,6 +114,12 @@ The directives below let you control languages and add translation data.
 
   ```md
   :t{key=hello ns=ui}
+  ```
+
+  You can translate link text as well:
+
+  ```md
+  [[:t{key=next}->Next]]
   ```
 
 To use plural forms, add separate `_one` and `_other` keys and supply a `count`

--- a/apps/campfire/__tests__/Passage.test.tsx
+++ b/apps/campfire/__tests__/Passage.test.tsx
@@ -377,4 +377,33 @@ describe('Passage', () => {
     const text = await screen.findByText('2 apples')
     expect(text).toBeInTheDocument()
   })
+
+  it('resolves translations inside links', async () => {
+    const start: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        { type: 'text', value: ':translations{next="Next"}' },
+        { type: 'text', value: '[[:t{key=next}->Next]]' }
+      ]
+    }
+    const next: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '2', name: 'Next' },
+      children: []
+    }
+
+    useStoryDataStore.setState({
+      passages: [start, next],
+      currentPassageId: '1'
+    })
+
+    render(<Passage />)
+
+    const button = await screen.findByRole('button', { name: 'Next' })
+    button.click()
+    expect(useStoryDataStore.getState().currentPassageId).toBe('Next')
+  })
 })

--- a/apps/campfire/__tests__/Passage.test.tsx
+++ b/apps/campfire/__tests__/Passage.test.tsx
@@ -353,18 +353,18 @@ describe('Passage', () => {
   })
 
   it('handles pluralization with t directive', async () => {
-    i18next.addResource('en-US', 'translation', 'apple_one', '{{count}} apple')
-    i18next.addResource(
-      'en-US',
-      'translation',
-      'apple_other',
-      '{{count}} apples'
-    )
     const passage: Element = {
       type: 'element',
       tagName: 'tw-passagedata',
       properties: { pid: '1', name: 'Start' },
-      children: [{ type: 'text', value: ':t{key=apple count=2}' }]
+      children: [
+        {
+          type: 'text',
+          value:
+            ':translations{apple_one="1 apple" apple_other="{{count}} apples"}'
+        },
+        { type: 'text', value: ':t{key=apple count=2}' }
+      ]
     }
 
     useStoryDataStore.setState({

--- a/apps/campfire/__tests__/Passage.test.tsx
+++ b/apps/campfire/__tests__/Passage.test.tsx
@@ -351,4 +351,30 @@ describe('Passage', () => {
     const text = await screen.findByText('Hello')
     expect(text).toBeInTheDocument()
   })
+
+  it('handles pluralization with t directive', async () => {
+    i18next.addResource('en-US', 'translation', 'apple_one', '{{count}} apple')
+    i18next.addResource(
+      'en-US',
+      'translation',
+      'apple_other',
+      '{{count}} apples'
+    )
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [{ type: 'text', value: ':t{key=apple count=2}' }]
+    }
+
+    useStoryDataStore.setState({
+      passages: [passage],
+      currentPassageId: '1'
+    })
+
+    render(<Passage />)
+
+    const text = await screen.findByText('2 apples')
+    expect(text).toBeInTheDocument()
+  })
 })

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -389,7 +389,19 @@ export const useDirectiveHandlers = () => {
     const text = i18next.t(key, options)
     if (parent && typeof index === 'number') {
       parent.children.splice(index, 1, { type: 'text', value: text })
-      return index
+      let idx = index
+      const prev = parent.children[idx - 1] as MdText | undefined
+      if (prev && prev.type === 'text') {
+        prev.value += (parent.children[idx] as MdText).value
+        parent.children.splice(idx, 1)
+        idx--
+      }
+      const next = parent.children[idx + 1] as MdText | undefined
+      if (next && next.type === 'text') {
+        ;(parent.children[idx] as MdText).value += next.value
+        parent.children.splice(idx + 1, 1)
+      }
+      return idx
     }
   }
 


### PR DESCRIPTION
## Summary
- document i18next usage before language directives
- remove custom handler example from README

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_688d1379e0b08320a652d3c03f025866