### PR TITLE
feat: unify directive attribute extraction

### DIFF
--- a/apps/campfire/src/directives/helpers.ts
+++ b/apps/campfire/src/directives/helpers.ts
@@ -10,6 +10,11 @@ export {
   stripLabel,
   removeNode,
   ensureKey,
+  extractAttributes,
   type RangeValue,
-  type DirectiveNode
+  type DirectiveNode,
+  type AttributeSpec,
+  type AttributeSchema,
+  type ExtractedAttrs,
+  type ExtractResult
 } from '@/packages/remark-campfire/helpers'

--- a/packages/remark-campfire/__tests__/extractAttributes.test.ts
+++ b/packages/remark-campfire/__tests__/extractAttributes.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'bun:test'
+import type { Parent } from 'mdast'
+import type { ContainerDirective } from 'mdast-util-directive'
+import { extractAttributes, type DirectiveNode } from '../helpers'
+
+/**
+ * Creates a directive node with the given attributes for testing.
+ *
+ * @param attrs - Attribute map to assign to the directive.
+ * @returns A directive node populated with the attributes.
+ */
+const createDirective = (attrs: Record<string, unknown> = {}): DirectiveNode =>
+  ({
+    type: 'leafDirective',
+    name: 'test',
+    attributes: attrs as Record<string, unknown>
+  }) as DirectiveNode
+
+describe('extractAttributes', () => {
+  it('parses and evaluates attributes according to schema', () => {
+    const directive = createDirective({
+      key: 'item1',
+      count: 'a + b',
+      flag: 'false',
+      list: '1,2,3',
+      obj: '{"x":1}'
+    })
+    const schema = {
+      key: { type: 'string', required: true },
+      count: { type: 'number' },
+      flag: { type: 'boolean', default: true },
+      list: { type: 'array' },
+      obj: { type: 'object' }
+    } as const
+    const result = extractAttributes(directive, undefined, undefined, schema, {
+      state: { a: 2, b: 3 },
+      keyAttr: 'key'
+    })
+    expect(result.valid).toBe(true)
+    expect(result.key).toBe('item1')
+    expect(result.attrs as Record<string, unknown>).toEqual({
+      count: 5,
+      flag: false,
+      list: ['1', '2', '3'],
+      obj: { x: 1 }
+    })
+  })
+
+  it('reports missing required key and removes directive', () => {
+    const directive = createDirective()
+    const parent: Parent = { type: 'root', children: [directive] }
+    const schema = { key: { type: 'string', required: true } } as const
+    const result = extractAttributes(directive, parent, 0, schema, {
+      keyAttr: 'key'
+    })
+    expect(result.valid).toBe(false)
+    expect(parent.children).toHaveLength(0)
+    expect(result.errors[0]).toContain('missing required key attribute')
+  })
+
+  it('extracts label text when requested', () => {
+    const directive: ContainerDirective = {
+      type: 'containerDirective',
+      name: 'test',
+      attributes: { key: 'id' },
+      children: [
+        {
+          type: 'paragraph',
+          data: { directiveLabel: true },
+          children: [{ type: 'text', value: 'Label text' }]
+        }
+      ]
+    }
+    const schema = { key: { type: 'string' } } as const
+    const result = extractAttributes(directive, undefined, undefined, schema, {
+      keyAttr: 'key',
+      label: true
+    })
+    expect(result.label).toBe('Label text')
+  })
+})

--- a/packages/remark-campfire/helpers.ts
+++ b/packages/remark-campfire/helpers.ts
@@ -1,4 +1,5 @@
 import { toString } from 'mdast-util-to-string'
