### PR TITLE
fix: parse if directives after break conversion

### DIFF
--- a/apps/campfire/__tests__/Passage.test.tsx
+++ b/apps/campfire/__tests__/Passage.test.tsx
@@ -1751,4 +1751,22 @@ describe('Passage', () => {
       expect(useGameStore.getState().gameData.go).toBe('true')
     })
   })
+
+  it('parses if directives after blank lines', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value: ':set[boolean]{open=true}\n\n:::if{!open}\nnot open\n:::'
+        }
+      ]
+    }
+    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+    render(<Passage />)
+    await waitFor(() => expect(screen.queryByText('not open')).toBeNull())
+    expect(screen.queryByText(':::if{!open}')).toBeNull()
+  })
 })

--- a/apps/campfire/src/Passage.tsx
+++ b/apps/campfire/src/Passage.tsx
@@ -33,9 +33,9 @@ export const Passage = () => {
       unified()
         .use(remarkParse)
         .use(remarkGfm)
-        .use(remarkBreaks)
         .use(remarkDirective)
         .use(remarkCampfire, { handlers })
+        .use(remarkBreaks)
         .use(remarkRehype)
         .use(rehypeCampfire)
         .use(rehypeReact, {


### PR DESCRIPTION
## Summary
- ensure directives parse before converting newlines to `<br>`
- add regression test for `:::if` after blank lines

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68926512f74483229ea98ed3fd8fd321