### PR TITLE
feat: remove increment and decrement directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,22 +79,6 @@ Directives are grouped by purpose.
 
 Operations that set, update or remove scalar values.
 
-- `decrement`: Decrease a numeric key.
-
-  ```md
-  :decrement{key=HP amount=VALUE}
-  ```
-
-  Replace `HP` with the key to change and `VALUE` with the amount.
-
-- `increment`: Increase a numeric key.
-
-  ```md
-  :increment{key=HP amount=VALUE}
-  ```
-
-  Replace `HP` with the key to change and `VALUE` with the amount.
-
 - `random`: Assign a random integer.
 
   ```md
@@ -303,7 +287,8 @@ Run directives on specific passage events or group actions.
   :::batch
   :::set{key=HP value=VALUE}
   :::
-  :increment{key=HP amount=VALUE}
+  :push{key=items value=sword}
+  :unset{key=old}
   :::
   ```
 

--- a/apps/campfire/__tests__/Passage.test.tsx
+++ b/apps/campfire/__tests__/Passage.test.tsx
@@ -394,7 +394,7 @@ describe('Passage', () => {
       }
     })
     useGameStore.getState().init({})
-    useGameStore.getState().setGameData({ hp: 1, items: [], old: true })
+    useGameStore.getState().setGameData({ items: [], old: true })
     const passage: Element = {
       type: 'element',
       tagName: 'tw-passagedata',
@@ -403,7 +403,7 @@ describe('Passage', () => {
         {
           type: 'text',
           value:
-            ':::batch\\n:set[boolean]{key=visited value=true}\\n:increment{key=hp amount=2}\\n:push{key=items value=sword}\\n:unset{key=old}\\n:::\n'
+            ':::batch\\n:set[boolean]{key=visited value=true}\\n:push{key=items value=sword}\\n:unset{key=old}\\n:::\n'
         }
       ]
     }
@@ -417,7 +417,6 @@ describe('Passage', () => {
 
     await waitFor(() => {
       const data = useGameStore.getState().gameData as Record<string, unknown>
-      expect(data.hp).toBe(3)
       expect(data.items).toEqual(['sword'])
       expect(data.visited).toBe(true)
       expect('old' in data).toBe(false)
@@ -927,58 +926,6 @@ describe('Passage', () => {
       const span = screen.getByText('7')
       expect(span.closest('p')?.textContent?.replace(/\s+/g, '')).toBe('HP:7')
     })
-  })
-
-  it('increments values', async () => {
-    useGameStore.setState(state => ({
-      ...state,
-      gameData: { count: 1 }
-    }))
-    const passage: Element = {
-      type: 'element',
-      tagName: 'tw-passagedata',
-      properties: { pid: '1', name: 'Start' },
-      children: [{ type: 'text', value: ':increment{key=count amount=2}' }]
-    }
-
-    useStoryDataStore.setState({
-      passages: [passage],
-      currentPassageId: '1'
-    })
-
-    render(<Passage />)
-
-    await waitFor(() =>
-      expect(
-        (useGameStore.getState().gameData as Record<string, unknown>).count
-      ).toBe(3)
-    )
-  })
-
-  it('decrements values', async () => {
-    useGameStore.setState(state => ({
-      ...state,
-      gameData: { count: 3 }
-    }))
-    const passage: Element = {
-      type: 'element',
-      tagName: 'tw-passagedata',
-      properties: { pid: '1', name: 'Start' },
-      children: [{ type: 'text', value: ':decrement{key=count amount=1}' }]
-    }
-
-    useStoryDataStore.setState({
-      passages: [passage],
-      currentPassageId: '1'
-    })
-
-    render(<Passage />)
-
-    await waitFor(() =>
-      expect(
-        (useGameStore.getState().gameData as Record<string, unknown>).count
-      ).toBe(2)
-    )
   })
 
   it('creates range values with set[range]', async () => {

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -649,53 +649,6 @@ export const useDirectiveHandlers = () => {
     return removeNode(parent, index)
   }
 
-  const handleIncrement = (
-    directive: DirectiveNode,
-    parent: Parent | undefined,
-    index: number | undefined,
-    sign = 1
-  ): DirectiveHandlerResult => {
-    const attrs = directive.attributes || {}
-    const key = ensureKey((attrs as Record<string, unknown>).key, parent, index)
-    if (!key) return index
-    const amountRaw = (attrs as Record<string, unknown>).amount
-
-    let amount: number = 1
-    if (typeof amountRaw === 'number') {
-      amount = amountRaw
-    } else if (typeof amountRaw === 'string') {
-      let evaluated: unknown = amountRaw
-      try {
-        const fn = compile(amountRaw)
-        evaluated = fn(gameData)
-      } catch {
-        // ignore
-      }
-      amount =
-        typeof evaluated === 'number'
-          ? evaluated
-          : parseNumericValue(evaluated, 1)
-    }
-
-    amount *= sign
-
-    const current = gameData[key]
-    if (isRange(current)) {
-      setGameData({
-        [key]: {
-          ...current,
-          value: clamp(current.value + amount, current.lower, current.upper)
-        }
-      })
-    } else {
-      const base = parseNumericValue(current, 0)
-      setGameData({ [key]: base + amount })
-    }
-
-    const removed = removeNode(parent, index)
-    if (typeof removed === 'number') return removed
-  }
-
   const handleUnset: DirectiveHandler = (directive, parent, index) => {
     const attrs = directive.attributes || {}
     const key = ensureKey(
@@ -1295,16 +1248,6 @@ export const useDirectiveHandlers = () => {
       unshift: handleUnshift,
       splice: handleSplice,
       concat: handleConcat,
-      increment: (
-        d: DirectiveNode,
-        p: Parent | undefined,
-        i: number | undefined
-      ) => handleIncrement(d, p, i, 1),
-      decrement: (
-        d: DirectiveNode,
-        p: Parent | undefined,
-        i: number | undefined
-      ) => handleIncrement(d, p, i, -1),
       unset: handleUnset,
       if: handleIf,
       once: handleOnce,


### PR DESCRIPTION
## Summary
- remove `increment` and `decrement` directive handlers
- drop tests referencing increment/decrement directives
- update documentation and examples

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_689351bdd1088322b7ddfa440b24b80b