### PR TITLE
feat: add goto, save, and load directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,9 @@ is also recorded if `restore` cannot find the requested checkpoint.
 
 ### Persistence
 
-Store progress in the browser to resume later.
+Store progress in the browser to resume later. These directives run
+asynchronously and set the game state's `loading` flag while accessing local
+storage.
 
 - `save` – write the current game state and checkpoints to local storage. Optionally set a `key`.
 

--- a/README.md
+++ b/README.md
@@ -194,9 +194,8 @@ is also recorded if `restore` cannot find the requested checkpoint.
 
 ### Persistence
 
-Store progress in the browser to resume later. These directives run
-asynchronously and set the game state's `loading` flag while accessing local
-storage.
+Store progress in the browser to resume later. These directives set the game
+state's `loading` flag while accessing local storage.
 
 - `save` – write the current game state and checkpoints to local storage. Optionally set a `key`.
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,13 @@ ignored inside passages brought in with `:include`.
   :restore
   ```
 
+- `clearCheckpoint` – remove a saved checkpoint. Without an `id`, all checkpoints are cleared.
+
+  ```md
+  :clearCheckpoint{id=save1}
+  :clearCheckpoint
+  ```
+
 Multiple checkpoints in the same passage are ignored and log an error. An error
 is also recorded if `restore` cannot find the requested checkpoint.
 
@@ -199,6 +206,12 @@ Store progress in the browser to resume later.
 
   ```md
   :load{key=slot1}
+  ```
+
+- `clearSave` – remove a stored game state from local storage using the same `key`.
+
+  ```md
+  :clearSave{key=slot1}
   ```
 
 ### Localization

--- a/README.md
+++ b/README.md
@@ -189,13 +189,13 @@ is also recorded if `restore` cannot find the requested checkpoint.
 
 Store progress in the browser to resume later.
 
-- `save` – write the current game state to local storage. Optionally set a `key`.
+- `save` – write the current game state and checkpoints to local storage. Optionally set a `key`.
 
   ```md
   :save{key=slot1}
   ```
 
-- `load` – load game state from local storage using the same `key`.
+- `load` – load game state and checkpoints from local storage using the same `key`.
 
   ```md
   :load{key=slot1}

--- a/README.md
+++ b/README.md
@@ -118,6 +118,13 @@ Directives come in two forms:
   :::
   ```
 
+- `goto` – jump to another passage by name or id
+
+  ```md
+  :goto[Intro]
+  :goto[42]
+  ```
+
 - `include` – insert another passage by name or id
 
   ```md
@@ -177,6 +184,22 @@ ignored inside passages brought in with `:include`.
 
 Multiple checkpoints in the same passage are ignored and log an error. An error
 is also recorded if `restore` cannot find the requested checkpoint.
+
+### Persistence
+
+Store progress in the browser to resume later.
+
+- `save` – write the current game state to local storage. Optionally set a `key`.
+
+  ```md
+  :save{key=slot1}
+  ```
+
+- `load` – load game state from local storage using the same `key`.
+
+  ```md
+  :load{key=slot1}
+  ```
 
 ### Localization
 

--- a/apps/campfire/__tests__/Passage.test.tsx
+++ b/apps/campfire/__tests__/Passage.test.tsx
@@ -916,6 +916,37 @@ describe('Passage', () => {
     })
   })
 
