### PR TITLE
feat: add math directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ Directives come in two forms:
   HP: :get{hp}
   ```
 
+- `math` – evaluate an expression and insert the result. Add `key` to store it.
+
+  ```md
+  Result: :math[1 + 2]
+  :math[hp + 5]{key=hp}
+  ```
+
 - `random` – store a random number or choice in a key
 
   ```md

--- a/apps/campfire/__tests__/Passage.test.tsx
+++ b/apps/campfire/__tests__/Passage.test.tsx
@@ -209,6 +209,53 @@ describe('Passage', () => {
     expect(text).toBeInTheDocument()
   })
 
+  it('evaluates expressions with math directive', async () => {
+    useGameStore.setState(state => ({
+      ...state,
+      gameData: { x: 3 }
+    }))
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [{ type: 'text', value: 'Result: :math[x * 2]' }]
+    }
+
+    useStoryDataStore.setState({
+      passages: [passage],
+      currentPassageId: '1'
+    })
+
+    render(<Passage />)
+
+    const text = await screen.findByText('Result: 6')
+    expect(text).toBeInTheDocument()
+  })
+
+  it('can set state with math directive', async () => {
+    useGameStore.setState(state => ({
+      ...state,
+      gameData: { hp: 5 }
+    }))
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [{ type: 'text', value: 'HP: :math[hp + 1]{key=hp}' }]
+    }
+
+    useStoryDataStore.setState({
+      passages: [passage],
+      currentPassageId: '1'
+    })
+
+    render(<Passage />)
+
+    const text = await screen.findByText('HP: 6')
+    expect(text).toBeInTheDocument()
+    expect(useGameStore.getState().gameData.hp).toBe(6)
+  })
+
   it('increments values', async () => {
     useGameStore.setState(state => ({
       ...state,

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -212,7 +212,8 @@ export const useDirectiveHandlers = () => {
     try {
       const fn = compile(expr)
       value = fn(gameData)
-    } catch {
+    } catch (error) {
+      console.error('Error evaluating math expression:', expr, error);
       value = ''
     }
 

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -190,18 +190,14 @@ export const useDirectiveHandlers = () => {
    * Evaluates a mathematical or JavaScript expression in the context of the current game data.
    * Optionally stores the result in the game data state if a 'key' attribute is provided.
    * Replaces the directive node in the AST with a text node containing the result.
-   *
-   * @param {ContainerDirective} directive - The directive node containing the expression and optional attributes.
-   * @param {Parent | undefined} parent - The parent AST node, if available.
-   * @param {number | undefined} index - The index of the directive node within its parent's children array.
-   * @returns {number | undefined} The index at which the node was replaced, or undefined if not replaced.
    */
   const handleMath: DirectiveHandler = (directive, parent, index) => {
     const attrs = directive.attributes || {}
+    const typedAttrs = attrs as Record<string, unknown>
     let expr = toString(directive).trim()
     if (!expr) {
-      if (typeof (attrs as Record<string, unknown>).expr === 'string') {
-        expr = String((attrs as Record<string, unknown>).expr)
+      if (typeof typedAttrs.expr === 'string') {
+        expr = String(typedAttrs.expr)
       } else {
         const first = Object.keys(attrs)[0]
         expr = first && first !== 'key' ? first : ''
@@ -213,13 +209,13 @@ export const useDirectiveHandlers = () => {
       const fn = compile(expr)
       value = fn(gameData)
     } catch (error) {
-      console.error('Error evaluating math expression:', expr, error);
+      console.error('Error evaluating math expression:', expr, error)
       value = ''
     }
 
     const key =
-      typeof (attrs as Record<string, unknown>).key === 'string'
-        ? ((attrs as Record<string, unknown>).key as string)
+      typeof typedAttrs.key === 'string'
+        ? (typedAttrs.key as string)
         : undefined
     if (typeof key === 'string') {
       setGameData({ [key]: value })
@@ -485,9 +481,7 @@ export const useDirectiveHandlers = () => {
 
     const text = passage.children
       .map((child: ElementContent) =>
-        child.type === 'text' && typeof (child as HastText).value === 'string'
-          ? (child as HastText).value
-          : ''
+        child.type === 'text' ? (child as HastText).value : ''
       )
       .join('')
 

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -186,6 +186,16 @@ export const useDirectiveHandlers = () => {
     }
   }
 
+  /**
+   * Evaluates a mathematical or JavaScript expression in the context of the current game data.
+   * Optionally stores the result in the game data state if a 'key' attribute is provided.
+   * Replaces the directive node in the AST with a text node containing the result.
+   *
+   * @param {ContainerDirective} directive - The directive node containing the expression and optional attributes.
+   * @param {Parent | undefined} parent - The parent AST node, if available.
+   * @param {number | undefined} index - The index of the directive node within its parent's children array.
+   * @returns {number | undefined} The index at which the node was replaced, or undefined if not replaced.
+   */
   const handleMath: DirectiveHandler = (directive, parent, index) => {
     const attrs = directive.attributes || {}
     let expr = toString(directive).trim()


### PR DESCRIPTION
## Summary
- add math directive to evaluate expressions inline
- allow math directive to store results in game state with a `key` attribute
- test math directive output and state storage
- document math directive usage

## Testing
- `bun x prettier --write README.md apps/campfire/src/useDirectiveHandlers.ts apps/campfire/__tests__/Passage.test.tsx`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_688d7cc80b0483229130a074f0201332