### PR TITLE
fix: enforce quoting for navigation directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ structures. Indent them just like normal text:
   :set{key=visited value=true}
 
 > Quoted
-> :goto{passage=NEXT}
+> :goto["NEXT"]
 ```
 
 ### Variables & simple state
@@ -362,27 +362,30 @@ Control the flow between passages or how they appear.
 - `goto`: Jump to another passage.
 
   ```md
-  :goto{passage=PASSAGE-NAME}
+  :goto["PASSAGE-NAME"]
   ```
 
-  Replace `PASSAGE-NAME` with the target passage.
+  Use quotes or backticks for passage names. Unquoted numbers navigate by pid.
+  When using the `passage` attribute, unquoted strings are treated as keys in the
+  game state.
 
 - `include`: Embed another passage's content.
 
   ```md
-  :include{passage=PASSAGE-NAME}
+  :include["PASSAGE-NAME"]
   ```
 
-  Replace `PASSAGE-NAME` with the passage to include. Nested includes are
-  limited to 10 levels to prevent infinite loops.
+  Use quotes or backticks for passage names. Unquoted numbers include by pid.
+  When using the `passage` attribute, unquoted strings are treated as keys in the
+  game state. Nested includes are limited to 10 levels to prevent infinite loops.
 
 - `title`: Set the document title.
 
   ```md
