### PR TITLE
fix(modal): sync dialog with events

### DIFF
--- a/apps/campfire/__tests__/Modal.test.tsx
+++ b/apps/campfire/__tests__/Modal.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach } from 'bun:test'
+import { render, screen, act } from '@testing-library/react'
+import { Modal } from '../src/Modal'
+import { useGameStore } from '@/packages/use-game-store'
+
+const resetStore = () => {
+  useGameStore.setState({
+    gameData: {},
+    _initialGameData: {},
+    lockedKeys: {},
+    onceKeys: {},
+    checkpoints: {},
+    errors: [],
+    loading: false
+  })
+}
+
+describe('Modal', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    resetStore()
+  })
+
+  it('closes and updates game state on backdrop click', () => {
+    useGameStore.setState(state => ({ ...state, gameData: { modal: true } }))
+    render(<Modal open='modal'>content</Modal>)
+    const dialog = screen.getByRole('dialog') as HTMLDialogElement
+    expect(dialog.hasAttribute('open')).toBe(true)
+
+    act(() => {
+      dialog.click()
+    })
+
+    expect(dialog.hasAttribute('open')).toBe(false)
+    expect(useGameStore.getState().gameData.modal).toBe(false)
+  })
+
+  it('updates game state when cancel event fires', () => {
+    useGameStore.setState(state => ({ ...state, gameData: { modal: true } }))
+    render(<Modal open='modal'>content</Modal>)
+    const dialog = screen.getByRole('dialog') as HTMLDialogElement
+
+    act(() => {
+      dialog.dispatchEvent(new Event('cancel'))
+    })
+
+    expect(useGameStore.getState().gameData.modal).toBe(false)
+  })
+})

--- a/apps/campfire/src/Modal.tsx
+++ b/apps/campfire/src/Modal.tsx
@@ -21,18 +21,20 @@ export const Modal = ({ open, className, children }: ModalProps) => {
       : []
   const dialogRef = useRef<HTMLDialogElement>(null)
   const handleClick = (e: MouseEvent<HTMLDialogElement>) => {
-    if (e.target === e.currentTarget && open) {
-      if (
-        dialogRef.current?.open &&
-        typeof dialogRef.current.close === 'function'
-      ) {
+    if (e.target === e.currentTarget) {
+      const dialog = dialogRef.current
+      if (!dialog) return
+      if (dialog.open && typeof dialog.close === 'function') {
         try {
-          dialogRef.current.close()
+          dialog.close()
         } catch {
-          dialogRef.current.removeAttribute('open')
+          dialog.removeAttribute('open')
+          dialog.dispatchEvent(new Event('close'))
         }
+      } else {
+        dialog.removeAttribute('open')
+        dialog.dispatchEvent(new Event('close'))
       }
-      setGameData({ [open]: false })
     }
   }
   useEffect(() => {
@@ -65,6 +67,19 @@ export const Modal = ({ open, className, children }: ModalProps) => {
       }
     }
   }, [isOpen])
+
+  useEffect(() => {
+    const dialog = dialogRef.current
+    if (!dialog || !open) return
+
+    const handleClose = () => setGameData({ [open]: false })
+    dialog.addEventListener('close', handleClose)
+    dialog.addEventListener('cancel', handleClose)
+    return () => {
+      dialog.removeEventListener('close', handleClose)
+      dialog.removeEventListener('cancel', handleClose)
+    }
+  }, [open, setGameData])
 
   return (
     <>


### PR DESCRIPTION
## Summary
- listen for dialog close and cancel events to update game state
- stop directly setting state in modal click handler
- add component tests covering modal close and cancel handling

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_689029b9f5b08322a158c676ee1eb1b9