### PR TITLE
feat(campfire): add passage debug tab

### DIFF
--- a/apps/campfire/__tests__/DebugWindow.test.tsx
+++ b/apps/campfire/__tests__/DebugWindow.test.tsx
@@ -1,9 +1,10 @@
-import { describe, it, expect, beforeEach } from 'bun:test'
+import { describe, it, expect, beforeEach, mock } from 'bun:test'
 import { render, screen, act } from '@testing-library/react'
 import { DebugWindow } from '../src/DebugWindow'
 import { useStoryDataStore } from '@/packages/use-story-data-store'
 import { useGameStore } from '@/packages/use-game-store'
 import i18next from 'i18next'
+import type { Element } from 'hast'
 
 const resetStores = async () => {
   useStoryDataStore.setState({
@@ -62,8 +63,15 @@ describe('DebugWindow', () => {
   })
 
   it('shows game data by default and switches tabs', () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: []
+    }
     useStoryDataStore.setState({
-      storyData: { options: 'debug', foo: 'bar' }
+      storyData: { options: 'debug', foo: 'bar' },
+      passages: [passage]
     })
     useGameStore.setState(state => ({
       ...state,
@@ -78,6 +86,7 @@ describe('DebugWindow', () => {
       storyTab.click()
     })
     expect(screen.getByText(/"foo": "bar"/)).toBeInTheDocument()
+    expect(screen.getByText('Start')).toBeInTheDocument()
   })
 
   it('shows translations from i18next', () => {
@@ -109,5 +118,56 @@ describe('DebugWindow', () => {
       errTab.click()
     })
     expect(screen.getByText('something went wrong')).toBeInTheDocument()
+  })
+
+  it('shows raw current passage', () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [{ type: 'text', value: 'Raw [[Link]]' }]
+    }
+    useStoryDataStore.setState({
+      storyData: { options: 'debug' },
+      passages: [passage],
+      currentPassageId: '1'
+    })
+    render(<DebugWindow />)
+    const passageTab = screen.getByRole('button', { name: 'Passage' })
+    act(() => {
+      passageTab.click()
+    })
+    expect(screen.getByText('Raw [[Link]]')).toBeInTheDocument()
+  })
+
+  it('copies raw passage to clipboard', () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [{ type: 'text', value: 'Raw [[Link]]' }]
+    }
+    useStoryDataStore.setState({
+      storyData: { options: 'debug' },
+      passages: [passage],
+      currentPassageId: '1'
+    })
+
+    const writeText = mock(() => Promise.resolve())
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true
+    })
+
+    render(<DebugWindow />)
+    const passageTab = screen.getByRole('button', { name: 'Passage' })
+    act(() => {
+      passageTab.click()
+    })
+    const copyButton = screen.getByRole('button', { name: 'Copy' })
+    act(() => {
+      copyButton.click()
+    })
+    expect(writeText).toHaveBeenCalledWith('Raw [[Link]]')
   })
 })


### PR DESCRIPTION
## Summary
- list passages on Story Data tab in debug window
- add Passage tab showing current passage raw content
- allow copying raw passage text to clipboard from Passage tab

## Testing
- `bun x prettier --write apps/campfire/__tests__/DebugWindow.test.tsx apps/campfire/src/DebugWindow.tsx`
- `bun tsc && echo 'tsc succeeded'`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_6892912f08c48322a3361f6f2ec54b20