### PR TITLE
fix: reprocess passage when game state changes

### DIFF
--- a/apps/campfire/src/Passage.tsx
+++ b/apps/campfire/src/Passage.tsx
@@ -48,6 +48,15 @@ export const Passage = () => {
   )
   const [content, setContent] = useState<ReactNode>(null)
   const prevPassageId = useRef<string | undefined>(undefined)
+  const [version, setVersion] = useState(0)
+
+  useEffect(() => {
+    const rerender = () => setVersion(v => v + 1)
+    window.addEventListener('campfire-statechange', rerender)
+    return () => {
+      window.removeEventListener('campfire-statechange', rerender)
+    }
+  }, [])
 
   useEffect(() => {
     if (!passage) return
@@ -86,7 +95,7 @@ export const Passage = () => {
       setContent(file.result as ReactNode)
     }
     void run()
-  }, [passage])
+  }, [passage, version])
 
   return <>{content}</>
 }

--- a/apps/campfire/src/TriggerButton.tsx
+++ b/apps/campfire/src/TriggerButton.tsx
@@ -36,6 +36,9 @@ export const TriggerButton = ({
       disabled={disabled}
       onClick={() => {
         runBlock(clone(JSON.parse(content)))
+        setTimeout(() => {
+          window.dispatchEvent(new CustomEvent('campfire-statechange'))
+        })
       }}
     >
       {children}


### PR DESCRIPTION
## Summary
- trigger a passage re-render when game data changes
- fire a custom event after trigger directives run

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_6890b0fa80f8832288975c343934ba6b