### PR TITLE
feat: use id attribute for save/load directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,18 +365,18 @@ Save and restore progress or store data in the browser.
 - `clearSave`: Remove a stored game state.
 
   ```md
-  :clearSave{key=SLOT}
+  :clearSave{id=SLOT}
   ```
 
-  Replace `SLOT` with the storage key.
+  Replace `SLOT` with the storage id.
 
 - `load`: Load state from local storage.
 
   ```md
-  :load{key=SLOT}
+  :load{id=SLOT}
   ```
 
-  Replace `SLOT` with the storage key.
+  Replace `SLOT` with the storage id.
 
 - `restore`: Load a saved state.
 
@@ -389,10 +389,10 @@ Save and restore progress or store data in the browser.
 - `save`: Write the current state to local storage.
 
   ```md
-  :save{key=SLOT}
+  :save{id=SLOT}
   ```
 
-  Replace `SLOT` with the storage key.
+  Replace `SLOT` with the storage id.
 
 ### Localization & internationalization
 

--- a/apps/campfire/__tests__/Passage.checkpoint.test.tsx
+++ b/apps/campfire/__tests__/Passage.checkpoint.test.tsx
@@ -170,7 +170,7 @@ describe('Passage checkpoint directives', () => {
         {
           type: 'text',
           value:
-            ':::set[number]{key=hp value=5}\n:::\n:checkpoint{id=cp1}:save{key=slot1}'
+            ':::set[number]{key=hp value=5}\n:::\n:checkpoint{id=cp1}:save{id=slot1}'
         }
       ]
     }
@@ -210,7 +210,7 @@ describe('Passage checkpoint directives', () => {
       type: 'element',
       tagName: 'tw-passagedata',
       properties: { pid: '1', name: 'Start' },
-      children: [{ type: 'text', value: ':load{key=slot1}' }]
+      children: [{ type: 'text', value: ':load{id=slot1}' }]
     }
     const second: Element = {
       type: 'element',
@@ -250,7 +250,7 @@ describe('Passage checkpoint directives', () => {
       type: 'element',
       tagName: 'tw-passagedata',
       properties: { pid: '1', name: 'Start' },
-      children: [{ type: 'text', value: ':load{key=slot1}' }]
+      children: [{ type: 'text', value: ':load{id=slot1}' }]
     }
 
     useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
@@ -329,7 +329,7 @@ describe('Passage checkpoint directives', () => {
       type: 'element',
       tagName: 'tw-passagedata',
       properties: { pid: '1', name: 'Start' },
-      children: [{ type: 'text', value: ':clearSave{key=slot1}' }]
+      children: [{ type: 'text', value: ':clearSave{id=slot1}' }]
     }
 
     useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -968,9 +968,16 @@ export const useDirectiveHandlers = () => {
     return removeNode(parent, index)
   }
 
+  /**
+   * Saves the current game state to local storage.
+   *
+   * @param directive - The directive node being processed.
+   * @param parent - Parent node containing the directive.
+   * @param index - Index of the directive within the parent.
+   */
   const handleSave: DirectiveHandler = (directive, parent, index) => {
     const attrs = (directive.attributes || {}) as Record<string, unknown>
-    const key = typeof attrs.key === 'string' ? attrs.key : 'campfire.save'
+    const id = typeof attrs.id === 'string' ? attrs.id : 'campfire.save'
     setLoading(true)
     try {
       if (typeof localStorage !== 'undefined') {
@@ -990,7 +997,7 @@ export const useDirectiveHandlers = () => {
           checkpoints: { ...state.checkpoints },
           currentPassageId
         }
-        localStorage.setItem(key, JSON.stringify(data))
+        localStorage.setItem(id, JSON.stringify(data))
       }
     } catch (error) {
       console.error('Error saving game state:', error)
@@ -1001,13 +1008,20 @@ export const useDirectiveHandlers = () => {
     return removeNode(parent, index)
   }
 
+  /**
+   * Loads a game state from local storage.
+   *
+   * @param directive - The directive node being processed.
+   * @param parent - Parent node containing the directive.
+   * @param index - Index of the directive within the parent.
+   */
   const handleLoad: DirectiveHandler = (directive, parent, index) => {
     const attrs = (directive.attributes || {}) as Record<string, unknown>
-    const key = typeof attrs.key === 'string' ? attrs.key : 'campfire.save'
+    const id = typeof attrs.id === 'string' ? attrs.id : 'campfire.save'
     setLoading(true)
     try {
       if (typeof localStorage !== 'undefined') {
-        const raw = localStorage.getItem(key)
+        const raw = localStorage.getItem(id)
         if (raw) {
           const data = JSON.parse(raw) as {
             gameData?: Record<string, unknown>
@@ -1040,13 +1054,20 @@ export const useDirectiveHandlers = () => {
     return removeNode(parent, index)
   }
 
+  /**
+   * Clears a saved game state from local storage.
+   *
+   * @param directive - The directive node being processed.
+   * @param parent - Parent node containing the directive.
+   * @param index - Index of the directive within the parent.
+   */
   const handleClearSave: DirectiveHandler = (directive, parent, index) => {
     const attrs = (directive.attributes || {}) as Record<string, unknown>
-    const key = typeof attrs.key === 'string' ? attrs.key : 'campfire.save'
+    const id = typeof attrs.id === 'string' ? attrs.id : 'campfire.save'
     setLoading(true)
     try {
       if (typeof localStorage !== 'undefined') {
-        localStorage.removeItem(key)
+        localStorage.removeItem(id)
       }
     } catch (error) {
       console.error('Error clearing saved game state:', error)


### PR DESCRIPTION
## Summary
- use `id` attribute for save/load/clearSave directives
- document new directive attribute
- adjust checkpoint tests for `id`

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_6893eb1fc7608322a9b76c21160a6ad9