### PR TITLE
feat: enhance translations and range directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Directives come in two forms:
 - `range` – create a numeric range object using the `set` directive
 
   ```md
-  :set[range]{hp='{"lower":0,"upper":10,"value":5}'}
+  :set[range]{key=hp min=0 max=10 value=5}
   ```
 
 - `increment` – increase a numeric value
@@ -144,13 +144,7 @@ The directives below let you control languages and add translation data.
   :lang{locale=fr}
   ```
 
-- `namespace` – register a translation namespace
-
-  ```md
-  :namespace{ns=ui locale=fr data={"hello":"Bonjour"}}
-  ```
-
-- `translations` – add multiple translations
+- `translations` – add multiple translations. If a namespace (`ns`) is provided, it will be created if needed.
 
   ```md
   :translations{ns=ui locale=fr hello="Bonjour" bye="Au revoir"}
@@ -178,13 +172,11 @@ attribute:
 
 #### i18next namespaces
 
-i18next organizes translations into namespaces. Use the `namespace` directive to
-register a namespace and optionally provide initial data. The `translations`
-directive adds or updates keys within a namespace. Reference the namespace when
-translating strings:
+i18next organizes translations into namespaces. The `translations` directive
+creates a namespace when an `ns` attribute is provided and adds keys to it.
+Reference the namespace when translating strings:
 
 ```md
-:namespace{ns=ui locale=fr data={"ok":"D'accord"}}
 :translations{ns=ui locale=fr cancel="Annuler"}
-:t{key=ok ns=ui}
+:t{key=cancel ns=ui}
 ```

--- a/apps/campfire/__tests__/Passage.test.tsx
+++ b/apps/campfire/__tests__/Passage.test.tsx
@@ -367,6 +367,32 @@ describe('Passage', () => {
     )
   })
 
