### PR TITLE
feat: add shorthand set directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,17 @@ Operations that set, update or remove scalar values.
   :set{key=player_name value="Alice"}
   ```
 
+  The shorthand form `:set[key=value]` is also available. In shorthand syntax,
+  quoted values are treated as strings, `true`/`false` as booleans, values
+  wrapped in `{}` as objects, purely numeric values as numbers and any other
+  value is evaluated as an expression or state reference.
+
+  ```md
+  :set[health=100]
+  :set[playerName="John"]
+  :set[isActive=true]
+  ```
+
 - `set[range]`: Initialize a key with a numeric range. This directive is leaf-only and cannot wrap
   content.
 
@@ -135,7 +146,12 @@ Operations that set, update or remove scalar values.
   :setOnce{key=visited value=true}
   ```
 
-  Replace `visited` with the key to lock on first use.
+  Replace `visited` with the key to lock on first use. Shorthand syntax is also
+  supported:
+
+  ```md
+  :setOnce[visited=true]
+  ```
 
 - `unset`: Remove a key from state. This directive is leaf-only and cannot wrap
   content.

--- a/apps/campfire/__tests__/Passage.state.test.tsx
+++ b/apps/campfire/__tests__/Passage.state.test.tsx
@@ -115,6 +115,35 @@ describe('Passage game state directives', () => {
     expect(paragraphs).toHaveLength(1)
   })
 
+  it('supports shorthand syntax for set directive', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        { type: 'text', value: ':set[hp=5]' },
+        { type: 'text', value: ':set[name="John"]' },
+        { type: 'text', value: ':set[isActive=true]' },
+        { type: 'text', value: ':set[double=hp*2]' }
+      ]
+    }
+
+    useStoryDataStore.setState({
+      passages: [passage],
+      currentPassageId: '1'
+    })
+
+    render(<Passage />)
+
+    await waitFor(() => {
+      const data = useGameStore.getState().gameData as Record<string, unknown>
+      expect(data.hp).toBe(5)
+      expect(data.name).toBe('John')
+      expect(data.isActive).toBe(true)
+      expect(data.double).toBe(10)
+    })
+  })
+
   it('batches state updates into one change', async () => {
     const unsetCalls: string[] = []
     const origUnset = useGameStore.getState().unsetGameData
@@ -187,6 +216,35 @@ describe('Passage game state directives', () => {
 
     expect(
       (useGameStore.getState().gameData as Record<string, unknown>).gold
+    ).toBe(10)
+  })
+
+  it('locks keys with setOnce shorthand', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [{ type: 'text', value: ':setOnce[coins=10]' }]
+    }
+
+    useStoryDataStore.setState({
+      passages: [passage],
+      currentPassageId: '1'
+    })
+
+    render(<Passage />)
+
+    await waitFor(() =>
+      expect(
+        (useGameStore.getState().gameData as Record<string, unknown>).coins
+      ).toBe(10)
+    )
+    expect(useGameStore.getState().lockedKeys.coins).toBe(true)
+
+    useGameStore.getState().setGameData({ coins: 5 })
+
+    expect(
+      (useGameStore.getState().gameData as Record<string, unknown>).coins
     ).toBe(10)
   })
 

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -224,7 +224,10 @@ export const useDirectiveHandlers = () => {
         const inner = trimmed.slice(1, -1)
         const obj: Record<string, unknown> = {}
         for (const part of inner.split(',')) {
-          const [k, v] = part.split(':')
+          const colonIndex = part.indexOf(':')
+          if (colonIndex === -1) continue
+          const k = part.slice(0, colonIndex)
+          const v = part.slice(colonIndex + 1)
           if (!k || typeof v === 'undefined') continue
           obj[k.trim()] = parseShorthandValue(v)
         }

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -229,7 +229,8 @@ export const useDirectiveHandlers = () => {
           const k = part.slice(0, colonIndex)
           const v = part.slice(colonIndex + 1)
           if (!k || typeof v === 'undefined') continue
-          obj[k.trim()] = parseShorthandValue(v)
+          if (!k) continue
+          if (typeof v !== 'undefined') obj[k.trim()] = parseShorthandValue(v)
         }
         return obj
       }


### PR DESCRIPTION
## Summary
- add `:set[key=value]` and `:setOnce[key=value]` shorthand
- document shorthand parsing rules and examples
- cover shorthand with unit tests

## Testing
- `bun tsc`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_68961b00449483229158f4a51f70afeb