### PR TITLE
refactor: remove trigger state change event

### DIFF
--- a/apps/campfire/src/Passage.tsx
+++ b/apps/campfire/src/Passage.tsx
@@ -48,15 +48,6 @@ export const Passage = () => {
   )
   const [content, setContent] = useState<ReactNode>(null)
   const prevPassageId = useRef<string | undefined>(undefined)
-  const [version, setVersion] = useState(0)
-
-  useEffect(() => {
-    const rerender = () => setVersion(v => v + 1)
-    window.addEventListener('campfire-statechange', rerender)
-    return () => {
-      window.removeEventListener('campfire-statechange', rerender)
-    }
-  }, [])
 
   useEffect(() => {
     if (!passage) return
@@ -95,7 +86,7 @@ export const Passage = () => {
       setContent(file.result as ReactNode)
     }
     void run()
-  }, [passage, version])
+  }, [passage])
 
   return <>{content}</>
 }

--- a/apps/campfire/src/TriggerButton.tsx
+++ b/apps/campfire/src/TriggerButton.tsx
@@ -34,12 +34,7 @@ export const TriggerButton = ({
       type='button'
       className={['campfire-trigger', ...classes].join(' ')}
       disabled={disabled}
-      onClick={() => {
-        runBlock(clone(JSON.parse(content)))
-        setTimeout(() => {
-          window.dispatchEvent(new CustomEvent('campfire-statechange'))
-        })
-      }}
+      onClick={() => runBlock(clone(JSON.parse(content)))}
     >
       {children}
     </button>


### PR DESCRIPTION
## Summary
- remove `campfire-statechange` custom event and rely on direct state updates

## Testing
- `bun tsc && echo 'tsc success'`
- `bun test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6890b9c12ab48322b7ee69b0333b7a96