### PR TITLE
feat: require quotes for string values in set directive

### DIFF
--- a/apps/campfire/__tests__/If.test.tsx
+++ b/apps/campfire/__tests__/If.test.tsx
@@ -117,7 +117,7 @@ describe('If', () => {
     render(<If test='true' content={content} />)
     expect(screen.getByText('Start')).toBeInTheDocument()
     expect(screen.getByText('HP!')).toBeInTheDocument()
-    expect(useGameStore.getState().gameData.hp).toBe('2')
+    expect(useGameStore.getState().gameData.hp).toBe(2)
   })
 
   it('executes trigger directives', async () => {
@@ -130,7 +130,7 @@ describe('If', () => {
       button.click()
     })
     await waitFor(() => {
-      expect(useGameStore.getState().gameData.fired).toBe('true')
+      expect(useGameStore.getState().gameData.fired).toBe(true)
     })
   })
 })

--- a/apps/campfire/__tests__/Passage.basic.test.tsx
+++ b/apps/campfire/__tests__/Passage.basic.test.tsx
@@ -249,7 +249,7 @@ describe('Passage rendering and navigation', () => {
     await waitFor(() =>
       expect(
         (useGameStore.getState().gameData as Record<string, unknown>).visited
-      ).toBe('true')
+      ).toBe(true)
     )
   })
 

--- a/apps/campfire/__tests__/Passage.state.test.tsx
+++ b/apps/campfire/__tests__/Passage.state.test.tsx
@@ -42,6 +42,53 @@ describe('Passage game state directives', () => {
     )
   })
 
+  it('sets string values only when quoted', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value: ':::set{key=item value="\'sword\'"}\n:::'
+        }
+      ]
+    }
+
+    useStoryDataStore.setState({
+      passages: [passage],
+      currentPassageId: '1'
+    })
+
+    render(<Passage />)
+
+    await waitFor(() =>
+      expect(
+        (useGameStore.getState().gameData as Record<string, unknown>).item
+      ).toBe('sword')
+    )
+  })
+
+  it('ignores unquoted string values', () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [{ type: 'text', value: ':::set{key=item value=sword}\n:::' }]
+    }
+
+    useStoryDataStore.setState({
+      passages: [passage],
+      currentPassageId: '1'
+    })
+
+    render(<Passage />)
+
+    expect(
+      (useGameStore.getState().gameData as Record<string, unknown>).item
+    ).toBeUndefined()
+  })
+
   it('removes paragraphs left empty by directives', async () => {
     const passage: Element = {
       type: 'element',

--- a/apps/campfire/__tests__/Passage.trigger.test.tsx
+++ b/apps/campfire/__tests__/Passage.trigger.test.tsx
@@ -42,7 +42,7 @@ describe('Passage trigger directives', () => {
       button.click()
     })
     await waitFor(() => {
-      expect(useGameStore.getState().gameData.fired).toBe('true')
+      expect(useGameStore.getState().gameData.fired).toBe(true)
     })
   })
 
@@ -92,7 +92,7 @@ describe('Passage trigger directives', () => {
       button.click()
     })
     await waitFor(() => {
-      expect(useGameStore.getState().gameData.go).toBe('true')
+      expect(useGameStore.getState().gameData.go).toBe(true)
     })
   })
 })

--- a/apps/campfire/__tests__/Story.test.tsx
+++ b/apps/campfire/__tests__/Story.test.tsx
@@ -125,7 +125,7 @@ is open!
       button.click()
     })
     await waitFor(() => {
-      expect(useGameStore.getState().gameData.clicked).toBe('true')
+      expect(useGameStore.getState().gameData.clicked).toBe(true)
     })
   })
 
@@ -160,7 +160,7 @@ not open
     `
     render(<Story />)
     await waitFor(() =>
-      expect(useGameStore.getState().gameData.done).toBe('true')
+      expect(useGameStore.getState().gameData.done).toBe(true)
     )
     expect(screen.queryByText(':::')).toBeNull()
   })


### PR DESCRIPTION
## Summary
- enforce quoting for string values in the `set` directive
- add tests covering quoted and unquoted string handling
- update existing tests to reflect expression evaluation of unquoted values

## Testing
- `bun tsc --noEmit`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_6894c4cd0af4832298509dfcf93de1dd