### PR TITLE
feat: allow overriding page title

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,12 @@ Directives come in two forms:
   :include[42]
   ```
 
+- `title` – override the page title for the current passage
+
+  ```md
+  :title[The Beginning]
+  ```
+
 - `once` – execute a block only the first time it's encountered
 
   ```md

--- a/apps/campfire/__tests__/Passage.test.tsx
+++ b/apps/campfire/__tests__/Passage.test.tsx
@@ -23,12 +23,12 @@ const resetStore = () => {
     loading: false
   })
   localStorage.clear()
+  document.title = ''
 }
 
 describe('Passage', () => {
   beforeEach(async () => {
     document.body.innerHTML = ''
-    document.title = ''
     resetStore()
     if (!i18next.isInitialized) {
       await i18next.use(initReactI18next).init({ lng: 'en-US', resources: {} })

--- a/apps/campfire/__tests__/Passage.test.tsx
+++ b/apps/campfire/__tests__/Passage.test.tsx
@@ -28,6 +28,7 @@ const resetStore = () => {
 describe('Passage', () => {
   beforeEach(async () => {
     document.body.innerHTML = ''
+    document.title = ''
     resetStore()
     if (!i18next.isInitialized) {
       await i18next.use(initReactI18next).init({ lng: 'en-US', resources: {} })
@@ -59,6 +60,63 @@ describe('Passage', () => {
   it('renders nothing when no passage is set', () => {
     render(<Passage />)
     expect(document.body.textContent).toBe('')
+  })
+
+  it('sets document title to passage name', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [{ type: 'text', value: 'Hello' }]
+    }
+
+    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+    render(<Passage />)
+
+    await waitFor(() => {
+      expect(document.title).toBe('Start')
+    })
+  })
+
+  it('overrides title with title directive', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [{ type: 'text', value: ':title[Custom]' }]
+    }
+
+    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+    render(<Passage />)
+
+    await waitFor(() => {
+      expect(document.title).toBe('Custom')
+    })
+  })
+
+  it('ignores title directive in included passages', async () => {
+    const start: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [{ type: 'text', value: ':include[Second]' }]
+    }
+    const second: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '2', name: 'Second' },
+      children: [{ type: 'text', value: ':title[Other]' }]
+    }
+
+    useStoryDataStore.setState({
+      passages: [start, second],
+      currentPassageId: '1'
+    })
+    render(<Passage />)
+
+    await waitFor(() => {
+      expect(document.title).toBe('Start')
+    })
   })
 
   it('navigates to the linked passage when a button is clicked', async () => {

--- a/apps/campfire/src/Passage.tsx
+++ b/apps/campfire/src/Passage.tsx
@@ -44,6 +44,17 @@ export const Passage = () => {
   const [content, setContent] = useState<ReactNode>(null)
 
   useEffect(() => {
+    if (!passage) return
+    const name =
+      typeof passage.properties?.name === 'string'
+        ? passage.properties.name
+        : undefined
+    if (name) {
+      document.title = name
+    }
+  }, [passage])
+
+  useEffect(() => {
     const run = async () => {
       if (!passage) {
         setContent(null)

--- a/apps/campfire/src/Passage.tsx
+++ b/apps/campfire/src/Passage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type ReactNode } from 'react'
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import * as runtime from 'react/jsx-runtime'
 import { jsxDEV } from 'react/jsx-dev-runtime'
 import { unified } from 'unified'
@@ -11,6 +11,7 @@ import rehypeCampfire from '@/packages/rehype-campfire'
 import rehypeReact from 'rehype-react'
 import type { Text, Content } from 'hast'
 import { useDirectiveHandlers } from './useDirectiveHandlers'
+import { isTitleOverridden, clearTitleOverride } from './titleState'
 import {
   useStoryDataStore,
   type StoryDataState
@@ -42,14 +43,24 @@ export const Passage = () => {
     state.getCurrentPassage()
   )
   const [content, setContent] = useState<ReactNode>(null)
+  const prevPassageId = useRef<string | undefined>(undefined)
 
   useEffect(() => {
     if (!passage) return
+    const id =
+      typeof passage.properties?.pid === 'string'
+        ? passage.properties.pid
+        : undefined
+    const isNewPassage = prevPassageId.current !== id
+    if (isNewPassage) {
+      prevPassageId.current = id
+      clearTitleOverride()
+    }
     const name =
       typeof passage.properties?.name === 'string'
         ? passage.properties.name
         : undefined
-    if (name) {
+    if (name && !isTitleOverridden()) {
       document.title = name
     }
   }, [passage])

--- a/apps/campfire/src/titleState.ts
+++ b/apps/campfire/src/titleState.ts
@@ -1,0 +1,11 @@
+let overridden = false
+
+export const markTitleOverridden = () => {
+  overridden = true
+}
+
+export const clearTitleOverride = () => {
+  overridden = false
+}
+
+export const isTitleOverridden = () => overridden

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -13,6 +13,7 @@ import type { Text as HastText, ElementContent } from 'hast'
 import type { ContainerDirective } from 'mdast-util-directive'
 import { useStoryDataStore } from '@/packages/use-story-data-store'
 import { useGameStore, type Checkpoint } from '@/packages/use-game-store'
+import { markTitleOverridden } from './titleState'
 import {
   isRange,
   clamp,
@@ -1016,6 +1017,7 @@ export const useDirectiveHandlers = () => {
     const title = toString(directive).trim()
     if (title) {
       document.title = i18next.t(title)
+      markTitleOverridden()
     }
     return removeNode(parent, index)
   }

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -1011,6 +1011,15 @@ export const useDirectiveHandlers = () => {
     return removeNode(parent, index)
   }
 
+  const handleTitle: DirectiveHandler = (directive, parent, index) => {
+    if (includeDepth > 0) return removeNode(parent, index)
+    const title = toString(directive).trim()
+    if (title) {
+      document.title = i18next.t(title)
+    }
+    return removeNode(parent, index)
+  }
+
   const handleInclude: DirectiveHandler = (directive, parent, index) => {
     const target =
       toString(directive).trim() ||
@@ -1098,6 +1107,7 @@ export const useDirectiveHandlers = () => {
       onChange: handleOnChange,
       lang: handleLang,
       include: handleInclude,
+      title: handleTitle,
       goto: handleGoto,
       save: handleSave,
       load: handleLoad,


### PR DESCRIPTION
## Summary
- set page title from current passage name
- add `:title` directive to override passage name
- document new `:title` directive and cover with tests

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_688f982150708322805cb2046ac0002f