### PR TITLE
feat: hash game data for passage re-render

### DIFF
--- a/apps/campfire/__tests__/DebugWindow.test.tsx
+++ b/apps/campfire/__tests__/DebugWindow.test.tsx
@@ -17,7 +17,9 @@ const resetStores = async () => {
     lockedKeys: {},
     onceKeys: {},
     checkpoints: {},
-    errors: []
+    errors: [],
+    loading: false,
+    hash: 0
   })
   if (!i18next.isInitialized) {
     await i18next.init({ lng: 'en-US', resources: {} })

--- a/apps/campfire/__tests__/Passage.test.tsx
+++ b/apps/campfire/__tests__/Passage.test.tsx
@@ -20,7 +20,8 @@ const resetStore = () => {
     onceKeys: {},
     checkpoints: {},
     errors: [],
-    loading: false
+    loading: false,
+    hash: 0
   })
   localStorage.clear()
   document.title = ''
@@ -362,15 +363,8 @@ describe('Passage', () => {
         origUnset(key)
       }
     })
-    useGameStore.setState({
-      gameData: { hp: 1, items: [], old: true },
-      _initialGameData: {},
-      lockedKeys: {},
-      onceKeys: {},
-      checkpoints: {},
-      errors: [],
-      loading: false
-    })
+    useGameStore.getState().init({})
+    useGameStore.getState().setGameData({ hp: 1, items: [], old: true })
     const passage: Element = {
       type: 'element',
       tagName: 'tw-passagedata',
@@ -1355,12 +1349,7 @@ describe('Passage', () => {
       children: []
     }
 
-    useGameStore.setState({
-      gameData: { hp: 1 },
-      _initialGameData: { hp: 1 },
-      lockedKeys: {},
-      onceKeys: {}
-    })
+    useGameStore.getState().init({ hp: 1 })
     useStoryDataStore.setState({
       passages: [start, next],
       currentPassageId: '1'
@@ -1831,7 +1820,7 @@ describe('Passage', () => {
     const { rerender } = render(<Passage key='start' />)
     await screen.findByText('Not fired')
     const button = await screen.findByRole('button', { name: 'Fire' })
-    act(() => {
+    await act(async () => {
       button.click()
     })
     rerender(<Passage key='updated' />)

--- a/apps/campfire/src/Passage.tsx
+++ b/apps/campfire/src/Passage.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useCallback,
+  type ReactNode
+} from 'react'
 import * as runtime from 'react/jsx-runtime'
 import { jsxDEV } from 'react/jsx-dev-runtime'
 import { unified } from 'unified'
@@ -16,6 +23,7 @@ import {
   useStoryDataStore,
   type StoryDataState
 } from '@/packages/use-story-data-store'
+import { useGameStore } from '@/packages/use-game-store'
 import { LinkButton } from './LinkButton'
 import { TriggerButton } from './TriggerButton'
 
@@ -46,8 +54,10 @@ export const Passage = () => {
   const passage = useStoryDataStore((state: StoryDataState) =>
     state.getCurrentPassage()
   )
+  const hash = useGameStore(state => state.hash)
   const [content, setContent] = useState<ReactNode>(null)
   const prevPassageId = useRef<string | undefined>(undefined)
+  const processingRef = useRef(false)
 
   useEffect(() => {
     if (!passage) return
@@ -69,24 +79,32 @@ export const Passage = () => {
     }
   }, [passage])
 
-  useEffect(() => {
-    const run = async () => {
-      if (!passage) {
-        setContent(null)
-        return
-      }
-      const text = passage.children
-        .map((child: Content) =>
-          child.type === 'text' && typeof child.value === 'string'
-            ? (child as Text).value
-            : ''
-        )
-        .join('')
-      const file = await processor.process(text)
-      setContent(file.result as ReactNode)
+  const renderPassage = useCallback(async () => {
+    if (!passage) {
+      setContent(null)
+      return
     }
-    void run()
-  }, [passage])
+    processingRef.current = true
+    const text = passage.children
+      .map((child: Content) =>
+        child.type === 'text' && typeof child.value === 'string'
+          ? (child as Text).value
+          : ''
+      )
+      .join('')
+    const file = await processor.process(text)
+    setContent(file.result as ReactNode)
+    processingRef.current = false
+  }, [passage, processor])
+
+  useEffect(() => {
+    void renderPassage()
+  }, [renderPassage])
+
+  useEffect(() => {
+    if (processingRef.current) return
+    void renderPassage()
+  }, [hash, renderPassage])
 
   return <>{content}</>
 }

--- a/packages/use-game-store/__tests__/index.test.ts
+++ b/packages/use-game-store/__tests__/index.test.ts
@@ -9,7 +9,8 @@ beforeEach(() => {
     onceKeys: {},
     checkpoints: {},
     errors: [],
-    loading: false
+    loading: false,
+    hash: 0
   })
   useGameStore.getState().init({})
 })
@@ -43,6 +44,15 @@ describe('useGameStore', () => {
     useGameStore.getState().setGameData({ health: 10, mana: 5 })
     useGameStore.getState().unsetGameData('mana')
     expect(useGameStore.getState().gameData).toEqual({ health: 10 })
+  })
+
+  it('updates hash when game data changes', () => {
+    const initial = useGameStore.getState().hash
+    useGameStore.getState().setGameData({ health: 1 })
+    const afterSet = useGameStore.getState().hash
+    expect(afterSet).not.toBe(initial)
+    useGameStore.getState().unsetGameData('health')
+    expect(useGameStore.getState().hash).not.toBe(afterSet)
   })
 
   it('marks once keys and clears on reset', () => {


### PR DESCRIPTION
## Summary
- track a fast hash of game data in the Zustand game store
- re-render passages automatically when the game data hash changes
- verify game data hash updates through unit tests

## Testing
- `bun tsc`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_6890dc40428c83228b18efce0f2fef0b