### PR TITLE
fix(story): support triggers in if directives

### DIFF
--- a/apps/campfire/__tests__/Story.test.tsx
+++ b/apps/campfire/__tests__/Story.test.tsx
@@ -103,13 +103,30 @@ is open!
     expect(screen.queryByText('is open!')).toBeNull()
   })
 
-  it.skip('executes trigger directives within if directives', async () => {
-    // TODO: implement test verifying trigger directives within if blocks
-    useStoryDataStore.setState({
-      passages: [samplePassage],
-      currentPassageId: '1'
-    })
+  it('renders trigger directives within if directives', async () => {
+    document.body.innerHTML = `
+<tw-storydata name="Story" startnode="1">
+  <tw-passagedata pid="1" name="Start">:::set[boolean]{key=open value=true}
+:::
+
+:::if{open}
+:::trigger{label="open"}
+:::set{key=clicked value=true}
+:::
+:::
+:::
+</tw-passagedata>
+</tw-storydata>
+    `
     render(<Story />)
+    const button = await screen.findByRole('button', { name: 'open' })
+    expect(button).toBeInTheDocument()
+    act(() => {
+      button.click()
+    })
+    await waitFor(() => {
+      expect(useGameStore.getState().gameData.clicked).toBe('true')
+    })
   })
 
   it('parses if directives after blank lines', async () => {

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -680,17 +680,16 @@ export const useDirectiveHandlers = () => {
         }
       }
     }
-    let idx = 1
-    while (
-      idx < children.length &&
-      children[idx].type !== 'containerDirective'
-    ) {
-      idx++
-    }
-    const content = JSON.stringify(stripLabel(children.slice(0, idx)))
-    const next = children[idx] as ContainerDirective | undefined
+    const elseIndex = children.findIndex(
+      child =>
+        child.type === 'containerDirective' &&
+        (child as ContainerDirective).name === 'else'
+    )
+    const main = elseIndex === -1 ? children : children.slice(0, elseIndex)
+    const content = JSON.stringify(stripLabel(main))
     let fallback: string | undefined
-    if (next && next.name === 'else') {
+    if (elseIndex !== -1) {
+      const next = children[elseIndex] as ContainerDirective
       fallback = JSON.stringify(stripLabel(next.children as RootContent[]))
     }
     const node: Parent = {


### PR DESCRIPTION
## Summary
- add regression test for trigger directives nested in if blocks
- allow if directive handler to parse nested directives

## Testing
- `bun test`
- `bun tsc`


------
https://chatgpt.com/codex/tasks/task_e_6893c212885083229008461d1d9ff01a