### PR TITLE
feat: add show directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,14 @@ Read or compute data without mutating state.
   Replace `RESULT` with the key to store and `HP`/`VALUE` with numbers or
   keys.
 
+- `show`: Display a key's value.
+
+  ```md
+  :show{key=HP}
+  ```
+
+  Replace `HP` with the key to display.
+
 ### Conditional logic
 
 Run content only when conditions hold.

--- a/README.md
+++ b/README.md
@@ -232,10 +232,10 @@ Read or compute data without mutating state.
 - `show`: Display a key's value.
 
   ```md
-  :show{key=HP}
+  :show[hp]
   ```
 
-  Replace `HP` with the key to display.
+  Replace `hp` with the key to display.
 
 ### Conditional logic
 

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Read or compute data without mutating state.
 - `show`: Display a key's value.
 
   ```md
-  :show[hp]
+  :show{key=hp}
   ```
 
   Replace `hp` with the key to display.

--- a/apps/campfire/__tests__/Passage.test.tsx
+++ b/apps/campfire/__tests__/Passage.test.tsx
@@ -897,6 +897,28 @@ describe('Passage', () => {
     expect(useGameStore.getState().gameData.hp).toBe(6)
   })
 
+  it('renders game data with show directive', async () => {
+    useGameStore.setState(state => ({
+      ...state,
+      gameData: { hp: 7 }
+    }))
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [{ type: 'text', value: 'HP: :show[hp]' }]
+    }
+
+    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+
+    render(<Passage />)
+
+    await waitFor(() => {
+      const span = screen.getByText('7')
+      expect(span.closest('p')?.textContent?.replace(/\s+/g, '')).toBe('HP:7')
+    })
+  })
+
   it('increments values', async () => {
     useGameStore.setState(state => ({
       ...state,

--- a/apps/campfire/__tests__/Passage.test.tsx
+++ b/apps/campfire/__tests__/Passage.test.tsx
@@ -906,7 +906,7 @@ describe('Passage', () => {
       type: 'element',
       tagName: 'tw-passagedata',
       properties: { pid: '1', name: 'Start' },
-      children: [{ type: 'text', value: 'HP: :show[hp]' }]
+      children: [{ type: 'text', value: 'HP: :show{key=hp}' }]
     }
 
     useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -362,6 +362,36 @@ export const useDirectiveHandlers = () => {
     }
   }
 
+  /**
+   * Inserts a Show component that displays the value for the provided key.
+   *
+   * @param directive - The directive node representing the show directive.
+   * @param parent - The parent AST node containing this directive.
+   * @param index - The index of the directive node within its parent.
+   */
+  const handleShow: DirectiveHandler = (directive, parent, index) => {
+    const attrs = directive.attributes || {}
+    const key = ensureKey(
+      (attrs as Record<string, unknown>).key ??
+        (toString(directive).trim() || Object.keys(attrs)[0]),
+      parent,
+      index
+    )
+    if (!key) return index
+    const node: MdText = {
+      type: 'text',
+      value: '',
+      data: {
+        hName: 'show',
+        hProperties: { 'data-key': key }
+      }
+    }
+    if (parent && typeof index === 'number') {
+      parent.children.splice(index, 1, node)
+      return index
+    }
+  }
+
   const handleRandom: DirectiveHandler = (directive, parent, index) => {
     const attrs = directive.attributes || {}
     const key = ensureKey((attrs as Record<string, unknown>).key, parent, index)
@@ -1246,6 +1276,7 @@ export const useDirectiveHandlers = () => {
       ) => handleArray(d, p, i, true),
       defined: handleDefined,
       math: handleMath,
+      show: handleShow,
       random: handleRandom,
       pop: handlePop,
       push: handlePush,

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -388,8 +388,8 @@ export const useDirectiveHandlers = () => {
     }
     if (parent && typeof index === 'number') {
       parent.children.splice(index, 1, node)
-      return index
     }
+    return index
   }
 
   const handleRandom: DirectiveHandler = (directive, parent, index) => {

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -371,12 +371,7 @@ export const useDirectiveHandlers = () => {
    */
   const handleShow: DirectiveHandler = (directive, parent, index) => {
     const attrs = directive.attributes || {}
-    const key = ensureKey(
-      (attrs as Record<string, unknown>).key ??
-        (toString(directive).trim() || Object.keys(attrs)[0]),
-      parent,
-      index
-    )
+    const key = ensureKey((attrs as Record<string, unknown>).key, parent, index)
     if (!key) return index
     const node: MdText = {
       type: 'text',


### PR DESCRIPTION
## Summary
- add `show` directive handler to render game data
- document `show` directive
- test rendering of `show` directive

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_6892c69d8f4c83229d228773992d5884