### PR TITLE
docs: clarify set directive usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,19 @@ They come in leaf or container form.
 
 Directives are grouped by purpose.
 
+### Indentation
+
+Directives preserve leading spaces, so they can appear inside other Markdown
+structures. Indent them just like normal text:
+
+```md
+- Step one
+  :set{key=visited value=true}
+
+> Quoted
+> :goto{passage=NEXT}
+```
+
 ### Variables & simple state
 
 Operations that set, update or remove scalar values.
@@ -105,20 +118,20 @@ Operations that set, update or remove scalar values.
   Replace `HP` with the key, `MIN`/`MAX` with bounds and `VALUE` with the
   starting number (defaults to `MIN`).
 
-- `set`: Assign a value to a key.
+- `set`: Assign a value to a key. This directive is leaf-only and cannot wrap
+  content.
 
   ```md
-  :::set{key=HP value=VALUE}
-  :::
+  :set{key=HP value=VALUE}
   ```
 
   Replace `VALUE` with the number or string to store.
 
-- `setOnce`: Set a key only if it has not been set.
+- `setOnce`: Set a key only if it has not been set. This directive is leaf-only
+  and cannot wrap content.
 
   ```md
-  :::setOnce{key=visited value=true}
-  :::
+  :setOnce{key=visited value=true}
   ```
 
   Replace `visited` with the key to lock on first use.

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -132,8 +132,8 @@ export const useDirectiveHandlers = () => {
   }, [currentPassageId])
 
   /**
-   * Handles the `set` and `setOnce` directives by assigning a value to a key in
-   * game data. Supports optional typing via the directive label and range
+   * Handles the leaf `set` and `setOnce` directives by assigning a value to a key
+   * in game data. Supports optional typing via the directive label and range
    * initialization.
    *
    * @param directive - The directive node being processed.


### PR DESCRIPTION
## Summary
- document that `set` and `setOnce` must be used as leaf directives
- add examples of directive indentation inside lists and blockquotes

## Testing
- `bun x prettier --write README.md apps/campfire/src/useDirectiveHandlers.ts`
- `bun tsc`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_689407d1d1a883229b691935df92d1c5