-  :title{value=GAME-TITLE}
+  :title["GAME-TITLE"]
   ```
 
-  Replace `GAME-TITLE` with the text to display.
+  Replace `GAME-TITLE` with the text to display, wrapped in matching quotes or backticks.
 
 ### Checkpoints & persistence
 

--- a/apps/campfire/__tests__/Passage.basic.test.tsx
+++ b/apps/campfire/__tests__/Passage.basic.test.tsx
@@ -84,7 +84,7 @@ describe('Passage rendering and navigation', () => {
       type: 'element',
       tagName: 'tw-passagedata',
       properties: { pid: '1', name: 'Start' },
-      children: [{ type: 'text', value: ':title[Custom]' }]
+      children: [{ type: 'text', value: ':title["Custom"]' }]
     }
 
     useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
@@ -100,13 +100,13 @@ describe('Passage rendering and navigation', () => {
       type: 'element',
       tagName: 'tw-passagedata',
       properties: { pid: '1', name: 'Start' },
-      children: [{ type: 'text', value: ':include[Second]' }]
+      children: [{ type: 'text', value: ':include["Second"]' }]
     }
     const second: Element = {
       type: 'element',
       tagName: 'tw-passagedata',
       properties: { pid: '2', name: 'Second' },
-      children: [{ type: 'text', value: ':title[Other]' }]
+      children: [{ type: 'text', value: ':title["Other"]' }]
     }
 
     useStoryDataStore.setState({
@@ -151,7 +151,7 @@ describe('Passage rendering and navigation', () => {
       type: 'element',
       tagName: 'tw-passagedata',
       properties: { pid: '1', name: 'Start' },
-      children: [{ type: 'text', value: ':goto[Second]' }]
+      children: [{ type: 'text', value: ':goto["Second"]' }]
     }
     const second: Element = {
       type: 'element',
@@ -200,12 +200,40 @@ describe('Passage rendering and navigation', () => {
     })
   })
 
+  it('navigates to a passage using a state key with goto directive', async () => {
+    const start: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [{ type: 'text', value: ':goto{passage=next}' }]
+    }
+    const second: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '2', name: 'Second' },
+      children: [{ type: 'text', value: 'Second text' }]
+    }
+
+    useGameStore.setState({ gameData: { next: 'Second' } })
+    useStoryDataStore.setState({
+      passages: [start, second],
+      currentPassageId: '1'
+    })
+
+    render(<Passage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Second text')).toBeInTheDocument()
+      expect(useStoryDataStore.getState().currentPassageId).toBe('Second')
+    })
+  })
+
   it('renders included passage content', async () => {
     const start: Element = {
       type: 'element',
       tagName: 'tw-passagedata',
       properties: { pid: '1', name: 'Start' },
-      children: [{ type: 'text', value: ':include[Second]' }]
+      children: [{ type: 'text', value: ':include["Second"]' }]
     }
     const second: Element = {
       type: 'element',
@@ -225,12 +253,38 @@ describe('Passage rendering and navigation', () => {
     expect(text).toBeInTheDocument()
   })
 
+  it('includes a passage using a state key with include directive', async () => {
+    const start: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [{ type: 'text', value: ':include{passage=part}' }]
+    }
+    const second: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '2', name: 'Second' },
+      children: [{ type: 'text', value: 'Inner text' }]
+    }
+
+    useGameStore.setState({ gameData: { part: 'Second' } })
+    useStoryDataStore.setState({
+      passages: [start, second],
+      currentPassageId: '1'
+    })
+
+    render(<Passage />)
+
+    const text = await screen.findByText('Inner text')
+    expect(text).toBeInTheDocument()
+  })
+
   it('evaluates directives within included passages', async () => {
     const start: Element = {
       type: 'element',
       tagName: 'tw-passagedata',
       properties: { pid: '1', name: 'Start' },
-      children: [{ type: 'text', value: ':include[Second]' }]
+      children: [{ type: 'text', value: ':include["Second"]' }]
     }
     const second: Element = {
       type: 'element',
@@ -261,7 +315,7 @@ describe('Passage rendering and navigation', () => {
       children: [
         {
           type: 'text',
-          value: ':include[Second]\n:::if{true}\nAfter\n:::'
+          value: ':include["Second"]\n:::if{true}\nAfter\n:::'
         }
       ]
     }

--- a/apps/campfire/__tests__/Passage.basic.test.tsx
+++ b/apps/campfire/__tests__/Passage.basic.test.tsx
@@ -95,6 +95,34 @@ describe('Passage rendering and navigation', () => {
     })
   })
 
+  it('logs error when title directive is not quoted', async () => {
+    const logged: unknown[] = []
+    const orig = console.error
+    console.error = (...args: unknown[]) => {
+      logged.push(args)
+    }
+
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [{ type: 'text', value: ':title[Custom]' }]
+    }
+
+    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+    render(<Passage />)
+
+    await waitFor(() => {
+      expect(logged).toHaveLength(1)
+      expect(useGameStore.getState().errors).toEqual([
+        'Title directive value must be wrapped in matching quotes or backticks'
+      ])
+      expect(document.title).toBe('Start')
+    })
+
+    console.error = orig
+  })
+
   it('ignores title directive in included passages', async () => {
     const start: Element = {
       type: 'element',

--- a/apps/campfire/__tests__/Passage.checkpoint.test.tsx
+++ b/apps/campfire/__tests__/Passage.checkpoint.test.tsx
@@ -95,7 +95,7 @@ describe('Passage checkpoint directives', () => {
         {
           type: 'text',
           value:
-            ':::set[number]{key=hp value=2}\n:::\n:checkpoint{id=cp1}:include[Second]'
+            ':::set[number]{key=hp value=2}\n:::\n:checkpoint{id=cp1}:include["Second"]'
         }
       ]
     }

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -1046,6 +1046,31 @@ export const useDirectiveHandlers = () => {
   }
 
   /**
+   * Resolves a passage target from directive text or attributes.
+   *
+   * @param rawText - The trimmed text content of the directive.
+   * @param attrs - Attributes associated with the directive.
+   * @returns The passage id or name if recognized, otherwise undefined.
+   */
+  const resolvePassageTarget = (
+    rawText: string,
+    attrs: Record<string, unknown>
+  ): string | undefined => {
+    if (rawText) {
+      return (
+        getQuotedValue(rawText) ??
+        (NUMERIC_PATTERN.test(rawText) ? rawText : undefined)
+      )
+    }
+    const attr =
+      typeof attrs.passage === 'string' ? attrs.passage.trim() : undefined
+    return attr
+      ? (getQuotedValue(attr) ??
+          (NUMERIC_PATTERN.test(attr) ? attr : getStateValue(attr)))
+      : undefined
+  }
+
+  /**
    * Handles the `:goto` directive, which navigates to another passage.
    * Passage names must be wrapped in matching quotes or backticks, while
    * unquoted numbers are treated as passage IDs. When the `passage` attribute
@@ -1060,18 +1085,7 @@ export const useDirectiveHandlers = () => {
   const handleGoto: DirectiveHandler = (directive, parent, index) => {
     const attrs = (directive.attributes || {}) as Record<string, unknown>
     const rawText = toString(directive).trim()
-    let target: string | undefined
-
-    if (rawText) {
-      target =
-        getQuotedValue(rawText) ??
-        (NUMERIC_PATTERN.test(rawText) ? rawText : undefined)
-    } else if (typeof attrs.passage === 'string') {
-      const rawAttr = attrs.passage.trim()
-      target =
-        getQuotedValue(rawAttr) ??
-        (NUMERIC_PATTERN.test(rawAttr) ? rawAttr : getStateValue(rawAttr))
-    }
+    const target = resolvePassageTarget(rawText, attrs)
 
     const passage = target
       ? NUMERIC_PATTERN.test(target)
@@ -1311,18 +1325,7 @@ export const useDirectiveHandlers = () => {
   const handleInclude: DirectiveHandler = (directive, parent, index) => {
     const attrs = (directive.attributes || {}) as Record<string, unknown>
     const rawText = toString(directive).trim()
-    let target: string | undefined
-
-    if (rawText) {
-      target =
-        getQuotedValue(rawText) ??
-        (NUMERIC_PATTERN.test(rawText) ? rawText : undefined)
-    } else if (typeof attrs.passage === 'string') {
-      const rawAttr = attrs.passage.trim()
-      target =
-        getQuotedValue(rawAttr) ??
-        (NUMERIC_PATTERN.test(rawAttr) ? rawAttr : getStateValue(rawAttr))
-    }
+    const target = resolvePassageTarget(rawText, attrs)
 
     if (!parent || typeof index !== 'number' || !target) {
       return removeNode(parent, index)

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -38,6 +38,8 @@ import type {
 } from '@/packages/remark-campfire'
 
 const clone = rfdc()
+const QUOTE_PATTERN = /^(['"`])(.*)\1$/
+const NUMERIC_PATTERN = /^\d+$/
 
 export const useDirectiveHandlers = () => {
   const storeGameData = useGameStore(state => state.gameData)
@@ -1025,7 +1027,7 @@ export const useDirectiveHandlers = () => {
    * @returns The inner string if quoted, otherwise undefined.
    */
   const getQuotedValue = (value: string): string | undefined => {
-    const match = value.trim().match(/^(["'`])(.*)\1$/)
+    const match = value.trim().match(QUOTE_PATTERN)
     return match ? match[2] : undefined
   }
 
@@ -1036,6 +1038,7 @@ export const useDirectiveHandlers = () => {
    * @returns The value as a string if present, otherwise undefined.
    */
   const getStateValue = (key: string): string | undefined => {
+    if (!Object.prototype.hasOwnProperty.call(gameData, key)) return undefined
     const value = (gameData as Record<string, unknown>)[key]
     return typeof value === 'string' || typeof value === 'number'
       ? String(value)
@@ -1061,16 +1064,17 @@ export const useDirectiveHandlers = () => {
 
     if (rawText) {
       target =
-        getQuotedValue(rawText) ?? (/^\d+$/.test(rawText) ? rawText : undefined)
+        getQuotedValue(rawText) ??
+        (NUMERIC_PATTERN.test(rawText) ? rawText : undefined)
     } else if (typeof attrs.passage === 'string') {
       const rawAttr = attrs.passage.trim()
       target =
         getQuotedValue(rawAttr) ??
-        (/^\d+$/.test(rawAttr) ? rawAttr : getStateValue(rawAttr))
+        (NUMERIC_PATTERN.test(rawAttr) ? rawAttr : getStateValue(rawAttr))
     }
 
     const passage = target
-      ? /^\d+$/.test(target)
+      ? NUMERIC_PATTERN.test(target)
         ? getPassageById(target)
         : getPassageByName(target)
       : null
@@ -1311,12 +1315,13 @@ export const useDirectiveHandlers = () => {
 
     if (rawText) {
       target =
-        getQuotedValue(rawText) ?? (/^\d+$/.test(rawText) ? rawText : undefined)
+        getQuotedValue(rawText) ??
+        (NUMERIC_PATTERN.test(rawText) ? rawText : undefined)
     } else if (typeof attrs.passage === 'string') {
       const rawAttr = attrs.passage.trim()
       target =
         getQuotedValue(rawAttr) ??
-        (/^\d+$/.test(rawAttr) ? rawAttr : getStateValue(rawAttr))
+        (NUMERIC_PATTERN.test(rawAttr) ? rawAttr : getStateValue(rawAttr))
     }
 
     if (!parent || typeof index !== 'number' || !target) {
@@ -1328,7 +1333,7 @@ export const useDirectiveHandlers = () => {
       return removeNode(parent, index)
     }
 
-    const passage = /^\d+$/.test(target)
+    const passage = NUMERIC_PATTERN.test(target)
       ? getPassageById(target)
       : getPassageByName(target)
 

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -1038,7 +1038,7 @@ export const useDirectiveHandlers = () => {
    * @returns The value as a string if present, otherwise undefined.
    */
   const getStateValue = (key: string): string | undefined => {
-    if (!Object.prototype.hasOwnProperty.call(gameData, key)) return undefined
+    if (!Object.hasOwn(gameData, key)) return undefined
     const value = (gameData as Record<string, unknown>)[key]
     return typeof value === 'string' || typeof value === 'number'
       ? String(value)
@@ -1301,10 +1301,16 @@ export const useDirectiveHandlers = () => {
    */
   const handleTitle: DirectiveHandler = (directive, parent, index) => {
     if (includeDepth > 0) return removeNode(parent, index)
-    const title = getQuotedValue(toString(directive).trim())
+    const raw = toString(directive).trim()
+    const title = getQuotedValue(raw)
     if (title) {
       document.title = i18next.t(title)
       markTitleOverridden()
+    } else if (raw) {
+      const msg =
+        'Title directive value must be wrapped in matching quotes or backticks'
+      console.error(msg)
+      addError(msg)
     }
     return removeNode(parent, index)
   }


### PR DESCRIPTION
## Summary
- require quotes or backticks for title directive values
- interpret quoted passages as names and unquoted numbers as pids for goto/include
- treat unquoted `passage` attributes as game state keys
- document new quoting rules

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_6895257d11a88322a8b3c5b7aeabe052