### PR TITLE
refactor: remove hash-based game state tracking

### DIFF
--- a/apps/campfire/__tests__/DebugWindow.test.tsx
+++ b/apps/campfire/__tests__/DebugWindow.test.tsx
@@ -3,7 +3,6 @@ import { render, screen, act } from '@testing-library/react'
 import { DebugWindow } from '../src/DebugWindow'
 import { useStoryDataStore } from '@/packages/use-story-data-store'
 import { useGameStore } from '@/packages/use-game-store'
-import { hash as hashObject } from 'ohash'
 import i18next from 'i18next'
 
 const resetStores = async () => {
@@ -19,8 +18,7 @@ const resetStores = async () => {
     onceKeys: {},
     checkpoints: {},
     errors: [],
-    loading: false,
-    hash: hashObject({})
+    loading: false
   })
   if (!i18next.isInitialized) {
     await i18next.init({ lng: 'en-US', resources: {} })

--- a/apps/campfire/__tests__/Passage.test.tsx
+++ b/apps/campfire/__tests__/Passage.test.tsx
@@ -6,7 +6,6 @@ import type { Element } from 'hast'
 import { Passage } from '../src/Passage'
 import { useStoryDataStore } from '@/packages/use-story-data-store'
 import { useGameStore } from '@/packages/use-game-store'
-import { hash as hashObject } from 'ohash'
 
 const resetStore = () => {
   useStoryDataStore.setState({
@@ -21,8 +20,7 @@ const resetStore = () => {
     onceKeys: {},
     checkpoints: {},
     errors: [],
-    loading: false,
-    hash: hashObject({})
+    loading: false
   })
   localStorage.clear()
   document.title = ''
@@ -199,6 +197,37 @@ describe('Passage', () => {
       expect(screen.getByText('Second text')).toBeInTheDocument()
       expect(useStoryDataStore.getState().currentPassageId).toBe('2')
     })
+  })
+
+  it('renders the latest passage when state changes quickly', async () => {
+    const first: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'First' },
+      children: [{ type: 'text', value: 'First text' }]
+    }
+    const second: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '2', name: 'Second' },
+      children: [{ type: 'text', value: 'Second text' }]
+    }
+
+    useStoryDataStore.setState({
+      passages: [first, second],
+      currentPassageId: '1'
+    })
+
+    const { rerender } = render(<Passage />)
+    act(() => {
+      useStoryDataStore.setState({ currentPassageId: '2' })
+    })
+    rerender(<Passage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Second text')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('First text')).toBeNull()
   })
 
   it('renders included passage content', async () => {

--- a/apps/campfire/__tests__/Passage.test.tsx
+++ b/apps/campfire/__tests__/Passage.test.tsx
@@ -199,7 +199,7 @@ describe('Passage', () => {
     })
   })
 
-  it('renders the latest passage when state changes quickly', async () => {
+  it('cancels an in-flight render when passage changes quickly', async () => {
     const first: Element = {
       type: 'element',
       tagName: 'tw-passagedata',
@@ -219,14 +219,17 @@ describe('Passage', () => {
     })
 
     const { rerender } = render(<Passage />)
+    await new Promise(resolve => setTimeout(resolve, 10))
     act(() => {
       useStoryDataStore.setState({ currentPassageId: '2' })
     })
     rerender(<Passage />)
 
     await waitFor(() => {
+      expect(screen.queryByText('First text')).toBeNull()
       expect(screen.getByText('Second text')).toBeInTheDocument()
     })
+    await new Promise(resolve => setTimeout(resolve, 10))
     expect(screen.queryByText('First text')).toBeNull()
   })
 

--- a/apps/campfire/src/Passage.tsx
+++ b/apps/campfire/src/Passage.tsx
@@ -75,10 +75,10 @@ export const Passage = () => {
     const controller = new AbortController()
     abortRef.current = controller
     prevController?.abort()
-    const render = async () => {
+    ;(async () => {
       if (controller.signal.aborted) return
       if (!passage) {
-        if (!controller.signal.aborted) setContent(null)
+        setContent(null)
         return
       }
       const text = passage.children
@@ -92,12 +92,10 @@ export const Passage = () => {
       const file = await processor.process(text)
       if (controller.signal.aborted) return
       setContent(file.result as ReactNode)
-    }
-    void render()
-    return () => {
-      controller.abort()
-    }
+    })()
   }, [passage, processor])
+
+  useEffect(() => () => abortRef.current?.abort(), [])
 
   return <>{content}</>
 }

--- a/apps/campfire/src/Passage.tsx
+++ b/apps/campfire/src/Passage.tsx
@@ -69,8 +69,9 @@ export const Passage = () => {
     }
   }, [passage])
 
