### PR TITLE
fix: remove stray ::: after lone if directive

### DIFF
--- a/apps/campfire/__tests__/Story.test.tsx
+++ b/apps/campfire/__tests__/Story.test.tsx
@@ -144,4 +144,24 @@ not open
     await waitFor(() => expect(screen.queryByText('not open')).toBeNull())
     expect(screen.queryByText(':::if{!open}')).toBeNull()
   })
+
+  it('does not render ::: when if has no else', async () => {
+    document.body.innerHTML = `
+<tw-storydata name="Story" startnode="1">
+  <tw-passagedata pid="1" name="Start">:::set{key=open value=true}
+:::
+
+:::if{open}
+:::set{key=done value=true}
+:::
+:::
+  </tw-passagedata>
+</tw-storydata>
+    `
+    render(<Story />)
+    await waitFor(() =>
+      expect(useGameStore.getState().gameData.done).toBe('true')
+    )
+    expect(screen.queryByText(':::')).toBeNull()
+  })
 })

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -643,6 +643,14 @@ export const useDirectiveHandlers = () => {
   }
 
   /**
+   * Determines whether the provided node is a Markdown text node.
+   *
+   * @param node - The AST node to check.
+   * @returns Whether the node is an `MdText` node.
+   */
+  const isTextNode = (node: RootContent): node is MdText => node.type === 'text'
+
+  /**
    * Serializes `:::if` directive blocks into `<if>` components that
    * evaluate a test expression against game data and render optional
    * fallback content when the expression is falsy.
@@ -699,8 +707,8 @@ export const useDirectiveHandlers = () => {
         next &&
         next.type === 'paragraph' &&
         next.children.length === 1 &&
-        next.children[0].type === 'text' &&
-        (next.children[0] as MdText).value.trim() === ':::'
+        isTextNode(next.children[0]) &&
+        next.children[0].value.trim() === ':::'
       ) {
         parent.children.splice(index + 1, 1)
       }

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -693,6 +693,18 @@ export const useDirectiveHandlers = () => {
       }
     }
     parent.children.splice(index, 1, node as RootContent)
+    if (elseIndex === -1) {
+      const next = parent.children[index + 1]
+      if (
+        next &&
+        next.type === 'paragraph' &&
+        next.children.length === 1 &&
+        next.children[0].type === 'text' &&
+        (next.children[0] as MdText).value.trim() === ':::'
+      ) {
+        parent.children.splice(index + 1, 1)
+      }
+    }
     return [SKIP, index]
   }
 


### PR DESCRIPTION
## Summary
- avoid leftover `:::` when an `if` block has no accompanying `else`
- add regression test to ensure bare `if` directives render cleanly

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_6893d1ae84ac83229d3b88df2737ca96