### PR TITLE
feat: translate directive uses Show component

### DIFF
--- a/apps/campfire/__tests__/Passage.i18n.test.tsx
+++ b/apps/campfire/__tests__/Passage.i18n.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'bun:test'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, act } from '@testing-library/react'
 import i18next from 'i18next'
 import { initReactI18next } from 'react-i18next'
 import type { Element } from 'hast'
@@ -135,5 +135,31 @@ describe('Passage i18n directives', () => {
     const text = await screen.findByText('Au revoir')
     expect(text).toBeInTheDocument()
     expect(i18next.hasResourceBundle('en-US', 'ui')).toBe(true)
+  })
+
+  it('updates translations when language changes', async () => {
+    i18next.addResource('en-US', 'translation', 'hello', 'Hello')
+    i18next.addResource('fr-FR', 'translation', 'hello', 'Bonjour')
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [{ type: 'text', value: ':t{key=hello}' }]
+    }
+
+    useStoryDataStore.setState({
+      passages: [passage],
+      currentPassageId: '1'
+    })
+
+    render(<Passage />)
+
+    expect(await screen.findByText('Hello')).toBeInTheDocument()
+
+    await act(async () => {
+      await i18next.changeLanguage('fr-FR')
+    })
+
+    expect(await screen.findByText('Bonjour')).toBeInTheDocument()
   })
 })

--- a/apps/campfire/src/Show.tsx
+++ b/apps/campfire/src/Show.tsx
@@ -1,4 +1,6 @@
 import { useGameStore } from '@/packages/use-game-store'
+import { useTranslation } from 'react-i18next'
+import i18next from 'i18next'
 import { isRange } from './directives/helpers'
 
 interface ShowProps {
@@ -6,14 +8,36 @@ interface ShowProps {
   key?: string
   /** Optional key attribute when using data-* */
   'data-key'?: string
+  /** Translation key to display */
+  'data-i18n-key'?: string
+  /** Namespace for the translation key */
+  'data-i18n-ns'?: string
+  /** Pluralization count for the translation */
+  'data-i18n-count'?: number
 }
 
 /**
- * Displays a value from the game store for the provided key.
- * Returns `null` when the referenced value is `null` or `undefined`.
- * Updates automatically when the underlying data changes.
+ * Displays a value from the game store or a translated string for the
+ * provided key. Returns `null` when the referenced value is `null` or
+ * `undefined`. Updates automatically when the underlying data or translations
+ * change.
  */
 export const Show = (props: ShowProps) => {
+  const { t } = useTranslation(
+    typeof props['data-i18n-ns'] === 'string'
+      ? props['data-i18n-ns']
+      : undefined,
+    { i18n: i18next }
+  )
+  const tKey = props['data-i18n-key']
+  if (tKey) {
+    const options: Record<string, unknown> = {}
+    if (typeof props['data-i18n-ns'] === 'string')
+      options.ns = props['data-i18n-ns']
+    if (props['data-i18n-count'] !== undefined)
+      options.count = props['data-i18n-count']
+    return <span>{t(tKey, options)}</span>
+  }
   const storeKey = props['data-key'] ?? props.key
   const value = useGameStore(state => {
     if (!storeKey) return undefined

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -9,7 +9,7 @@ import remarkGfm from 'remark-gfm'
 import remarkDirective from 'remark-directive'
 import remarkCampfire from '@/packages/remark-campfire'
 import type { Text as MdText, Parent, RootContent, Root } from 'mdast'
-import type { Text as HastText, ElementContent } from 'hast'
+import type { Text as HastText, ElementContent, Properties } from 'hast'
 import type { ContainerDirective } from 'mdast-util-directive'
 import rfdc from 'rfdc'
 import deepEqual from 'fast-deep-equal'
@@ -896,37 +896,63 @@ export const useDirectiveHandlers = () => {
     return removeNode(parent, index)
   }
 
+  /**
+   * Inserts a Show component that renders a translation for the provided key.
+   *
+   * @param directive - The `t` directive node being processed.
+   * @param parent - The parent AST node containing the directive.
+   * @param index - The index of the directive within its parent.
+   */
   const handleTranslate: DirectiveHandler = (directive, parent, index) => {
     const attrs = (directive.attributes || {}) as Record<string, unknown>
     const key =
       typeof attrs.key === 'string' ? attrs.key : toString(directive).trim()
     if (!key) return removeNode(parent, index)
-    const options: Record<string, unknown> = {}
-    if (typeof attrs.ns === 'string') options.ns = attrs.ns
-    if (attrs.count !== undefined) {
-      const n =
-        typeof attrs.count === 'number'
-          ? attrs.count
-          : parseFloat(String(attrs.count))
-      if (!Number.isNaN(n)) options.count = n
-    }
-    const text = i18next.t(key, options)
     if (parent && typeof index === 'number') {
-      parent.children.splice(index, 1, { type: 'text', value: text })
-      let idx = index
-      const prev = parent.children[idx - 1] as MdText | undefined
-      if (prev && prev.type === 'text') {
-        prev.value += (parent.children[idx] as MdText).value
-        parent.children.splice(idx, 1)
-        idx--
+      const prev = parent.children[index - 1] as MdText | undefined
+      const next = parent.children[index + 1] as MdText | undefined
+      const inLink =
+        prev?.type === 'text' &&
+        prev.value.endsWith('[[') &&
+        next?.type === 'text' &&
+        next.value.includes(']]')
+      if (inLink) {
+        const options: Record<string, unknown> = {}
+        if (typeof attrs.ns === 'string') options.ns = attrs.ns
+        if (attrs.count !== undefined) {
+          const n =
+            typeof attrs.count === 'number'
+              ? attrs.count
+              : parseFloat(String(attrs.count))
+          if (!Number.isNaN(n)) options.count = n
+        }
+        const text = i18next.t(key, options)
+        if (prev && next) {
+          prev.value += text + next.value
+          parent.children.splice(index, 2)
+          return index - 1
+        }
+        parent.children.splice(index, 1, { type: 'text', value: text })
+        return index
       }
-      const next = parent.children[idx + 1] as MdText | undefined
-      if (next && next.type === 'text') {
-        ;(parent.children[idx] as MdText).value += next.value
-        parent.children.splice(idx + 1, 1)
+      const props: Properties = { 'data-i18n-key': key }
+      if (typeof attrs.ns === 'string') props['data-i18n-ns'] = attrs.ns
+      if (attrs.count !== undefined) {
+        const n =
+          typeof attrs.count === 'number'
+            ? attrs.count
+            : parseFloat(String(attrs.count))
+        if (!Number.isNaN(n)) props['data-i18n-count'] = n
       }
-      return idx
+      const node: MdText = {
+        type: 'text',
+        value: '0',
+        data: { hName: 'show', hProperties: props }
+      }
+      parent.children.splice(index, 1, node)
+      return index
     }
+    return index
   }
 
   const handleGoto: DirectiveHandler = (directive, parent, index) => {


### PR DESCRIPTION
## Summary
- render translation strings through the Show component
- handle translation directives inside links
- verify translations react to language changes

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_6893d95e7b0c8322bc4c2b26ee7ba8fb