### PR TITLE
feat: preserve indentation for directives

### DIFF
--- a/apps/campfire/__tests__/Passage.basic.test.tsx
+++ b/apps/campfire/__tests__/Passage.basic.test.tsx
@@ -252,4 +252,34 @@ describe('Passage rendering and navigation', () => {
       ).toBe('true')
     )
   })
+
+  it('processes directives after including empty passages', async () => {
+    const start: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value: ':include[Second]\n:::if{true}\nAfter\n:::'
+        }
+      ]
+    }
+    const second: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '2', name: 'Second' },
+      children: []
+    }
+
+    useStoryDataStore.setState({
+      passages: [start, second],
+      currentPassageId: '1'
+    })
+
+    render(<Passage />)
+
+    const text = await screen.findByText('After')
+    expect(text).toBeInTheDocument()
+  })
 })

--- a/apps/campfire/__tests__/Passage.lifecycle.test.tsx
+++ b/apps/campfire/__tests__/Passage.lifecycle.test.tsx
@@ -51,4 +51,28 @@ describe('Passage lifecycle directives', () => {
       expect(screen.queryByText('Hello')).toBeNull()
     })
   })
+
+  it('handles empty once blocks without skipping following directives', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value: ':::once{intro}\n:::\n:::if{true}\nAfter\n:::'
+        }
+      ]
+    }
+
+    useStoryDataStore.setState({
+      passages: [passage],
+      currentPassageId: '1'
+    })
+
+    render(<Passage />)
+
+    const text = await screen.findByText('After')
+    expect(text).toBeInTheDocument()
+  })
 })

--- a/apps/campfire/src/TriggerButton.tsx
+++ b/apps/campfire/src/TriggerButton.tsx
@@ -1,5 +1,7 @@
 import { unified } from 'unified'
-import remarkCampfire from '@/packages/remark-campfire'
+import remarkCampfire, {
+  remarkCampfireIndentation
+} from '@/packages/remark-campfire'
 import type { RootContent, Root } from 'mdast'
 import rfdc from 'rfdc'
 import { useDirectiveHandlers } from './useDirectiveHandlers'
@@ -13,6 +15,14 @@ interface TriggerButtonProps {
   disabled?: boolean
 }
 
