### PR TITLE
fix: require key for math directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,14 +207,14 @@ Read or compute data without mutating state.
 
   Replace `HP` with the key to test.
 
-- `math`: Perform a calculation.
+- `math`: Perform a calculation and store the result under a key.
 
   ```md
-  :math{into=RESULT expr="HP + VALUE"}
+  :math[HP + VALUE]{key=RESULT}
   ```
 
   Replace `RESULT` with the key to store and `HP`/`VALUE` with numbers or
-  keys.
+  keys. Use `:show` to display stored values.
 
 - `show`: Display a key's value.
 

--- a/apps/campfire/__tests__/Passage.test.tsx
+++ b/apps/campfire/__tests__/Passage.test.tsx
@@ -859,7 +859,7 @@ describe('Passage', () => {
     })
   })
 
-  it('evaluates expressions with math directive', async () => {
+  it('requires a key and does not display results', async () => {
     useGameStore.setState(state => ({
       ...state,
       gameData: { x: 3 }
@@ -878,8 +878,9 @@ describe('Passage', () => {
 
     render(<Passage />)
 
-    const text = await screen.findByText('Result: 6')
-    expect(text).toBeInTheDocument()
+    await screen.findByText('Result:')
+    expect(screen.queryByText('Result: 6')).toBeNull()
+    expect(useGameStore.getState().gameData.x).toBe(3)
   })
 
   it('can set state with math directive', async () => {
@@ -891,7 +892,12 @@ describe('Passage', () => {
       type: 'element',
       tagName: 'tw-passagedata',
       properties: { pid: '1', name: 'Start' },
-      children: [{ type: 'text', value: 'HP: :math[hp + 1]{key=hp}' }]
+      children: [
+        {
+          type: 'text',
+          value: 'HP: :math[hp + 1]{key=hp} :show{key=hp}'
+        }
+      ]
     }
 
     useStoryDataStore.setState({
@@ -901,8 +907,10 @@ describe('Passage', () => {
 
     render(<Passage />)
 
-    const text = await screen.findByText('HP: 6')
-    expect(text).toBeInTheDocument()
+    await waitFor(() => {
+      const span = screen.getByText('6')
+      expect(span.closest('p')?.textContent?.replace(/\s+/g, '')).toBe('HP:6')
+    })
     expect(useGameStore.getState().gameData.hp).toBe(6)
   })
 

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -334,13 +334,15 @@ export const useDirectiveHandlers = () => {
   }
 
   /**
-   * Evaluates a mathematical or JavaScript expression in the context of the current game data.
-   * Optionally stores the result in the game data state if a 'key' attribute is provided.
-   * Replaces the directive node in the AST with a text node containing the result.
+   * Evaluates a mathematical or JavaScript expression in the context of the current game data
+   * and stores the result under the provided key. The directive does not display any output.
    */
   const handleMath: DirectiveHandler = (directive, parent, index) => {
     const attrs = directive.attributes || {}
     const typedAttrs = attrs as Record<string, unknown>
+    const key = ensureKey(typedAttrs.key, parent, index)
+    if (!key) return index
+
     let expr = toString(directive).trim()
     if (!expr) {
       if (typeof typedAttrs.expr === 'string') {
@@ -360,22 +362,9 @@ export const useDirectiveHandlers = () => {
       value = ''
     }
 
-    const key =
-      typeof typedAttrs.key === 'string'
-        ? (typedAttrs.key as string)
-        : undefined
-    if (typeof key === 'string') {
-      setGameData({ [key]: value })
-    }
-
-    const textNode: MdText = {
-      type: 'text',
-      value: value == null ? '' : String(value)
-    }
-    if (parent && typeof index === 'number') {
-      parent.children.splice(index, 1, textNode)
-      return index
-    }
+    setGameData({ [key]: value })
+    gameData = { ...gameData, [key]: value }
+    return removeNode(parent, index)
   }
 
   /**


### PR DESCRIPTION
## Summary
- require key for `math` directive and remove text output
- document math directive usage and update tests

## Testing
- `bun tsc`
- `bun test 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68936f9490f88322a1275c4bfe53ac9b