### PR TITLE
fix(campfire): render If directive tree directly

### DIFF
--- a/apps/campfire/__tests__/If.test.tsx
+++ b/apps/campfire/__tests__/If.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'bun:test'
-import { render, screen } from '@testing-library/react'
+import { render, screen, act, waitFor } from '@testing-library/react'
 import { unified } from 'unified'
 import remarkParse from 'remark-parse'
 import remarkGfm from 'remark-gfm'
@@ -118,5 +118,19 @@ describe('If', () => {
     expect(screen.getByText('Start')).toBeInTheDocument()
     expect(screen.getByText('HP!')).toBeInTheDocument()
     expect(useGameStore.getState().gameData.hp).toBe('2')
+  })
+
+  it('executes trigger directives', async () => {
+    const content = makeMixedContent(
+      ':::trigger{label="Fire"}\n:::set{key=fired value=true}\n:::\n:::'
+    )
+    render(<If test='true' content={content} />)
+    const button = await screen.findByRole('button', { name: 'Fire' })
+    act(() => {
+      button.click()
+    })
+    await waitFor(() => {
+      expect(useGameStore.getState().gameData.fired).toBe('true')
+    })
   })
 })

--- a/apps/campfire/__tests__/Story.test.tsx
+++ b/apps/campfire/__tests__/Story.test.tsx
@@ -103,6 +103,15 @@ is open!
     expect(screen.queryByText('is open!')).toBeNull()
   })
 
+  it.skip('executes trigger directives within if directives', async () => {
+    // TODO: implement test verifying trigger directives within if blocks
+    useStoryDataStore.setState({
+      passages: [samplePassage],
+      currentPassageId: '1'
+    })
+    render(<Story />)
+  })
+
   it('parses if directives after blank lines', async () => {
     document.body.innerHTML = `
 <tw-storydata name="Story" startnode="1">

--- a/apps/campfire/src/If.tsx
+++ b/apps/campfire/src/If.tsx
@@ -27,15 +27,13 @@ interface IfProps {
  */
 export const If = ({ test, content, fallback }: IfProps) => {
   const handlers = useDirectiveHandlers()
-  const processor = useMemo(
-    () =>
-      unified()
-        .use(remarkGfm)
-        .use(remarkCampfire, { handlers })
-        .use(remarkRehype)
-        .use(rehypeCampfire),
-    [handlers]
-  )
+  const processor = useMemo(() => {
+    return unified()
+      .use(remarkGfm)
+      .use(remarkCampfire, { handlers })
+      .use(remarkRehype)
+      .use(rehypeCampfire)
+  }, [handlers])
   const gameData = useGameStore(state => state.gameData)
   let condition = false
   try {

--- a/apps/campfire/src/If.tsx
+++ b/apps/campfire/src/If.tsx
@@ -6,7 +6,7 @@ import remarkGfm from 'remark-gfm'
 import remarkCampfire from '@/packages/remark-campfire'
 import remarkRehype from 'remark-rehype'
 import rehypeCampfire from '@/packages/rehype-campfire'
-import rehypeReact from 'rehype-react'
+import { toJsxRuntime } from 'hast-util-to-jsx-runtime'
 import type { RootContent, Root } from 'mdast'
 import { useGameStore } from '@/packages/use-game-store'
 import { useDirectiveHandlers } from './useDirectiveHandlers'
@@ -33,20 +33,7 @@ export const If = ({ test, content, fallback }: IfProps) => {
         .use(remarkGfm)
         .use(remarkCampfire, { handlers })
         .use(remarkRehype)
-        .use(rehypeCampfire)
-        .use(rehypeReact, {
-          Fragment: runtime.Fragment,
-          jsx: runtime.jsx,
-          jsxs: runtime.jsxs,
-          jsxDEV,
-          development: process.env.NODE_ENV === 'development',
-          components: {
-            button: LinkButton,
-            trigger: TriggerButton,
-            if: If,
-            show: Show
-          }
-        }),
+        .use(rehypeCampfire),
     [handlers]
   )
   const gameData = useGameStore(state => state.gameData)
@@ -68,5 +55,17 @@ export const If = ({ test, content, fallback }: IfProps) => {
   const nodes: RootContent[] = JSON.parse(source)
   const root: Root = { type: 'root', children: nodes }
   const tree = processor.runSync(root)
-  return processor.stringify(tree) as ReactNode
+  return toJsxRuntime(tree, {
+    Fragment: runtime.Fragment,
+    jsx: runtime.jsx,
+    jsxs: runtime.jsxs,
+    jsxDEV,
+    development: process.env.NODE_ENV === 'development',
+    components: {
+      button: LinkButton,
+      trigger: TriggerButton,
+      if: If,
+      show: Show
+    }
+  }) as ReactNode
 }


### PR DESCRIPTION
## Summary
- ensure `If` renders directive components without stringifying the tree
- add test confirming trigger directives run inside `If`
- add skipped Story test for future validation of triggers inside `If`

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68937e0c2eec8322b68cd4b403c818df