### PR TITLE
fix: support attribute comparisons in if directive

### DIFF
--- a/apps/campfire/__tests__/Passage.test.tsx
+++ b/apps/campfire/__tests__/Passage.test.tsx
@@ -1126,6 +1126,57 @@ describe('Passage', () => {
     expect(document.body.textContent).not.toContain('Hidden')
   })
 
+  it('evaluates if directives with attribute comparisons', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value:
+            ':set[boolean]{openModal=false}\n:::if{openModal=false}\nhello!\n:::'
+        }
+      ]
+    }
+
+    useStoryDataStore.setState({
+      passages: [passage],
+      currentPassageId: '1'
+    })
+
+    render(<Passage />)
+
+    const text = await screen.findByText('hello!')
+    expect(text).toBeInTheDocument()
+  })
+
+  it('skips content when attribute comparison fails', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value:
+            ':set[boolean]{openModal=true}\n:::if{openModal=false}\nhello!\n:::'
+        }
+      ]
+    }
+
+    useStoryDataStore.setState({
+      passages: [passage],
+      currentPassageId: '1'
+    })
+
+    render(<Passage />)
+
+    await waitFor(() => {
+      expect(screen.queryByText('hello!')).toBeNull()
+    })
+  })
+
   it('changes locale with lang directive', async () => {
     const passage: Element = {
       type: 'element',

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -217,6 +217,7 @@ export const useDirectiveHandlers = () => {
           lockKey(k)
         }
       }
+      gameData = { ...gameData, ...safe }
     }
 
     if (parent && typeof index === 'number') {
@@ -286,6 +287,7 @@ export const useDirectiveHandlers = () => {
           lockKey(k)
         }
       }
+      gameData = { ...gameData, ...safe }
     }
 
     return removeNode(parent, index)
@@ -307,7 +309,25 @@ export const useDirectiveHandlers = () => {
     evalConditionFn: (expr: string) => boolean = evalCondition
   ): RootContent[] => {
     const children = node.children as RootContent[]
-    const expr = getLabel(node) || Object.keys(node.attributes || {})[0] || ''
+    let expr = getLabel(node) || ''
+    if (!expr) {
+      const attrs = node.attributes || {}
+      const [firstKey, firstValue] = Object.entries(attrs)[0] || []
+      if (firstKey) {
+        if (firstValue === '' || typeof firstValue === 'undefined') {
+          expr = firstKey
+        } else {
+          const valStr = String(firstValue).trim()
+          const valueExpr =
+            valStr === 'true' ||
+            valStr === 'false' ||
+            /^-?\d+(?:\.\d+)?$/.test(valStr)
+              ? valStr
+              : JSON.stringify(valStr)
+          expr = `${firstKey}==${valueExpr}`
+        }
+      }
+    }
     let idx = 1
     while (
       idx < children.length &&


### PR DESCRIPTION
## Summary
- support `if` directives that compare attribute values
- sync internal game data after `set` and `array` directives
- add tests for `if` attribute comparisons

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_689043cccc3483228cd939c31cc4d338