### PR TITLE
feat: add array directives and random array support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,18 @@ Directives come in two forms:
   :setOnce{visited=true}
   ```
 
+- `array` – store a list of values
+
+  ```md
+  :array[number]{items=1,2,3}
+  ```
+
+- `arrayOnce` – like `array` but locks the key after first use
+
+  ```md
+  :arrayOnce{visited=forest,cave}
+  ```
+
 - `get` – insert a value from the game data
 
   ```md
@@ -82,6 +94,7 @@ Directives come in two forms:
 
   ```md
   :random{key=loot,min=1,max=5}
+  :random{key=treasure,options=[gold,silver,bronze]}
   ```
 
 - `range` – create a numeric range object using the `set` directive

--- a/apps/campfire/__tests__/Passage.test.tsx
+++ b/apps/campfire/__tests__/Passage.test.tsx
@@ -324,6 +324,51 @@ describe('Passage', () => {
     ).toBe(10)
   })
 
+  it('sets arrays with array directive', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [{ type: 'text', value: ':array[number]{nums=1,2,3}' }]
+    }
+
+    useStoryDataStore.setState({
+      passages: [passage],
+      currentPassageId: '1'
+    })
+
+    render(<Passage />)
+
+    await waitFor(() =>
+      expect(useGameStore.getState().gameData.nums).toEqual([1, 2, 3])
+    )
+  })
+
+  it('locks keys with arrayOnce', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [{ type: 'text', value: ':arrayOnce[number]{nums=1,2}' }]
+    }
+
+    useStoryDataStore.setState({
+      passages: [passage],
+      currentPassageId: '1'
+    })
+
+    render(<Passage />)
+
+    await waitFor(() =>
+      expect(useGameStore.getState().gameData.nums).toEqual([1, 2])
+    )
+    expect(useGameStore.getState().lockedKeys.nums).toBe(true)
+
+    useGameStore.getState().setGameData({ nums: [3] })
+
+    expect(useGameStore.getState().gameData.nums).toEqual([1, 2])
+  })
+
   it('retrieves values with get directive', async () => {
     useGameStore.setState(state => ({
       ...state,


### PR DESCRIPTION
## Summary
- add `array` and `arrayOnce` directives for storing lists
- allow `random` directive to choose from arrays
- document array directives and random array usage

## Testing
- `bun tsc && echo tsc-complete`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_688ebbb3db9083228b2bd4cdd3a58134