+  const renderIdRef = useRef(0)
   useEffect(() => {
-    let cancelled = false
+    const id = ++renderIdRef.current
     const render = async () => {
       if (!passage) {
         setContent(null)
@@ -84,14 +85,11 @@ export const Passage = () => {
         )
         .join('')
       const file = await processor.process(text)
-      if (!cancelled) {
+      if (renderIdRef.current === id) {
         setContent(file.result as ReactNode)
       }
     }
     void render()
-    return () => {
-      cancelled = true
-    }
   }, [passage, processor])
 
   return <>{content}</>

--- a/apps/campfire/src/Passage.tsx
+++ b/apps/campfire/src/Passage.tsx
@@ -48,6 +48,7 @@ export const Passage = () => {
   )
   const [content, setContent] = useState<ReactNode>(null)
   const prevPassageId = useRef<string | undefined>(undefined)
+  const renderIdRef = useRef(0)
 
   useEffect(() => {
     if (!passage) return
@@ -69,7 +70,6 @@ export const Passage = () => {
     }
   }, [passage])
 
-  const renderIdRef = useRef(0)
   useEffect(() => {
     const id = ++renderIdRef.current
     const render = async () => {

--- a/apps/campfire/src/Passage.tsx
+++ b/apps/campfire/src/Passage.tsx
@@ -48,7 +48,6 @@ export const Passage = () => {
   )
   const [content, setContent] = useState<ReactNode>(null)
   const prevPassageId = useRef<string | undefined>(undefined)
-  const abortRef = useRef<AbortController | null>(null)
 
   useEffect(() => {
     if (!passage) return
@@ -71,10 +70,7 @@ export const Passage = () => {
   }, [passage])
 
   useEffect(() => {
-    const prevController = abortRef.current
     const controller = new AbortController()
-    abortRef.current = controller
-    prevController?.abort()
     ;(async () => {
       if (controller.signal.aborted) return
       if (!passage) {
@@ -93,9 +89,8 @@ export const Passage = () => {
       if (controller.signal.aborted) return
       setContent(file.result as ReactNode)
     })()
+    return () => controller.abort()
   }, [passage, processor])
-
-  useEffect(() => () => abortRef.current?.abort(), [])
 
   return <>{content}</>
 }

--- a/apps/campfire/src/Passage.tsx
+++ b/apps/campfire/src/Passage.tsx
@@ -71,9 +71,10 @@ export const Passage = () => {
   }, [passage])
 
   useEffect(() => {
+    const prevController = abortRef.current
     const controller = new AbortController()
-    abortRef.current?.abort()
     abortRef.current = controller
+    prevController?.abort()
     const render = async () => {
       if (!passage) {
         if (!controller.signal.aborted) setContent(null)

--- a/apps/campfire/src/Passage.tsx
+++ b/apps/campfire/src/Passage.tsx
@@ -1,11 +1,4 @@
-import {
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  useCallback,
-  type ReactNode
-} from 'react'
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import * as runtime from 'react/jsx-runtime'
 import { jsxDEV } from 'react/jsx-dev-runtime'
 import { unified } from 'unified'
@@ -23,7 +16,6 @@ import {
   useStoryDataStore,
   type StoryDataState
 } from '@/packages/use-story-data-store'
-import { useGameStore } from '@/packages/use-game-store'
 import { LinkButton } from './LinkButton'
 import { TriggerButton } from './TriggerButton'
 
@@ -54,13 +46,8 @@ export const Passage = () => {
   const passage = useStoryDataStore((state: StoryDataState) =>
     state.getCurrentPassage()
   )
-  const hash = useGameStore(state => state.hash)
   const [content, setContent] = useState<ReactNode>(null)
   const prevPassageId = useRef<string | undefined>(undefined)
-  const processingRef = useRef(false)
-  const renderIdRef = useRef(0)
-  const pendingRef = useRef(false)
-  const renderRef = useRef<(() => Promise<void>) | null>(null)
 
   useEffect(() => {
     if (!passage) return
@@ -82,47 +69,30 @@ export const Passage = () => {
     }
   }, [passage])
 
-  const renderPassage = useCallback(async () => {
-    if (processingRef.current) {
-      pendingRef.current = true
-      return
+  useEffect(() => {
+    let cancelled = false
+    const render = async () => {
+      if (!passage) {
+        setContent(null)
+        return
+      }
+      const text = passage.children
+        .map((child: Content) =>
+          child.type === 'text' && typeof child.value === 'string'
+            ? (child as Text).value
+            : ''
+        )
+        .join('')
+      const file = await processor.process(text)
+      if (!cancelled) {
+        setContent(file.result as ReactNode)
+      }
     }
-    processingRef.current = true
-    pendingRef.current = false
-    const id = ++renderIdRef.current
-    if (!passage) {
-      setContent(null)
-      processingRef.current = false
-      if (pendingRef.current && renderRef.current) void renderRef.current()
-      return
+    void render()
+    return () => {
+      cancelled = true
     }
-    const text = passage.children
-      .map((child: Content) =>
-        child.type === 'text' && typeof child.value === 'string'
-          ? (child as Text).value
-          : ''
-      )
-      .join('')
-    const file = await processor.process(text)
-    if (renderIdRef.current === id) {
-      setContent(file.result as ReactNode)
-    }
-    processingRef.current = false
-    if (pendingRef.current && renderRef.current) void renderRef.current()
   }, [passage, processor])
-
-  useEffect(() => {
-    renderRef.current = renderPassage
-  }, [renderPassage])
-
-  useEffect(() => {
-    void renderPassage()
-  }, [renderPassage])
-
-  useEffect(() => {
-    if (processingRef.current) return
-    void renderPassage()
-  }, [hash, renderPassage])
 
   return <>{content}</>
 }

--- a/apps/campfire/src/Passage.tsx
+++ b/apps/campfire/src/Passage.tsx
@@ -76,6 +76,7 @@ export const Passage = () => {
     abortRef.current = controller
     prevController?.abort()
     const render = async () => {
+      if (controller.signal.aborted) return
       if (!passage) {
         if (!controller.signal.aborted) setContent(null)
         return
@@ -87,10 +88,10 @@ export const Passage = () => {
             : ''
         )
         .join('')
+      if (controller.signal.aborted) return
       const file = await processor.process(text)
-      if (!controller.signal.aborted) {
-        setContent(file.result as ReactNode)
-      }
+      if (controller.signal.aborted) return
+      setContent(file.result as ReactNode)
     }
     void render()
     return () => {

--- a/bun.lock
+++ b/bun.lock
@@ -101,7 +101,6 @@
       "version": "0.0.0",
       "dependencies": {
         "immer": "^10.1.1",
-        "ohash": "^2.0.11",
         "zustand": "^5.0.6",
       },
     },
@@ -946,8 +945,6 @@
     "object-keys": ["object-keys@1.1.1", "", {}, "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="],
 
     "object.assign": ["object.assign@4.1.7", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0", "has-symbols": "^1.1.0", "object-keys": "^1.1.1" } }, "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw=="],
-
-    "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 

--- a/packages/use-game-store/__tests__/index.test.ts
+++ b/packages/use-game-store/__tests__/index.test.ts
@@ -1,6 +1,5 @@
 import { useGameStore } from '../index'
 import { describe, it, expect, beforeEach } from 'bun:test'
-import { hash as hashObject } from 'ohash'
 
 // Reset store state before each test
 beforeEach(() => {
@@ -10,8 +9,7 @@ beforeEach(() => {
     onceKeys: {},
     checkpoints: {},
     errors: [],
-    loading: false,
-    hash: hashObject({})
+    loading: false
   })
   useGameStore.getState().init({})
 })
@@ -45,15 +43,6 @@ describe('useGameStore', () => {
     useGameStore.getState().setGameData({ health: 10, mana: 5 })
     useGameStore.getState().unsetGameData('mana')
     expect(useGameStore.getState().gameData).toEqual({ health: 10 })
-  })
-
-  it('updates hash when game data changes', () => {
-    const initial = useGameStore.getState().hash
-    useGameStore.getState().setGameData({ health: 1 })
-    const afterSet = useGameStore.getState().hash
-    expect(afterSet).not.toBe(initial)
-    useGameStore.getState().unsetGameData('health')
-    expect(useGameStore.getState().hash).not.toBe(afterSet)
   })
 
   it('marks once keys and clears on reset', () => {

--- a/packages/use-game-store/index.ts
+++ b/packages/use-game-store/index.ts
@@ -1,15 +1,10 @@
 import { produce } from 'immer'
 import { create } from 'zustand'
 import { subscribeWithSelector } from 'zustand/middleware'
-import { hash as hashObject } from 'ohash'
-
-const EMPTY_HASH = hashObject({})
 
 export interface GameState<T = Record<string, unknown>> {
   /** Arbitrary game state */
   gameData: T
-  /** Fast hash of the current game data */
-  hash: string
   /** Initialize gameData and remember the initial state */
   init: (data: T) => void
   /** Merge partial data into existing gameData */
@@ -75,15 +70,13 @@ export const useGameStore = create(
     loading: false,
     errors: [],
     checkpoints: {},
-    hash: EMPTY_HASH,
     init: data =>
       set(() => ({
         gameData: { ...data },
         _initialGameData: { ...data },
         onceKeys: {},
         errors: [],
-        loading: false,
-        hash: hashObject(data as Record<string, unknown>)
+        loading: false
       })),
     setGameData: data =>
       set(
@@ -93,7 +86,6 @@ export const useGameStore = create(
               ;(state.gameData as Record<string, unknown>)[k] = v
             }
           }
-          state.hash = hashObject(state.gameData)
         })
       ),
     unsetGameData: key =>
@@ -102,7 +94,6 @@ export const useGameStore = create(
           const k = key as string
           delete (state.gameData as Record<string, unknown>)[k]
           delete state.lockedKeys[k]
-          state.hash = hashObject(state.gameData)
         })
       ),
     lockKey: key =>
@@ -163,8 +154,7 @@ export const useGameStore = create(
         set({
           gameData: { ...cp.gameData },
           lockedKeys: { ...cp.lockedKeys },
-          onceKeys: { ...cp.onceKeys },
-          hash: hashObject(cp.gameData)
+          onceKeys: { ...cp.onceKeys }
         })
         return cp
       }
@@ -179,8 +169,7 @@ export const useGameStore = create(
         lockedKeys: {},
         onceKeys: {},
         errors: [],
-        loading: false,
-        hash: hashObject(state._initialGameData as Record<string, unknown>)
+        loading: false
       }))
   }))
 )

--- a/packages/use-game-store/package.json
+++ b/packages/use-game-store/package.json
@@ -7,7 +7,6 @@
   },
   "dependencies": {
     "immer": "^10.1.1",
-    "ohash": "^2.0.11",
     "zustand": "^5.0.6"
   }
 }


### PR DESCRIPTION
## Summary
- remove hash tracking from use-game-store
- drop hash-based re-rendering in Passage component
- remove ohash dependency and update tests
- simplify Passage rendering by removing processing and render refs

## Testing
- `bun x prettier --write .`
- `bun tsc && echo 'tsc completed'`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68912fc605ac8322ab1a1f95a396c7de