+import { compile } from 'expression-eval'
 import type { Parent, Paragraph, RootContent } from 'mdast'
 import type {
   ContainerDirective,
@@ -213,4 +214,185 @@ export const ensureKey = (
   if (typeof raw === 'string') return raw
   removeNode(parent, index)
   return undefined
+}
+
+const QUOTE_PATTERN = /^(['"`])(.*)\1$/
+
+export interface AttributeSpec<T = unknown> {
+  type: 'string' | 'number' | 'boolean' | 'object' | 'array'
+  required?: boolean
+  default?: T
+  expression?: boolean
+}
+
+export type AttributeSchema = Record<string, AttributeSpec<any>>
+
+type TypeFromSpec<S extends AttributeSpec<any>> = S['type'] extends 'string'
+  ? string
+  : S['type'] extends 'number'
+    ? number
+    : S['type'] extends 'boolean'
+      ? boolean
+      : S['type'] extends 'object'
+        ? Record<string, unknown>
+        : S['type'] extends 'array'
+          ? unknown[]
+          : unknown
+
+export type ExtractedAttrs<S extends AttributeSchema> = {
+  [K in keyof S as S[K]['required'] extends true ? K : never]: TypeFromSpec<
+    S[K]
+  >
+} & {
+  [K in keyof S as S[K]['required'] extends true ? never : K]?: TypeFromSpec<
+    S[K]
+  >
+}
+
+interface ExtractOptions<S extends AttributeSchema> {
+  state?: Record<string, unknown>
+  keyAttr?: keyof S
+  label?: boolean
+}
+
+export interface ExtractResult<S extends AttributeSchema> {
+  attrs: ExtractedAttrs<S>
+  key?: string
+  label?: string
+  valid: boolean
+  errors: string[]
+}
+
+export const extractAttributes = <S extends AttributeSchema>(
+  directive: DirectiveNode,
+  parent: Parent | undefined,
+  index: number | undefined,
+  schema: S,
+  options: ExtractOptions<S> = {}
+): ExtractResult<S> => {
+  const attrs = (directive.attributes || {}) as Record<string, unknown>
+  const { state = {}, keyAttr, label: includeLabel } = options
+  const processed: Record<string, unknown> = {}
+  const errors: string[] = []
+  let key: string | undefined
+
+  const evalExpr = (expr: string): unknown => {
+    try {
+      const fn = compile(expr)
+      return fn(state as any)
+    } catch {
+      return undefined
+    }
+  }
+
+  const parse = (raw: unknown, spec: AttributeSpec): unknown => {
+    if (raw == null) return undefined
+    switch (spec.type) {
+      case 'string': {
+        if (typeof raw === 'string') {
+          const m = raw.match(QUOTE_PATTERN)
+          if (m) return m[2]
+          if (spec.expression === false) return raw
+          const evaluated = evalExpr(raw)
+          if (typeof evaluated === 'string') return evaluated
+          return evaluated != null ? String(evaluated) : raw
+        }
+        return String(raw)
+      }
+      case 'number': {
+        if (typeof raw === 'number') return raw
+        const expr = typeof raw === 'string' ? raw : String(raw)
+        const evaluated = spec.expression === false ? expr : evalExpr(expr)
+        const num =
+          typeof evaluated === 'number'
+            ? evaluated
+            : parseFloat(String(evaluated))
+        return Number.isNaN(num) ? undefined : num
+      }
+      case 'boolean': {
+        if (typeof raw === 'boolean') return raw
+        if (typeof raw === 'string') {
+          if (spec.expression === false) return raw === 'true'
+          const evaluated = evalExpr(raw)
+          return typeof evaluated === 'boolean' ? evaluated : raw === 'true'
+        }
+        return undefined
+      }
+      case 'object': {
+        if (raw && typeof raw === 'object' && !Array.isArray(raw)) return raw
+        if (typeof raw === 'string') {
+          const evaluated =
+            spec.expression === false ? undefined : evalExpr(raw)
+          if (
+            evaluated &&
+            typeof evaluated === 'object' &&
+            !Array.isArray(evaluated)
+          )
+            return evaluated
+          try {
+            const parsed = JSON.parse(raw)
+            return typeof parsed === 'object' && !Array.isArray(parsed)
+              ? parsed
+              : undefined
+          } catch {
+            return undefined
+          }
+        }
+        return undefined
+      }
+      case 'array': {
+        if (Array.isArray(raw)) return raw
+        if (typeof raw === 'string') {
+          const evaluated =
+            spec.expression === false ? undefined : evalExpr(raw)
+          if (Array.isArray(evaluated)) return evaluated
+          try {
+            const parsed = JSON.parse(raw)
+            if (Array.isArray(parsed)) return parsed
+          } catch {
+            return raw
+              .split(',')
+              .map(s => s.trim())
+              .filter(Boolean)
+          }
+        }
+        return undefined
+      }
+      default:
+        return raw
+    }
+  }
+
+  for (const [name, spec] of Object.entries(schema) as [
+    keyof S,
+    AttributeSpec
+  ][]) {
+    const raw = attrs[name as string]
+    let value = parse(raw, spec)
+    if (typeof value === 'undefined' && typeof spec.default !== 'undefined') {
+      value = spec.default
+    }
+    if (name === keyAttr) {
+      key = ensureKey(value, parent, index)
+      if (!key) errors.push(`Missing required attribute: ${String(name)}`)
+    } else if (typeof value === 'undefined') {
+      if (spec.required)
+        errors.push(`Missing required attribute: ${String(name)}`)
+    } else {
+      processed[name as string] = value
+    }
+  }
+
+  let label: string | undefined
+  if (includeLabel && 'children' in directive) {
+    label = getLabel(directive as ContainerDirective)
+  }
+
+  return {
+    attrs: processed as ExtractedAttrs<S>,
+    key,
+    label,
+    valid: errors.length === 0,
+    errors
+  }
 }

--- a/packages/remark-campfire/helpers.ts
+++ b/packages/remark-campfire/helpers.ts
@@ -286,15 +286,28 @@ export const extractAttributes = <S extends AttributeSchema>(
   const errors: string[] = []
   let key: string | undefined
 
+  /**
+   * Evaluates an expression string against the provided state scope.
+   *
+   * @param expr - Expression to evaluate.
+   * @returns The evaluated result or undefined if evaluation fails.
+   */
   const evalExpr = (expr: string): unknown => {
     try {
-      const fn = compile(expr)
-      return fn(state as any)
+      const fn = compile(expr) as (scope: Record<string, unknown>) => unknown
+      return fn(state)
     } catch {
       return undefined
     }
   }
 
+  /**
+   * Parses a raw attribute value according to its specification.
+   *
+   * @param raw - Raw attribute value.
+   * @param spec - Attribute specification describing type and flags.
+   * @returns The parsed value or undefined if parsing fails.
+   */
   const parse = (raw: unknown, spec: AttributeSpec): unknown => {
     if (raw == null) return undefined
     switch (spec.type) {

--- a/packages/remark-campfire/helpers.ts
+++ b/packages/remark-campfire/helpers.ts
@@ -385,7 +385,9 @@ export const extractAttributes = <S extends AttributeSchema>(
     if (name === keyAttr) {
       key = ensureKey(value, parent, index)
       if (!key) {
-        errors.push(`Missing required attribute: ${String(name)}`)
+        errors.push(
+          `Directive "${directive.name}" missing required key attribute "${String(name)}"`
+        )
         return {
           attrs: processed as ExtractedAttrs<S>,
           key,
@@ -395,7 +397,9 @@ export const extractAttributes = <S extends AttributeSchema>(
       }
     } else if (typeof value === 'undefined') {
       if (spec.required)
-        errors.push(`Missing required attribute: ${String(name)}`)
+        errors.push(
+          `Directive "${directive.name}" missing required attribute "${String(name)}"`
+        )
     } else {
       processed[name as string] = value
     }

--- a/packages/remark-campfire/helpers.ts
+++ b/packages/remark-campfire/helpers.ts
@@ -263,6 +263,16 @@ export interface ExtractResult<S extends AttributeSchema> {
   errors: string[]
 }
 
+/**
+ * Extracts and validates directive attributes based on a schema.
+ *
+ * @param directive - Directive node containing raw attributes.
+ * @param parent - Parent node used when removing invalid directives.
+ * @param index - Index of the directive in its parent.
+ * @param schema - Specification describing expected attributes.
+ * @param options - Extraction options such as state and key handling.
+ * @returns Parsed attributes and validation details.
+ */
 export const extractAttributes = <S extends AttributeSchema>(
   directive: DirectiveNode,
   parent: Parent | undefined,
@@ -374,7 +384,15 @@ export const extractAttributes = <S extends AttributeSchema>(
     }
     if (name === keyAttr) {
       key = ensureKey(value, parent, index)
-      if (!key) errors.push(`Missing required attribute: ${String(name)}`)
+      if (!key) {
+        errors.push(`Missing required attribute: ${String(name)}`)
+        return {
+          attrs: processed as ExtractedAttrs<S>,
+          key,
+          valid: false,
+          errors
+        }
+      }
     } else if (typeof value === 'undefined') {
       if (spec.required)
         errors.push(`Missing required attribute: ${String(name)}`)


### PR DESCRIPTION
## Summary
- add generic `extractAttributes` helper for directive handlers
- refactor sample handlers to use new extractor
- re-export utility for app-level directives

## Testing
- `bun tsc --pretty false --noEmit`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68957d0f7c048322bcedb337920d2ba8