### PR TITLE
feat(campfire): add if directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,45 +2,39 @@
 
 ## [1.24.1](https://github.com/magicink/twine-campfire/compare/v1.24.0...v1.24.1) (2025-08-05)
 
-
 ### Bug Fixes
 
-* remove hash-based game state tracking ([#101](https://github.com/magicink/twine-campfire/issues/101)) ([3d733e7](https://github.com/magicink/twine-campfire/commit/3d733e7304b985679cb0a99c5556c1ab38610587))
+- remove hash-based game state tracking ([#101](https://github.com/magicink/twine-campfire/issues/101)) ([3d733e7](https://github.com/magicink/twine-campfire/commit/3d733e7304b985679cb0a99c5556c1ab38610587))
 
 ## [1.24.0](https://github.com/magicink/twine-campfire/compare/v1.23.5...v1.24.0) (2025-08-04)
 
-
 ### Features
 
-* hash game data for passage re-render ([#99](https://github.com/magicink/twine-campfire/issues/99)) ([fc8470f](https://github.com/magicink/twine-campfire/commit/fc8470fa6fe27ae68f6133cb40574b1e28263e91))
+- hash game data for passage re-render ([#99](https://github.com/magicink/twine-campfire/issues/99)) ([fc8470f](https://github.com/magicink/twine-campfire/commit/fc8470fa6fe27ae68f6133cb40574b1e28263e91))
 
 ## [1.23.5](https://github.com/magicink/twine-campfire/compare/v1.23.4...v1.23.5) (2025-08-04)
 
-
 ### Bug Fixes
 
-* cover if directive after trigger updates ([#97](https://github.com/magicink/twine-campfire/issues/97)) ([d7d02c9](https://github.com/magicink/twine-campfire/commit/d7d02c99e65b35b996523e0e765ec59eaa955344))
+- cover if directive after trigger updates ([#97](https://github.com/magicink/twine-campfire/issues/97)) ([d7d02c9](https://github.com/magicink/twine-campfire/commit/d7d02c99e65b35b996523e0e765ec59eaa955344))
 
 ## [1.23.4](https://github.com/magicink/twine-campfire/compare/v1.23.3...v1.23.4) (2025-08-04)
 
-
 ### Bug Fixes
 
-* reprocess passage when game state changes ([#94](https://github.com/magicink/twine-campfire/issues/94)) ([618610a](https://github.com/magicink/twine-campfire/commit/618610a5737e36e317b87c4e5c85e9547f3d24af))
+- reprocess passage when game state changes ([#94](https://github.com/magicink/twine-campfire/issues/94)) ([618610a](https://github.com/magicink/twine-campfire/commit/618610a5737e36e317b87c4e5c85e9547f3d24af))
 
 ## [1.23.3](https://github.com/magicink/twine-campfire/compare/v1.23.2...v1.23.3) (2025-08-04)
 
-
 ### Bug Fixes
 
-* support attribute comparisons in if directive ([#92](https://github.com/magicink/twine-campfire/issues/92)) ([b08d18c](https://github.com/magicink/twine-campfire/commit/b08d18c87d021e1aa2e06138eafc881ea57c203e))
+- support attribute comparisons in if directive ([#92](https://github.com/magicink/twine-campfire/issues/92)) ([b08d18c](https://github.com/magicink/twine-campfire/commit/b08d18c87d021e1aa2e06138eafc881ea57c203e))
 
 ## [1.23.2](https://github.com/magicink/twine-campfire/compare/v1.23.1...v1.23.2) (2025-08-04)
 
-
 ### Bug Fixes
 
-* remove modal directive and component ([#90](https://github.com/magicink/twine-campfire/issues/90)) ([e7e8fb8](https://github.com/magicink/twine-campfire/commit/e7e8fb813d4762ebadea010363f5cad55c4192ee))
+- remove modal directive and component ([#90](https://github.com/magicink/twine-campfire/issues/90)) ([e7e8fb8](https://github.com/magicink/twine-campfire/commit/e7e8fb813d4762ebadea010363f5cad55c4192ee))
 
 ## [1.22.0](https://github.com/magicink/twine-campfire/compare/v1.21.0...v1.22.0) (2025-08-03)
 

--- a/apps/campfire/__tests__/If.test.tsx
+++ b/apps/campfire/__tests__/If.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'bun:test'
+import { render, screen } from '@testing-library/react'
+import { If } from '../src/If'
+
+const makeContent = (text: string) =>
+  JSON.stringify([
+    { type: 'paragraph', children: [{ type: 'text', value: text }] }
+  ])
+
+describe('If', () => {
+  it('renders content when condition is true', () => {
+    render(<If test='true' content={makeContent('Hello')} />)
+    expect(screen.getByText('Hello')).toBeInTheDocument()
+  })
+
+  it('renders fallback when condition is false', () => {
+    render(
+      <If
+        test='false'
+        content={makeContent('Content')}
+        fallback={makeContent('Fallback')}
+      />
+    )
+    expect(screen.getByText('Fallback')).toBeInTheDocument()
+  })
+
+  it('renders nothing when condition is false and no fallback', () => {
+    const { container } = render(
+      <If test='false' content={makeContent('Nope')} />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/apps/campfire/src/If.tsx
+++ b/apps/campfire/src/If.tsx
@@ -1,0 +1,54 @@
+import { useMemo, type ReactNode } from 'react'
+import * as runtime from 'react/jsx-runtime'
+import { jsxDEV } from 'react/jsx-dev-runtime'
+import { unified } from 'unified'
+import remarkCampfire from '@/packages/remark-campfire'
+import remarkRehype from 'remark-rehype'
+import rehypeCampfire from '@/packages/rehype-campfire'
+import rehypeReact from 'rehype-react'
+import type { RootContent, Root } from 'mdast'
+import { compile } from 'expression-eval'
+import { useGameStore } from '@/packages/use-game-store'
+import { useDirectiveHandlers } from './useDirectiveHandlers'
+import { LinkButton } from './LinkButton'
+import { TriggerButton } from './TriggerButton'
+
+interface IfProps {
+  test: string
+  content: string
+  fallback?: string
+}
+
+export const If = ({ test, content, fallback }: IfProps) => {
+  const handlers = useDirectiveHandlers()
+  const processor = useMemo(
+    () =>
+      unified()
+        .use(remarkCampfire, { handlers })
+        .use(remarkRehype)
+        .use(rehypeCampfire)
+        .use(rehypeReact, {
+          Fragment: runtime.Fragment,
+          jsx: runtime.jsx,
+          jsxs: runtime.jsxs,
+          jsxDEV,
+          development: process.env.NODE_ENV === 'development',
+          components: { button: LinkButton, trigger: TriggerButton, if: If }
+        }),
+    [handlers]
+  )
+  const gameData = useGameStore(state => state.gameData)
+  let condition = false
+  try {
+    const fn = compile(test)
+    condition = !!fn(gameData as any)
+  } catch {
+    condition = false
+  }
+  const source = condition ? content : fallback
+  if (!source) return null
+  const nodes: RootContent[] = JSON.parse(source)
+  const root: Root = { type: 'root', children: nodes }
+  const tree = processor.runSync(root)
+  return processor.stringify(tree) as ReactNode
+}

--- a/apps/campfire/src/Passage.tsx
+++ b/apps/campfire/src/Passage.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/packages/use-story-data-store'
 import { LinkButton } from './LinkButton'
 import { TriggerButton } from './TriggerButton'
+import { If } from './If'
 
 export const Passage = () => {
   const handlers = useDirectiveHandlers()
@@ -38,7 +39,8 @@ export const Passage = () => {
           development: process.env.NODE_ENV === 'development',
           components: {
             button: LinkButton,
-            trigger: TriggerButton
+            trigger: TriggerButton,
+            if: If
           }
         }),
     [handlers]


### PR DESCRIPTION
## Summary
- add `if` directive that serializes block content to a new `<If>` component
- evaluate `if` expressions at runtime and parse directive content when rendered
- cover `If` component condition and fallback scenarios

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68922be0eb7483228ee41cde4bf38f4a