### PR TITLE
fix(show): display range values correctly

### DIFF
--- a/apps/campfire/__tests__/Show.test.tsx
+++ b/apps/campfire/__tests__/Show.test.tsx
@@ -25,6 +25,14 @@ describe('Show', () => {
     expect(screen.getByText('5')).toBeInTheDocument()
   })
 
+  it('renders the value of range objects', () => {
+    useGameStore
+      .getState()
+      .setGameData({ hp: { lower: 0, upper: 10, value: 4 } })
+    render(<Show data-key='hp' />)
+    expect(screen.getByText('4')).toBeInTheDocument()
+  })
+
   it('updates when the value changes', () => {
     useGameStore.getState().setGameData({ hp: 3 })
     render(<Show data-key='hp' />)

--- a/apps/campfire/src/Show.tsx
+++ b/apps/campfire/src/Show.tsx
@@ -1,4 +1,5 @@
 import { useGameStore } from '@/packages/use-game-store'
+import { isRange } from './directives/helpers'
 
 interface ShowProps {
   /** Game data key to display */
@@ -19,5 +20,6 @@ export const Show = (props: ShowProps) => {
     return (state.gameData as Record<string, unknown>)[storeKey]
   })
   if (value == null) return null
-  return <span>{String(value)}</span>
+  const displayValue = isRange(value) ? value.value : value
+  return <span>{String(displayValue)}</span>
 }


### PR DESCRIPTION
## Summary
- handle RangeValue objects in Show component so their numeric value is displayed
- test Show component with range game data

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68934a8606a483229047162082d2f0b1