### PR TITLE
feat: add onEnter, onExit, and onChange directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,30 @@ Directives come in two forms:
   :::
   ```
 
+- `onEnter` – run directives when entering a passage
+
+  ```md
+  :::onEnter
+  :set{visited=true}
+  :::
+  ```
+
+- `onExit` – run directives when leaving a passage
+
+  ```md
+  :::onExit
+  :set{visited=false}
+  :::
+  ```
+
+- `onChange` – run directives when a game data key changes
+
+  ```md
+  :::onChange{key=hp}
+  :set{warn=true}
+  :::
+  ```
+
 ### Localization
 
 Campfire uses [i18next](https://www.i18next.com/) to manage translations. For a

--- a/packages/remark-campfire/index.ts
+++ b/packages/remark-campfire/index.ts
@@ -1,7 +1,7 @@
 import { visit } from 'unist-util-visit'
 import type { Root, Parent } from 'mdast'
 import type { Node } from 'unist'
-import type { LeafDirective } from 'mdast-util-directive'
+import type { LeafDirective, ContainerDirective } from 'mdast-util-directive'
 import type { SKIP } from 'unist-util-visit'
 import type { DirectiveNode } from './helpers'
 
@@ -37,6 +37,29 @@ export interface LangAttributes {
 export interface LangDirective extends Omit<LeafDirective, 'attributes'> {
   name: 'lang'
   attributes: LangAttributes
+}
+
+export interface OnEnterDirective
+  extends Omit<ContainerDirective, 'attributes'> {
+  name: 'onEnter'
+  attributes?: Record<string, never>
+}
+
+export interface OnExitDirective
+  extends Omit<ContainerDirective, 'attributes'> {
+  name: 'onExit'
+  attributes?: Record<string, never>
+}
+
+export interface OnChangeAttributes {
+  /** Game data key to watch */
+  key: string
+}
+
+export interface OnChangeDirective
+  extends Omit<ContainerDirective, 'attributes'> {
+  name: 'onChange'
+  attributes: OnChangeAttributes
 }
 const remarkCampfire =
   (options: RemarkCampfireOptions = {}) =>


### PR DESCRIPTION
## Summary
- add directive handlers for onEnter, onExit, and onChange
- document new directives in the README
- cover onEnter/onExit/onChange behavior with tests
- expose onEnter/onExit/onChange directive types in remark-campfire

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_688d96951b9c83228675e5cd35ee2fff