+/**
+ * Button that processes directive content when clicked.
+ *
+ * @param className - Optional CSS classes.
+ * @param content - Serialized directive block.
+ * @param children - Button label.
+ * @param disabled - Disables the button when true.
+ */
 export const TriggerButton = ({
   className,
   content,
@@ -20,9 +30,17 @@ export const TriggerButton = ({
   disabled
 }: TriggerButtonProps) => {
   const handlers = useDirectiveHandlers()
+  /**
+   * Processes a block of AST nodes using the Campfire remark plugins.
+   *
+   * @param nodes - Nodes to process.
+   */
   const runBlock = (nodes: RootContent[]) => {
     const root: Root = { type: 'root', children: nodes }
-    unified().use(remarkCampfire, { handlers }).runSync(root)
+    unified()
+      .use(remarkCampfireIndentation)
+      .use(remarkCampfire, { handlers })
+      .runSync(root)
   }
   const classes = Array.isArray(className)
     ? className

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -762,7 +762,7 @@ export const useDirectiveHandlers = () => {
     markOnce(key)
     const content = stripLabel(container.children as RootContent[])
     const newIndex = replaceWithIndentation(directive, parent, index, content)
-    return [SKIP, newIndex + content.length - 1]
+    return [SKIP, newIndex + Math.max(0, content.length - 1)]
   }
   const handleBatch: DirectiveHandler = (directive, parent, index) => {
     if (!parent || typeof index !== 'number') return
@@ -1258,7 +1258,10 @@ export const useDirectiveHandlers = () => {
       index,
       tree.children as RootContent[]
     )
-    return [SKIP, newIndex + (tree.children as RootContent[]).length - 1]
+    return [
+      SKIP,
+      newIndex + Math.max(0, (tree.children as RootContent[]).length - 1)
+    ]
   }
 
   return useMemo(() => {

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -81,31 +81,6 @@ export const useDirectiveHandlers = () => {
   let includeDepth = 0
 
   /**
-   * Captures and removes indentation preceding a directive.
-   *
-   * @param directive - Directive node being processed.
-   * @param parent - Parent node of the directive.
-   * @param index - Index of the directive within its parent.
-   */
-  const preserveIndentation = (
-    directive: DirectiveNode,
-    parent: Parent | undefined,
-    index: number | undefined
-  ): void => {
-    if (!parent || typeof index !== 'number') return
-    const previous = parent.children[index - 1]
-    if (previous && previous.type === 'text') {
-      const textNode = previous as MdText
-      const match = textNode.value.match(/(\s+)$/)
-      if (match && match[1]) {
-        if (!directive.data) directive.data = {}
-        ;(directive.data as Record<string, unknown>).indentation = match[1]
-        textNode.value = textNode.value.slice(0, -match[1].length)
-      }
-    }
-  }
-
-  /**
    * Replaces a directive with new nodes while restoring preserved indentation.
    *
    * @param directive - Directive being replaced.
@@ -128,19 +103,6 @@ export const useDirectiveHandlers = () => {
     parent.children.splice(index, 1, ...insert)
     return index + (indent ? 1 : 0)
   }
-
-  /**
-   * Wraps a directive handler to preserve indentation before executing it.
-   *
-   * @param handler - Directive handler to wrap.
-   * @returns The wrapped handler.
-   */
-  const withIndentation =
-    (handler: DirectiveHandler): DirectiveHandler =>
-    (directive, parent, index) => {
-      preserveIndentation(directive, parent, index)
-      return handler(directive, parent, index)
-    }
 
   /**
    * Processes a block of AST nodes using the unified processor with the remarkCampfire plugin.
@@ -1345,10 +1307,7 @@ export const useDirectiveHandlers = () => {
       translations: handleTranslations,
       t: handleTranslate
     }
-    const wrapped = Object.fromEntries(
-      Object.entries(handlers).map(([k, h]) => [k, withIndentation(h)])
-    ) as Record<string, DirectiveHandler>
-    handlersRef.current = wrapped
-    return wrapped
+    handlersRef.current = handlers
+    return handlers
   }, [])
 }

--- a/packages/remark-campfire/__tests__/indentation.test.ts
+++ b/packages/remark-campfire/__tests__/indentation.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'bun:test'
+import { unified } from 'unified'
+import remarkParse from 'remark-parse'
+import remarkDirective from 'remark-directive'
+import remarkStringify from 'remark-stringify'
+import remarkCampfire, {
+  remarkCampfireIndentation,
+  type DirectiveHandler
+} from '../index'
+
+/**
+ * Replaces the directive with an "X" while preserving indentation.
+ *
+ * @param directive - Directive node being processed.
+ * @param parent - Parent node containing the directive.
+ * @param index - Index of the directive within its parent.
+ */
+const testHandler: DirectiveHandler = (directive, parent, index) => {
+  if (!parent || typeof index !== 'number') return
+  const indent =
+    (directive.data as { indentation?: string } | undefined)?.indentation || ''
+  parent.children.splice(index, 1, { type: 'text', value: `${indent}X` })
+}
+
+/**
+ * Processes markdown using remarkCampfire and the test handler.
+ *
+ * @param md - Markdown string to process.
+ * @returns The processed markdown as a string.
+ */
+const processMarkdown = (md: string) => {
+  const processor = unified()
+    .use(remarkParse)
+    .use(remarkDirective)
+    .use(remarkCampfireIndentation)
+    .use(remarkCampfire, { handlers: { test: testHandler } })
+    .use(remarkStringify)
+  return processor.processSync(md).toString()
+}
+
+describe('remarkCampfire indentation', () => {
+  it('preserves indentation inside list items', () => {
+    const md = `- item\n  :test\n  after`
+    const out = processMarkdown(md).trim()
+    expect(out).toBe('* item\n  X\n  after')
+  })
+
+  it('preserves indentation inside blockquotes', () => {
+    const md = `> quote\n> :test\n> after`
+    const out = processMarkdown(md).trim()
+    expect(out).toBe('> quote\n> X\n> after')
+  })
+})


### PR DESCRIPTION
## Summary
- preserve indentation in directive handlers
- attach preceding whitespace to directive nodes via remark plugin
- test indentation preservation in lists and blockquotes

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_6893f896069c8322bbba3b24265120ef