### PR TITLE
fix: remove empty paragraphs after directives

### DIFF
--- a/apps/campfire/__tests__/Passage.test.tsx
+++ b/apps/campfire/__tests__/Passage.test.tsx
@@ -274,6 +274,27 @@ describe('Passage', () => {
     )
   })
 
+  it('removes paragraphs left empty by directives', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [{ type: 'text', value: ':set[number]{hp=5}\n\nHello' }]
+    }
+
+    useStoryDataStore.setState({
+      passages: [passage],
+      currentPassageId: '1'
+    })
+
+    render(<Passage />)
+
+    await screen.findByText('Hello')
+
+    const paragraphs = document.querySelectorAll('p')
+    expect(paragraphs).toHaveLength(1)
+  })
+
   it('locks keys with setOnce', async () => {
     const passage: Element = {
       type: 'element',

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -583,8 +583,6 @@ export const useDirectiveHandlers = () => {
     setLoading(true)
     try {
       if (typeof localStorage !== 'undefined') {
-        const { gameData, lockedKeys, onceKeys, checkpoints } =
-          useGameStore.getState()
         const data = {
           gameData: { ...(gameData as Record<string, unknown>) },
           lockedKeys: { ...lockedKeys },

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -583,6 +583,8 @@ export const useDirectiveHandlers = () => {
     setLoading(true)
     try {
       if (typeof localStorage !== 'undefined') {
+        const { gameData, lockedKeys, onceKeys, checkpoints } =
+          useGameStore.getState()
         const data = {
           gameData: { ...(gameData as Record<string, unknown>) },
           lockedKeys: { ...lockedKeys },

--- a/packages/remark-campfire/index.ts
+++ b/packages/remark-campfire/index.ts
@@ -1,5 +1,5 @@
 import { visit } from 'unist-util-visit'
-import type { Root, Parent } from 'mdast'
+import type { Root, Parent, Paragraph, Text } from 'mdast'
 import type { Node } from 'unist'
 import type { LeafDirective, ContainerDirective } from 'mdast-util-directive'
 import type { SKIP } from 'unist-util-visit'
@@ -77,6 +77,24 @@ const remarkCampfire =
           const handler = options.handlers?.[directive.name]
           if (handler) {
             return handler(directive, parent, index)
+          }
+        }
+      }
+    )
+
+    visit(
+      tree,
+      (node: Node, index: number | undefined, parent: Parent | undefined) => {
+        if (node.type === 'paragraph' && parent && typeof index === 'number') {
+          const paragraph = node as Paragraph
+          const hasContent = paragraph.children.some(child => {
+            return !(
+              child.type === 'text' && (child as Text).value.trim() === ''
+            )
+          })
+          if (!hasContent) {
+            parent.children.splice(index, 1)
+            return index
           }
         }
       }


### PR DESCRIPTION
## Summary
- clean up empty paragraph nodes after directive processing
- persist current game state when saving
- test that directive cleanup doesn't leave stray paragraphs

## Testing
- `bun x prettier --write .`
- `bun tsc --noEmit`
- `bun test 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688e627113288322ac77ff75f5872bd3