+  it('creates range values with set[range]', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        { type: 'text', value: ':set[range]{key=hp min=0 max=10 value=5}' }
+      ]
+    }
+
+    useStoryDataStore.setState({
+      passages: [passage],
+      currentPassageId: '1'
+    })
+
+    render(<Passage />)
+
+    await waitFor(() => {
+      expect(useGameStore.getState().gameData.hp).toEqual({
+        lower: 0,
+        upper: 10,
+        value: 5
+      })
+    })
+  })
+
   it('unsets game data with the unset directive', async () => {
     useGameStore.setState(state => ({
       ...state,
@@ -511,6 +537,29 @@ describe('Passage', () => {
     const button = await screen.findByRole('button', { name: 'Next' })
     button.click()
     expect(useStoryDataStore.getState().currentPassageId).toBe('Next')
+  })
+
+  it('creates namespaces from translations directive', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        { type: 'text', value: ':translations{ns=ui goodbye="Au revoir"}' },
+        { type: 'text', value: ':t{key=goodbye ns=ui}' }
+      ]
+    }
+
+    useStoryDataStore.setState({
+      passages: [passage],
+      currentPassageId: '1'
+    })
+
+    render(<Passage />)
+
+    const text = await screen.findByText('Au revoir')
+    expect(text).toBeInTheDocument()
+    expect(i18next.hasResourceBundle('en-US', 'ui')).toBe(true)
   })
 
   it('runs onEnter and onExit blocks at the appropriate times', async () => {

--- a/apps/campfire/__tests__/Story.test.tsx
+++ b/apps/campfire/__tests__/Story.test.tsx
@@ -19,6 +19,7 @@ describe('Story', () => {
       await i18next.changeLanguage('en-US')
       i18next.services.resourceStore.data = {}
     }
+    i18next.options.debug = false
   })
 
   it('renders nothing when no passage is set', () => {
@@ -49,5 +50,15 @@ describe('Story', () => {
     expect(useStoryDataStore.getState().storyData).toEqual({
       name: 'Story Test'
     })
+  })
+
+  it('enables i18next debug when story options debug', () => {
+    const el = document.createElement('tw-storydata')
+    el.setAttribute('options', 'debug')
+    document.body.appendChild(el)
+
+    render(<Story />)
+
+    expect(i18next.options.debug).toBe(true)
   })
 })

--- a/apps/campfire/src/Story.tsx
+++ b/apps/campfire/src/Story.tsx
@@ -141,13 +141,17 @@ export const Story = () => {
   }
 
   useEffect(() => {
-    initialize()
+    const story = initialize()
+    const debug = story?.properties?.options === 'debug'
     if (!i18next.isInitialized) {
       void i18next.use(initReactI18next).init({
         lng: i18next.language || 'en-US',
         fallbackLng: 'en-US',
-        resources: {}
+        resources: {},
+        debug
       })
+    } else {
+      i18next.options.debug = debug
     }
   }, [])
 

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -17,7 +17,6 @@ import {
   isRange,
   clamp,
   parseNumericValue,
-  parseRange,
   getRandomItem,
   getRandomInt,
   ensureKey,
@@ -67,7 +66,7 @@ export const useDirectiveHandlers = () => {
     lock = false
   ): DirectiveHandlerResult => {
     const typeParam = (toString(directive).trim() || 'string').toLowerCase()
-    const attrs = directive.attributes
+    const attrs = directive.attributes as Record<string, unknown> | undefined
     const safe: Record<string, unknown> = {}
 
     const parseValue = (value: string): unknown => {
@@ -92,47 +91,61 @@ export const useDirectiveHandlers = () => {
           } catch {
             return {}
           }
-        case 'range':
-          try {
-            const parsed = JSON.parse(value)
-            if (parsed && typeof parsed === 'object') {
-              return parseRange(parsed)
-            }
-            const num =
-              typeof parsed === 'number' ? parsed : parseFloat(String(parsed))
-            return Number.isNaN(num) ? 0 : num
-          } catch {
-            const num = parseFloat(value)
-            return Number.isNaN(num) ? 0 : num
-          }
         case 'string':
         default:
           return value
       }
     }
 
+    const parseNumber = (value: unknown): number => {
+      if (typeof value === 'number') return value
+      if (typeof value !== 'string') return parseNumericValue(value)
+      let evaluated: unknown = value
+      try {
+        const fn = compile(value)
+        evaluated = fn(gameData)
+      } catch {
+        // fall back to raw value when evaluation fails
+      }
+      return parseNumericValue(evaluated)
+    }
+
     if (attrs && typeof attrs === 'object') {
-      for (const [key, value] of Object.entries(attrs)) {
-        if (typeof value === 'string') {
-          const parsed = parseValue(value)
-          const current = gameData[key]
-          if (isRange(current)) {
-            if (typeof parsed === 'number') {
-              safe[key] = {
-                ...current,
-                value: clamp(parsed, current.lower, current.upper)
-              }
-            } else if (isRange(parsed)) {
-              safe[key] = {
-                lower: parsed.lower,
-                upper: parsed.upper,
-                value: clamp(parsed.value, parsed.lower, parsed.upper)
+      if (typeParam === 'range') {
+        const key = typeof attrs.key === 'string' ? attrs.key : undefined
+        if (key) {
+          const lower = parseNumber(attrs.min)
+          const upper = parseNumber(attrs.max)
+          const val = parseNumber(attrs.value ?? lower)
+          safe[key] = {
+            lower,
+            upper,
+            value: clamp(val, lower, upper)
+          }
+        }
+      } else {
+        for (const [key, value] of Object.entries(attrs)) {
+          if (typeof value === 'string') {
+            const parsed = parseValue(value)
+            const current = gameData[key]
+            if (isRange(current)) {
+              if (typeof parsed === 'number') {
+                safe[key] = {
+                  ...current,
+                  value: clamp(parsed, current.lower, current.upper)
+                }
+              } else if (isRange(parsed)) {
+                safe[key] = {
+                  lower: parsed.lower,
+                  upper: parsed.upper,
+                  value: clamp(parsed.value, parsed.lower, parsed.upper)
+                }
+              } else {
+                safe[key] = parsed
               }
             } else {
               safe[key] = parsed
             }
-          } else {
-            safe[key] = parsed
           }
         }
       }
@@ -438,33 +451,6 @@ export const useDirectiveHandlers = () => {
     return removeNode(parent, index)
   }
 
-  const handleNamespace: DirectiveHandler = (directive, parent, index) => {
-    const attrs = (directive.attributes || {}) as Record<string, unknown>
-    const ns =
-      typeof attrs.ns === 'string' ? attrs.ns : toString(directive).trim()
-    if (!ns) return removeNode(parent, index)
-    const locale =
-      typeof attrs.locale === 'string'
-        ? attrs.locale
-        : i18next.resolvedLanguage || i18next.language
-    let resources: Record<string, unknown> = {}
-    if (typeof attrs.data === 'string') {
-      try {
-        resources = JSON.parse(attrs.data)
-      } catch {
-        // ignore
-      }
-    }
-    if (!i18next.hasResourceBundle(locale, ns)) {
-      i18next.addResourceBundle(locale, ns, resources, true, true)
-    } else if (Object.keys(resources).length) {
-      for (const [k, v] of Object.entries(resources)) {
-        i18next.addResource(locale, ns, k, v as string)
-      }
-    }
-    return removeNode(parent, index)
-  }
-
   const handleTranslations: DirectiveHandler = (directive, parent, index) => {
     const attrs = (directive.attributes || {}) as Record<string, unknown>
     const ns = typeof attrs.ns === 'string' ? attrs.ns : 'translation'
@@ -484,6 +470,9 @@ export const useDirectiveHandlers = () => {
         if (k === 'ns' || k === 'locale') continue
         resources[k] = v
       }
+    }
+    if (!i18next.hasResourceBundle(locale, ns)) {
+      i18next.addResourceBundle(locale, ns, {}, true, true)
     }
     if (Object.keys(resources).length) {
       for (const [k, v] of Object.entries(resources)) {
@@ -604,7 +593,6 @@ export const useDirectiveHandlers = () => {
       onChange: handleOnChange,
       lang: handleLang,
       include: handleInclude,
-      namespace: handleNamespace,
       translations: handleTranslations,
       t: handleTranslate
     }


### PR DESCRIPTION
## Summary
- remove namespace directive and auto-create namespaces via translations
- enable i18next debug when story options set to debug
- update set[range] directive to accept key/min/max/value

## Testing
- `bun x prettier --write README.md apps/campfire/src/useDirectiveHandlers.ts apps/campfire/src/Story.tsx apps/campfire/__tests__/Passage.test.tsx apps/campfire/__tests__/Story.test.tsx`
- `bun tsc`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_688de44eb2d8832285b68388161f4215