### PR TITLE
feat(campfire): support standard markdown formatting

### DIFF
--- a/apps/campfire/__tests__/If.test.tsx
+++ b/apps/campfire/__tests__/If.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'bun:test'
 import { render, screen } from '@testing-library/react'
 import { unified } from 'unified'
 import remarkParse from 'remark-parse'
+import remarkGfm from 'remark-gfm'
 import remarkDirective from 'remark-directive'
 import type { RootContent } from 'mdast'
 import { If } from '../src/If'
@@ -20,7 +21,7 @@ const makeContent = (text: string) =>
  */
 const makeMixedContent = (md: string) =>
   JSON.stringify(
-    unified().use(remarkParse).use(remarkDirective).parse(md)
+    unified().use(remarkParse).use(remarkGfm).use(remarkDirective).parse(md)
       .children as RootContent[]
   )
 
@@ -102,6 +103,13 @@ describe('If', () => {
     }))
     render(<If test='typeof key_a !== "string"' content={makeContent('Yes')} />)
     expect(screen.getByText('Yes')).toBeInTheDocument()
+  })
+
+  it('supports standard markdown formatting', () => {
+    const content = makeMixedContent('**bold** ~~strike~~')
+    render(<If test='true' content={content} />)
+    expect(screen.getByText('bold').tagName).toBe('STRONG')
+    expect(screen.getByText('strike').tagName).toBe('DEL')
   })
 
   it('mixes content and directives', () => {

--- a/apps/campfire/src/If.tsx
+++ b/apps/campfire/src/If.tsx
@@ -2,6 +2,7 @@ import { useMemo, type ReactNode } from 'react'
 import * as runtime from 'react/jsx-runtime'
 import { jsxDEV } from 'react/jsx-dev-runtime'
 import { unified } from 'unified'
+import remarkGfm from 'remark-gfm'
 import remarkCampfire from '@/packages/remark-campfire'
 import remarkRehype from 'remark-rehype'
 import rehypeCampfire from '@/packages/rehype-campfire'
@@ -29,6 +30,7 @@ export const If = ({ test, content, fallback }: IfProps) => {
   const processor = useMemo(
     () =>
       unified()
+        .use(remarkGfm)
         .use(remarkCampfire, { handlers })
         .use(remarkRehype)
         .use(rehypeCampfire)


### PR DESCRIPTION
## Summary
- render standard markdown inside If component using remark-gfm
- test If component markdown rendering

## Testing
- `bun x prettier --write apps/campfire/src/If.tsx apps/campfire/__tests__/If.test.tsx`
- `bun tsc`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_68937b3fc4f483229fe0ad9387ba5157