### PR TITLE
test: verify negated expressions in if directive

### DIFF
--- a/apps/campfire/__tests__/Passage.test.tsx
+++ b/apps/campfire/__tests__/Passage.test.tsx
@@ -1204,6 +1204,64 @@ describe('Passage', () => {
     })
   })
 
+  it('skips content for negated key expression', async () => {
+    useGameStore.setState(state => ({
+      ...state,
+      gameData: { some_key: true }
+    }))
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value: ':::if{!some_key}\nShown\n:::else\nHidden\n:::'
+        }
+      ]
+    }
+
+    useStoryDataStore.setState({
+      passages: [passage],
+      currentPassageId: '1'
+    })
+
+    render(<Passage />)
+
+    const text = await screen.findByText('Hidden')
+    expect(text).toBeInTheDocument()
+    expect(screen.queryByText('Shown')).toBeNull()
+  })
+
+  it('skips content for negated defined directive expression', async () => {
+    useGameStore.setState(state => ({
+      ...state,
+      gameData: { some_key: 1 }
+    }))
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value: ':::if{!:defined{key=some_key}}\nShown\n:::else\nHidden\n:::'
+        }
+      ]
+    }
+
+    useStoryDataStore.setState({
+      passages: [passage],
+      currentPassageId: '1'
+    })
+
+    render(<Passage />)
+
+    const text = await screen.findByText('Hidden')
+    expect(text).toBeInTheDocument()
+    expect(screen.queryByText('Shown')).toBeNull()
+  })
+
   it('changes locale with lang directive', async () => {
     const passage: Element = {
       type: 'element',


### PR DESCRIPTION
## Summary
- add tests for negated key expressions in if directives
- add tests for negated defined expressions in if directives

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_689163cb91c08322bfe491f5875030ed