+  it('logs error when loaded state lacks current passage id', async () => {
+    const logged: unknown[] = []
+    const orig = console.error
+    console.error = (...args: unknown[]) => {
+      logged.push(args)
+    }
+
+    localStorage.setItem('slot1', JSON.stringify({ gameData: { hp: 7 } }))
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [{ type: 'text', value: ':load{key=slot1}' }]
+    }
+
+    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+
+    render(<Passage />)
+
+    await waitFor(() => {
+      expect((useGameStore.getState().gameData as any).hp).toBe(7)
+      expect(useStoryDataStore.getState().currentPassageId).toBe('1')
+      expect(logged).toHaveLength(1)
+      expect(useGameStore.getState().errors).toEqual([
+        'Saved game state has no current passage'
+      ])
+    })
+
+    console.error = orig
+  })
+
   it('clears a checkpoint by id', async () => {
     const passage: Element = {
       type: 'element',

--- a/apps/campfire/__tests__/Passage.test.tsx
+++ b/apps/campfire/__tests__/Passage.test.tsx
@@ -19,7 +19,8 @@ const resetStore = () => {
     lockedKeys: {},
     onceKeys: {},
     checkpoints: {},
-    errors: []
+    errors: [],
+    loading: false
   })
   localStorage.clear()
 }
@@ -856,6 +857,7 @@ describe('Passage', () => {
     }
     useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
     render(<Passage />)
+    expect(useGameStore.getState().loading).toBe(true)
     await waitFor(() => {
       const raw = localStorage.getItem('slot1')
       expect(raw).toBeTruthy()
@@ -864,6 +866,7 @@ describe('Passage', () => {
       expect(data.currentPassageId).toBe('1')
       expect(data.checkpoints.cp1).toBeDefined()
     })
+    expect(useGameStore.getState().loading).toBe(false)
   })
 
   it('loads game state and checkpoints from local storage', async () => {
@@ -904,6 +907,7 @@ describe('Passage', () => {
     })
 
     render(<Passage />)
+    expect(useGameStore.getState().loading).toBe(true)
 
     await waitFor(() => {
       expect((useGameStore.getState().gameData as any).hp).toBe(7)
@@ -914,6 +918,7 @@ describe('Passage', () => {
       expect(useStoryDataStore.getState().currentPassageId).toBe('2')
       expect(screen.getByText('Second text')).toBeInTheDocument()
     })
+    expect(useGameStore.getState().loading).toBe(false)
   })
 
   it('logs error when loaded state lacks current passage id', async () => {
@@ -1013,10 +1018,12 @@ describe('Passage', () => {
     useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
 
     render(<Passage />)
+    expect(useGameStore.getState().loading).toBe(true)
 
     await waitFor(() => {
       expect(localStorage.getItem('slot1')).toBeNull()
     })
+    expect(useGameStore.getState().loading).toBe(false)
   })
 
   it('stores error when restore cannot find a checkpoint', async () => {

--- a/apps/campfire/__tests__/Passage.test.tsx
+++ b/apps/campfire/__tests__/Passage.test.tsx
@@ -916,6 +916,78 @@ describe('Passage', () => {
     })
   })
 
+  it('clears a checkpoint by id', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value: ':checkpoint{id=cp1}:clearCheckpoint{id=cp1}'
+        }
+      ]
+    }
+
+    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+
+    render(<Passage />)
+
+    await waitFor(() => {
+      expect(useGameStore.getState().checkpoints).toEqual({})
+    })
+  })
+
+  it('clears all checkpoints when no id is provided', async () => {
+    const state = useGameStore.getState()
+    state.saveCheckpoint('cp1', {
+      gameData: {},
+      lockedKeys: {},
+      onceKeys: {},
+      currentPassageId: '1'
+    })
+    state.saveCheckpoint('cp2', {
+      gameData: {},
+      lockedKeys: {},
+      onceKeys: {},
+      currentPassageId: '1'
+    })
+
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [{ type: 'text', value: ':clearCheckpoint' }]
+    }
+
+    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+
+    render(<Passage />)
+
+    await waitFor(() => {
+      expect(useGameStore.getState().checkpoints).toEqual({})
+    })
+  })
+
+  it('clears saved data from local storage', async () => {
+    localStorage.setItem('slot1', 'test')
+
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [{ type: 'text', value: ':clearSave{key=slot1}' }]
+    }
+
+    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+
+    render(<Passage />)
+
+    await waitFor(() => {
+      expect(localStorage.getItem('slot1')).toBeNull()
+    })
+  })
+
   it('stores error when restore cannot find a checkpoint', async () => {
     const logged: unknown[] = []
     const orig = console.error

--- a/apps/campfire/__tests__/Passage.test.tsx
+++ b/apps/campfire/__tests__/Passage.test.tsx
@@ -857,7 +857,6 @@ describe('Passage', () => {
     }
     useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
     render(<Passage />)
-    expect(useGameStore.getState().loading).toBe(true)
     await waitFor(() => {
       const raw = localStorage.getItem('slot1')
       expect(raw).toBeTruthy()
@@ -907,7 +906,6 @@ describe('Passage', () => {
     })
 
     render(<Passage />)
-    expect(useGameStore.getState().loading).toBe(true)
 
     await waitFor(() => {
       expect((useGameStore.getState().gameData as any).hp).toBe(7)
@@ -1018,7 +1016,6 @@ describe('Passage', () => {
     useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
 
     render(<Passage />)
-    expect(useGameStore.getState().loading).toBe(true)
 
     await waitFor(() => {
       expect(localStorage.getItem('slot1')).toBeNull()

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -608,7 +608,13 @@ export const useDirectiveHandlers = () => {
             onceKeys: { ...(data.onceKeys || {}) },
             checkpoints: { ...(data.checkpoints || {}) }
           })
-          setCurrentPassage(data.currentPassageId)
+          if (data.currentPassageId) {
+            setCurrentPassage(data.currentPassageId)
+          } else {
+            const msg = 'Saved game state has no current passage'
+            console.error(msg)
+            addError(msg)
+          }
         }
       }
     } catch (error) {

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -12,7 +12,7 @@ import type { Text as MdText, Parent, RootContent, Root } from 'mdast'
 import type { Text as HastText, ElementContent } from 'hast'
 import type { ContainerDirective } from 'mdast-util-directive'
 import { useStoryDataStore } from '@/packages/use-story-data-store'
-import { useGameStore } from '@/packages/use-game-store'
+import { useGameStore, type Checkpoint } from '@/packages/use-game-store'
 import {
   isRange,
   clamp,
@@ -576,6 +576,7 @@ export const useDirectiveHandlers = () => {
           gameData: { ...(state.gameData as Record<string, unknown>) },
           lockedKeys: { ...state.lockedKeys },
           onceKeys: { ...state.onceKeys },
+          checkpoints: { ...state.checkpoints },
           currentPassageId
         }
         localStorage.setItem(key, JSON.stringify(data))
@@ -598,12 +599,14 @@ export const useDirectiveHandlers = () => {
             gameData?: Record<string, unknown>
             lockedKeys?: Record<string, true>
             onceKeys?: Record<string, true>
+            checkpoints?: Record<string, Checkpoint<Record<string, unknown>>>
             currentPassageId?: string
           }
           useGameStore.setState({
             gameData: { ...(data.gameData || {}) },
             lockedKeys: { ...(data.lockedKeys || {}) },
-            onceKeys: { ...(data.onceKeys || {}) }
+            onceKeys: { ...(data.onceKeys || {}) },
+            checkpoints: { ...(data.checkpoints || {}) }
           })
           setCurrentPassage(data.currentPassageId)
         }

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -618,6 +618,20 @@ export const useDirectiveHandlers = () => {
     return removeNode(parent, index)
   }
 
+  const handleClearSave: DirectiveHandler = (directive, parent, index) => {
+    const attrs = (directive.attributes || {}) as Record<string, unknown>
+    const key = typeof attrs.key === 'string' ? attrs.key : 'campfire.save'
+    try {
+      if (typeof localStorage !== 'undefined') {
+        localStorage.removeItem(key)
+      }
+    } catch (error) {
+      console.error('Error clearing saved game state:', error)
+      addError('Failed to clear saved game state')
+    }
+    return removeNode(parent, index)
+  }
+
   const handleCheckpoint: DirectiveHandler = (directive, parent, index) => {
     if (lastPassageIdRef.current !== currentPassageId) {
       resetCheckpointState()
@@ -658,6 +672,22 @@ export const useDirectiveHandlers = () => {
     const cp = restoreCheckpointFn(id)
     if (cp?.currentPassageId) {
       setCurrentPassage(cp.currentPassageId)
+    }
+    return removeNode(parent, index)
+  }
+
+  const handleClearCheckpoint: DirectiveHandler = (
+    directive,
+    parent,
+    index
+  ) => {
+    if (includeDepth > 0) return removeNode(parent, index)
+    const attrs = (directive.attributes || {}) as Record<string, unknown>
+    const id = typeof attrs.id === 'string' ? attrs.id : undefined
+    if (id) {
+      removeCheckpoint(id)
+    } else {
+      useGameStore.setState({ checkpoints: {} })
     }
     return removeNode(parent, index)
   }
@@ -742,7 +772,9 @@ export const useDirectiveHandlers = () => {
       goto: handleGoto,
       save: handleSave,
       load: handleLoad,
+      clearSave: handleClearSave,
       checkpoint: handleCheckpoint,
+      clearCheckpoint: handleClearCheckpoint,
       restore: handleRestore,
       clearErrors: handleClearErrors,
       translations: handleTranslations,

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -571,27 +571,24 @@ export const useDirectiveHandlers = () => {
     const attrs = (directive.attributes || {}) as Record<string, unknown>
     const key = typeof attrs.key === 'string' ? attrs.key : 'campfire.save'
     setLoading(true)
-    void Promise.resolve()
-      .then(() => {
-        if (typeof localStorage !== 'undefined') {
-          const state = useGameStore.getState()
-          const data = {
-            gameData: { ...(state.gameData as Record<string, unknown>) },
-            lockedKeys: { ...state.lockedKeys },
-            onceKeys: { ...state.onceKeys },
-            checkpoints: { ...state.checkpoints },
-            currentPassageId
-          }
-          localStorage.setItem(key, JSON.stringify(data))
+    try {
+      if (typeof localStorage !== 'undefined') {
+        const state = useGameStore.getState()
+        const data = {
+          gameData: { ...(state.gameData as Record<string, unknown>) },
+          lockedKeys: { ...state.lockedKeys },
+          onceKeys: { ...state.onceKeys },
+          checkpoints: { ...state.checkpoints },
+          currentPassageId
         }
-      })
-      .catch(error => {
-        console.error('Error saving game state:', error)
-        addError('Failed to save game state')
-      })
-      .finally(() => {
-        setLoading(false)
-      })
+        localStorage.setItem(key, JSON.stringify(data))
+      }
+    } catch (error) {
+      console.error('Error saving game state:', error)
+      addError('Failed to save game state')
+    } finally {
+      setLoading(false)
+    }
     return removeNode(parent, index)
   }
 
@@ -599,41 +596,38 @@ export const useDirectiveHandlers = () => {
     const attrs = (directive.attributes || {}) as Record<string, unknown>
     const key = typeof attrs.key === 'string' ? attrs.key : 'campfire.save'
     setLoading(true)
-    void Promise.resolve()
-      .then(() => {
-        if (typeof localStorage !== 'undefined') {
-          const raw = localStorage.getItem(key)
-          if (raw) {
-            const data = JSON.parse(raw) as {
-              gameData?: Record<string, unknown>
-              lockedKeys?: Record<string, true>
-              onceKeys?: Record<string, true>
-              checkpoints?: Record<string, Checkpoint<Record<string, unknown>>>
-              currentPassageId?: string
-            }
-            useGameStore.setState({
-              gameData: { ...(data.gameData || {}) },
-              lockedKeys: { ...(data.lockedKeys || {}) },
-              onceKeys: { ...(data.onceKeys || {}) },
-              checkpoints: { ...(data.checkpoints || {}) }
-            })
-            if (data.currentPassageId) {
-              setCurrentPassage(data.currentPassageId)
-            } else {
-              const msg = 'Saved game state has no current passage'
-              console.error(msg)
-              addError(msg)
-            }
+    try {
+      if (typeof localStorage !== 'undefined') {
+        const raw = localStorage.getItem(key)
+        if (raw) {
+          const data = JSON.parse(raw) as {
+            gameData?: Record<string, unknown>
+            lockedKeys?: Record<string, true>
+            onceKeys?: Record<string, true>
+            checkpoints?: Record<string, Checkpoint<Record<string, unknown>>>
+            currentPassageId?: string
+          }
+          useGameStore.setState({
+            gameData: { ...(data.gameData || {}) },
+            lockedKeys: { ...(data.lockedKeys || {}) },
+            onceKeys: { ...(data.onceKeys || {}) },
+            checkpoints: { ...(data.checkpoints || {}) }
+          })
+          if (data.currentPassageId) {
+            setCurrentPassage(data.currentPassageId)
+          } else {
+            const msg = 'Saved game state has no current passage'
+            console.error(msg)
+            addError(msg)
           }
         }
-      })
-      .catch(error => {
-        console.error('Error loading game state:', error)
-        addError('Failed to load game state')
-      })
-      .finally(() => {
-        setLoading(false)
-      })
+      }
+    } catch (error) {
+      console.error('Error loading game state:', error)
+      addError('Failed to load game state')
+    } finally {
+      setLoading(false)
+    }
     return removeNode(parent, index)
   }
 
@@ -641,19 +635,16 @@ export const useDirectiveHandlers = () => {
     const attrs = (directive.attributes || {}) as Record<string, unknown>
     const key = typeof attrs.key === 'string' ? attrs.key : 'campfire.save'
     setLoading(true)
-    void Promise.resolve()
-      .then(() => {
-        if (typeof localStorage !== 'undefined') {
-          localStorage.removeItem(key)
-        }
-      })
-      .catch(error => {
-        console.error('Error clearing saved game state:', error)
-        addError('Failed to clear saved game state')
-      })
-      .finally(() => {
-        setLoading(false)
-      })
+    try {
+      if (typeof localStorage !== 'undefined') {
+        localStorage.removeItem(key)
+      }
+    } catch (error) {
+      console.error('Error clearing saved game state:', error)
+      addError('Failed to clear saved game state')
+    } finally {
+      setLoading(false)
+    }
     return removeNode(parent, index)
   }
 

--- a/packages/use-game-store/__tests__/index.test.ts
+++ b/packages/use-game-store/__tests__/index.test.ts
@@ -8,7 +8,8 @@ beforeEach(() => {
     lockedKeys: {},
     onceKeys: {},
     checkpoints: {},
-    errors: []
+    errors: [],
+    loading: false
   })
   useGameStore.getState().init({})
 })

--- a/packages/use-game-store/index.ts
+++ b/packages/use-game-store/index.ts
@@ -23,6 +23,10 @@ export interface GameState<T = Record<string, unknown>> {
   onceKeys: Record<string, true>
   /** Mark a once key as executed */
   markOnce: (key: string) => void
+  /** Indicates persistence operations are in progress */
+  loading: boolean
+  /** Set the loading state */
+  setLoading: (loading: boolean) => void
   /** Recorded errors */
   errors: string[]
   /** Add an error to the list */
@@ -63,6 +67,7 @@ export const useGameStore = create(
     _initialGameData: {},
     lockedKeys: {},
     onceKeys: {},
+    loading: false,
     errors: [],
     checkpoints: {},
     init: data =>
@@ -70,7 +75,8 @@ export const useGameStore = create(
         gameData: { ...data },
         _initialGameData: { ...data },
         onceKeys: {},
-        errors: []
+        errors: [],
+        loading: false
       })),
     setGameData: data =>
       set(
@@ -108,6 +114,7 @@ export const useGameStore = create(
           state.onceKeys[key] = true
         })
       ),
+    setLoading: loading => set({ loading }),
     addError: error =>
       set(
         produce((state: InternalState<Record<string, unknown>>) => {
@@ -161,7 +168,8 @@ export const useGameStore = create(
         gameData: { ...state._initialGameData },
         lockedKeys: {},
         onceKeys: {},
-        errors: []
+        errors: [],
+        loading: false
       }))
   }))
 )


### PR DESCRIPTION
## Summary
- add `goto` directive for navigating to passages by id or name
- add `save`/`load` directives to persist and restore game state via local storage
- document and test new directives

## Testing
- `bun tsc`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_688e2322678c832298bce5cf3384d5cf