### PR TITLE
feat: add Show component to display game data

### DIFF
--- a/apps/campfire/__tests__/Show.test.tsx
+++ b/apps/campfire/__tests__/Show.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach } from 'bun:test'
+import { render, screen, act } from '@testing-library/react'
+import { Show } from '../src/Show'
+import { useGameStore } from '@/packages/use-game-store'
+
+/**
+ * Resets the game store to an empty state before each test.
+ */
+beforeEach(() => {
+  useGameStore.setState({
+    gameData: {},
+    _initialGameData: {},
+    lockedKeys: {},
+    onceKeys: {},
+    checkpoints: {},
+    errors: [],
+    loading: false
+  })
+})
+
+describe('Show', () => {
+  it('renders the value for a given key', () => {
+    useGameStore.getState().setGameData({ hp: 5 })
+    render(<Show data-key='hp' />)
+    expect(screen.getByText('5')).toBeInTheDocument()
+  })
+
+  it('updates when the value changes', () => {
+    useGameStore.getState().setGameData({ hp: 3 })
+    render(<Show data-key='hp' />)
+    act(() => {
+      useGameStore.getState().setGameData({ hp: 7 })
+    })
+    expect(screen.getByText('7')).toBeInTheDocument()
+  })
+
+  it('renders nothing when the value is undefined', () => {
+    const { container } = render(<Show data-key='hp' />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing when the value is null', () => {
+    useGameStore.getState().setGameData({ hp: null })
+    const { container } = render(<Show data-key='hp' />)
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/apps/campfire/src/If.tsx
+++ b/apps/campfire/src/If.tsx
@@ -11,6 +11,7 @@ import { useGameStore } from '@/packages/use-game-store'
 import { useDirectiveHandlers } from './useDirectiveHandlers'
 import { LinkButton } from './LinkButton'
 import { TriggerButton } from './TriggerButton'
+import { Show } from './Show'
 
 interface IfProps {
   test: string
@@ -37,7 +38,12 @@ export const If = ({ test, content, fallback }: IfProps) => {
           jsxs: runtime.jsxs,
           jsxDEV,
           development: process.env.NODE_ENV === 'development',
-          components: { button: LinkButton, trigger: TriggerButton, if: If }
+          components: {
+            button: LinkButton,
+            trigger: TriggerButton,
+            if: If,
+            show: Show
+          }
         }),
     [handlers]
   )

--- a/apps/campfire/src/Passage.tsx
+++ b/apps/campfire/src/Passage.tsx
@@ -19,6 +19,7 @@ import {
 import { LinkButton } from './LinkButton'
 import { TriggerButton } from './TriggerButton'
 import { If } from './If'
+import { Show } from './Show'
 
 /**
  * Converts legacy if directive syntax using braces into label-based directives.
@@ -85,7 +86,8 @@ export const Passage = () => {
           components: {
             button: LinkButton,
             trigger: TriggerButton,
-            if: If
+            if: If,
+            show: Show
           }
         }),
     [handlers]

--- a/apps/campfire/src/Show.tsx
+++ b/apps/campfire/src/Show.tsx
@@ -13,7 +13,7 @@ interface ShowProps {
  * Updates automatically when the underlying data changes.
  */
 export const Show = (props: ShowProps) => {
-  const storeKey = props['data-key'] ?? (props as Record<string, unknown>).key
+  const storeKey = props['data-key'] ?? props.key
   const value = useGameStore(state => {
     if (!storeKey) return undefined
     return (state.gameData as Record<string, unknown>)[storeKey as string]

--- a/apps/campfire/src/Show.tsx
+++ b/apps/campfire/src/Show.tsx
@@ -1,0 +1,23 @@
+import { useGameStore } from '@/packages/use-game-store'
+
+interface ShowProps {
+  /** Game data key to display */
+  key?: string
+  /** Optional key attribute when using data-* */
+  'data-key'?: string
+}
+
+/**
+ * Displays a value from the game store for the provided key.
+ * Returns `null` when the referenced value is `null` or `undefined`.
+ * Updates automatically when the underlying data changes.
+ */
+export const Show = (props: ShowProps) => {
+  const storeKey = props['data-key'] ?? (props as Record<string, unknown>).key
+  const value = useGameStore(state => {
+    if (!storeKey) return undefined
+    return (state.gameData as Record<string, unknown>)[storeKey as string]
+  })
+  if (value == null) return null
+  return <span>{String(value)}</span>
+}

--- a/apps/campfire/src/Show.tsx
+++ b/apps/campfire/src/Show.tsx
@@ -16,7 +16,7 @@ export const Show = (props: ShowProps) => {
   const storeKey = props['data-key'] ?? props.key
   const value = useGameStore(state => {
     if (!storeKey) return undefined
-    return (state.gameData as Record<string, unknown>)[storeKey as string]
+    return (state.gameData as Record<string, unknown>)[storeKey]
   })
   if (value == null) return null
   return <span>{String(value)}</span>


### PR DESCRIPTION
## Summary
- add `Show` component to render game store values
- register `show` elements so they can be used within passages and `If`
- cover reactive value display with tests
- return `null` when the referenced game data is `null` or `undefined`

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_6892b9ddfd18832290afaf1f43c09ac3