### PR TITLE
feat: drop long-form set directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ structures. Indent them just like normal text:
 
 ```md
 - Step one
-  :set{key=visited value=true}
+  :set[visited=true]
 
 > Quoted
 > :goto["NEXT"]
@@ -108,20 +108,13 @@ Operations that set, update or remove scalar values.
   content.
 
   ```md
-  :set{key=HP value=VALUE}
+  :set[KEY=VALUE]
   ```
 
-  Replace `VALUE` with the number or string to store. To store a string, surround the value in matching single
-  quotes ('example'), double quotes ("example"), or backticks (\`example\`).
-
-  ```md
-  :set{key=player_name value="Alice"}
-  ```
-
-  The shorthand form `:set[key=value]` is also available. In shorthand syntax,
-  quoted values are treated as strings, `true`/`false` as booleans, values
-  wrapped in `{}` as objects, purely numeric values as numbers and any other
-  value is evaluated as an expression or state reference.
+  Replace `KEY` with the key name and `VALUE` with the number, string or
+  expression to store. Quoted values are treated as strings, `true`/`false` as
+  booleans, values wrapped in `{}` as objects, purely numeric values as numbers
+  and any other value is evaluated as an expression or state reference.
 
   ```md
   :set[health=100]
@@ -129,29 +122,14 @@ Operations that set, update or remove scalar values.
   :set[isActive=true]
   ```
 
-- `set[range]`: Initialize a key with a numeric range. This directive is leaf-only and cannot wrap
-  content.
-
-  ```md
-  :set[range]{key=HP min=MIN max=MAX value=VALUE}
-  ```
-
-  Replace `HP` with the key, `MIN`/`MAX` with bounds and `VALUE` with the
-  starting number (defaults to `MIN`).
-
 - `setOnce`: Set a key only if it has not been set. This directive is leaf-only
   and cannot wrap content.
 
   ```md
-  :setOnce{key=visited value=true}
-  ```
-
-  Replace `visited` with the key to lock on first use. Shorthand syntax is also
-  supported:
-
-  ```md
   :setOnce[visited=true]
   ```
+
+  Replace `visited` with the key to lock on first use.
 
 - `unset`: Remove a key from state. This directive is leaf-only and cannot wrap
   content.
@@ -326,7 +304,7 @@ Run content only when conditions hold.
   ```md
   :::if{has_key}
   You unlock the door.
-  :set{key=door_opened value=true}
+  :set[door_opened=true]
   [[Enter->Hallway]]
   :::
   ```
@@ -351,7 +329,7 @@ Run directives on specific passage events or group actions.
 
   ```md
   :::batch
-  :set{key=HP value=VALUE}
+  :set[HP=VALUE]
   :push{key=items value=sword}
   :unset{key=old}
   :::
@@ -363,7 +341,7 @@ Run directives on specific passage events or group actions.
 
   ```md
   :::trigger{label="Do it" class="primary" disabled}
-  :set{key=KEY value=VALUE}
+  :set[KEY=VALUE]
   :::
   ```
 

--- a/apps/campfire/__tests__/If.test.tsx
+++ b/apps/campfire/__tests__/If.test.tsx
@@ -113,7 +113,7 @@ describe('If', () => {
   })
 
   it('mixes content and directives', () => {
-    const content = makeMixedContent('Start\n:::set{key=hp value=2}\n:::\nHP!')
+    const content = makeMixedContent('Start\n:::set[hp=2]\n:::\nHP!')
     render(<If test='true' content={content} />)
     expect(screen.getByText('Start')).toBeInTheDocument()
     expect(screen.getByText('HP!')).toBeInTheDocument()
@@ -122,7 +122,7 @@ describe('If', () => {
 
   it('executes trigger directives', async () => {
     const content = makeMixedContent(
-      ':::trigger{label="Fire"}\n:::set{key=fired value=true}\n:::\n:::'
+      ':::trigger{label="Fire"}\n:::set[fired=true]\n:::\n:::'
     )
     render(<If test='true' content={content} />)
     const button = await screen.findByRole('button', { name: 'Fire' })

--- a/apps/campfire/__tests__/Passage.basic.test.tsx
+++ b/apps/campfire/__tests__/Passage.basic.test.tsx
@@ -367,7 +367,7 @@ describe('Passage rendering and navigation', () => {
       type: 'element',
       tagName: 'tw-passagedata',
       properties: { pid: '2', name: 'Second' },
-      children: [{ type: 'text', value: ':::set{key=visited value=true}\n:::' }]
+      children: [{ type: 'text', value: ':::set[visited=true]\n:::' }]
     }
 
     useStoryDataStore.setState({

--- a/apps/campfire/__tests__/Passage.checkpoint.test.tsx
+++ b/apps/campfire/__tests__/Passage.checkpoint.test.tsx
@@ -28,7 +28,7 @@ describe('Passage checkpoint directives', () => {
       children: [
         {
           type: 'text',
-          value: ':::set[number]{key=hp value=5}\n:::\n:checkpoint{id=cp1}'
+          value: ':::set[hp=5]\n:::\n:checkpoint{id=cp1}'
         }
       ]
     }
@@ -39,7 +39,7 @@ describe('Passage checkpoint directives', () => {
       children: [
         {
           type: 'text',
-          value: ':::set[number]{key=hp value=1}\n:::\n:restore{id=cp1}'
+          value: ':::set[hp=1]\n:::\n:restore{id=cp1}'
         }
       ]
     }
@@ -94,8 +94,7 @@ describe('Passage checkpoint directives', () => {
       children: [
         {
           type: 'text',
-          value:
-            ':::set[number]{key=hp value=2}\n:::\n:checkpoint{id=cp1}:include["Second"]'
+          value: ':::set[hp=2]\n:::\n:checkpoint{id=cp1}:include["Second"]'
         }
       ]
     }
@@ -106,8 +105,7 @@ describe('Passage checkpoint directives', () => {
       children: [
         {
           type: 'text',
-          value:
-            ':::set[number]{key=hp value=1}\n:::\n:restore{id=cp1}:checkpoint{id=cp2}'
+          value: ':::set[hp=1]\n:::\n:restore{id=cp1}:checkpoint{id=cp2}'
         }
       ]
     }
@@ -140,8 +138,7 @@ describe('Passage checkpoint directives', () => {
       children: [
         {
           type: 'text',
-          value:
-            ':checkpoint{id=cp1}:::set[number]{key=hp value=1}\n:::\n:checkpoint{id=cp2}'
+          value: ':checkpoint{id=cp1}:::set[hp=1]\n:::\n:checkpoint{id=cp2}'
         }
       ]
     }
@@ -169,8 +166,7 @@ describe('Passage checkpoint directives', () => {
       children: [
         {
           type: 'text',
-          value:
-            ':::set[number]{key=hp value=5}\n:::\n:checkpoint{id=cp1}:save{id=slot1}'
+          value: ':::set[hp=5]\n:::\n:checkpoint{id=cp1}:save{id=slot1}'
         }
       ]
     }

--- a/apps/campfire/__tests__/Passage.state.test.tsx
+++ b/apps/campfire/__tests__/Passage.state.test.tsx
@@ -25,7 +25,7 @@ describe('Passage game state directives', () => {
       type: 'element',
       tagName: 'tw-passagedata',
       properties: { pid: '1', name: 'Start' },
-      children: [{ type: 'text', value: ':::set[number]{key=hp value=5}\n:::' }]
+      children: [{ type: 'text', value: ':::set[hp=5]\n:::' }]
     }
 
     useStoryDataStore.setState({
@@ -50,7 +50,7 @@ describe('Passage game state directives', () => {
       children: [
         {
           type: 'text',
-          value: ':::set{key=item value="\'sword\'"}\n:::'
+          value: ':::set[item="sword"]\n:::'
         }
       ]
     }
@@ -74,7 +74,7 @@ describe('Passage game state directives', () => {
       type: 'element',
       tagName: 'tw-passagedata',
       properties: { pid: '1', name: 'Start' },
-      children: [{ type: 'text', value: ':::set{key=item value=sword}\n:::' }]
+      children: [{ type: 'text', value: ':::set[item=sword]\n:::' }]
     }
 
     useStoryDataStore.setState({
@@ -97,7 +97,7 @@ describe('Passage game state directives', () => {
       children: [
         {
           type: 'text',
-          value: ':::set[number]{key=hp value=5}\n:::\n\nHello'
+          value: ':::set[hp=5]\n:::\n\nHello'
         }
       ]
     }
@@ -163,7 +163,7 @@ describe('Passage game state directives', () => {
         {
           type: 'text',
           value:
-            ':::batch\\n:set[boolean]{key=visited value=true}\\n:push{key=items value=sword}\\n:unset{key=old}\\n:::\n'
+            ':::batch\\n:set[visited=true]\\n:push{key=items value=sword}\\n:unset{key=old}\\n:::\n'
         }
       ]
     }
@@ -193,7 +193,7 @@ describe('Passage game state directives', () => {
       children: [
         {
           type: 'text',
-          value: ':setOnce[number]{key=gold value=10}'
+          value: ':setOnce[gold=10]'
         }
       ]
     }
@@ -727,35 +727,6 @@ describe('Passage game state directives', () => {
     await waitFor(() => {
       const span = screen.getByText('7')
       expect(span.closest('p')?.textContent?.replace(/\s+/g, '')).toBe('HP:7')
-    })
-  })
-
-  it('creates range values with set[range]', async () => {
-    const passage: Element = {
-      type: 'element',
-      tagName: 'tw-passagedata',
-      properties: { pid: '1', name: 'Start' },
-      children: [
-        {
-          type: 'text',
-          value: ':set[range]{key=hp min=0 max=10 value=5}'
-        }
-      ]
-    }
-
-    useStoryDataStore.setState({
-      passages: [passage],
-      currentPassageId: '1'
-    })
-
-    render(<Passage />)
-
-    await waitFor(() => {
-      expect(useGameStore.getState().gameData.hp).toEqual({
-        lower: 0,
-        upper: 10,
-        value: 5
-      })
     })
   })
 

--- a/apps/campfire/__tests__/Passage.trigger.test.tsx
+++ b/apps/campfire/__tests__/Passage.trigger.test.tsx
@@ -29,7 +29,7 @@ describe('Passage trigger directives', () => {
         {
           type: 'text',
           value:
-            ':::trigger{label="Fire" class="extra"}\n:::set{key=fired value=true}\n:::\n:::'
+            ':::trigger{label="Fire" class="extra"}\n:::set[fired=true]\n:::\n:::'
         }
       ]
     }
@@ -55,7 +55,7 @@ describe('Passage trigger directives', () => {
         {
           type: 'text',
           value:
-            ':::trigger{label="Stop" disabled}\n:::set{key=stopped value=true}\n:::\n:::'
+            ':::trigger{label="Stop" disabled}\n:::set[stopped=true]\n:::\n:::'
         }
       ]
     }
@@ -80,7 +80,7 @@ describe('Passage trigger directives', () => {
         {
           type: 'text',
           value:
-            ':::trigger{label="Go" disabled=false}\n:::set{key=go value=true}\n:::\n:::'
+            ':::trigger{label="Go" disabled=false}\n:::set[go=true]\n:::\n:::'
         }
       ]
     }
@@ -104,8 +104,7 @@ describe('Passage trigger directives', () => {
       children: [
         {
           type: 'text',
-          value:
-            ':::trigger{label=Fire}\n:::set{key=fired value=true}\n:::\n:::'
+          value: ':::trigger{label=Fire}\n:::set[fired=true]\n:::\n:::'
         }
       ]
     }

--- a/apps/campfire/__tests__/Story.test.tsx
+++ b/apps/campfire/__tests__/Story.test.tsx
@@ -76,11 +76,11 @@ describe('Story', () => {
   it('renders content based on if directives', async () => {
     document.body.innerHTML = `
 <tw-storydata name="Story" startnode="1">
-  <tw-passagedata pid="1" name="Start">:::set[boolean]{key=open value=true}
+  <tw-passagedata pid="1" name="Start">:::set[open=true]
 :::
 
 :::trigger{label="open"}
-:::set[boolean]{key=open value=false}
+:::set[open=false]
 :::
 
 :::if{!open}
@@ -106,12 +106,12 @@ is open!
   it('renders trigger directives within if directives', async () => {
     document.body.innerHTML = `
 <tw-storydata name="Story" startnode="1">
-  <tw-passagedata pid="1" name="Start">:::set[boolean]{key=open value=true}
+  <tw-passagedata pid="1" name="Start">:::set[open=true]
 :::
 
 :::if{open}
 :::trigger{label="open"}
-:::set{key=clicked value=true}
+:::set[clicked=true]
 :::
 :::
 :::
@@ -132,7 +132,7 @@ is open!
   it('parses if directives after blank lines', async () => {
     document.body.innerHTML = `
 <tw-storydata name="Story" startnode="1">
-  <tw-passagedata pid="1" name="Start">:::set[boolean]{key=open value=true}
+  <tw-passagedata pid="1" name="Start">:::set[open=true]
 :::
 
 :::if{!open}
@@ -148,11 +148,11 @@ not open
   it('does not render ::: when if has no else', async () => {
     document.body.innerHTML = `
 <tw-storydata name="Story" startnode="1">
-  <tw-passagedata pid="1" name="Start">:::set{key=open value=true}
+  <tw-passagedata pid="1" name="Start">:::set[open=true]
 :::
 
 :::if{open}
-:::set{key=done value=true}
+:::set[done=true]
 :::
 :::
   </tw-passagedata>
@@ -168,14 +168,14 @@ not open
   it('executes only the matching branch when else is present', async () => {
     document.body.innerHTML = `
 <tw-storydata name="Story" startnode="1">
-  <tw-passagedata pid="1" name="Start">:::set{key=open value=true}
+  <tw-passagedata pid="1" name="Start">:::set[open=true]
 :::
 
 :::if{open}
-:::set{key=yes value=true}
+:::set[yes=true]
 :::
 :::else
-:::set{key=no value=true}
+:::set[no=true]
 :::
 :::
   </tw-passagedata>
@@ -190,14 +190,14 @@ not open
   it('renders else block when condition is false', async () => {
     document.body.innerHTML = `
 <tw-storydata name="Story" startnode="1">
-  <tw-passagedata pid="1" name="Start">:::set{key=open value=false}
+  <tw-passagedata pid="1" name="Start">:::set[open=false]
 :::
 
 :::if{open}
-:::set{key=yes value=true}
+:::set[yes=true]
 :::
 :::else
-:::set{key=no value=true}
+:::set[no=true]
 :::
 :::
   </tw-passagedata>

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -17,8 +17,6 @@ import { useStoryDataStore } from '@/packages/use-story-data-store'
 import { useGameStore, type Checkpoint } from '@/packages/use-game-store'
 import { markTitleOverridden } from './titleState'
 import {
-  isRange,
-  clamp,
   parseNumericValue,
   getRandomItem,
   getRandomInt,
@@ -125,9 +123,8 @@ export const useDirectiveHandlers = () => {
   }, [currentPassageId])
 
   /**
-   * Handles the leaf `set` and `setOnce` directives by assigning a value to a key
-   * in game data. Supports optional typing via the directive label and range
-   * initialization.
+   * Handles the leaf `set` and `setOnce` directives by assigning values to keys
+   * in game data using shorthand `key=value` pairs.
    *
    * @param directive - The directive node being processed.
    * @param parent - Parent node containing the directive.
@@ -143,66 +140,14 @@ export const useDirectiveHandlers = () => {
   ): DirectiveHandlerResult => {
     const rawLabel = (directive as { label?: string }).label
     const textContent = toString(directive)
-    let typeParam = 'string'
     let shorthand: string | undefined
     if (rawLabel && rawLabel.includes('=')) {
       shorthand = rawLabel
-    } else if (rawLabel) {
-      typeParam = rawLabel.trim().toLowerCase() || 'string'
     } else if (textContent && textContent.includes('=')) {
       shorthand = textContent.trim()
-    } else if (textContent) {
-      typeParam = textContent.trim().toLowerCase() || 'string'
     }
-    const attrs = directive.attributes
+
     const safe: Record<string, unknown> = {}
-
-    const isRecord = (value: unknown): value is Record<string, unknown> =>
-      !!value && typeof value === 'object' && !Array.isArray(value)
-
-    /**
-     * Parses a raw attribute value based on the provided type parameter.
-     * String values must be wrapped in matching quotes, double-quotes, or backticks.
-     * Unquoted values are treated as expressions evaluated against current game data.
-     *
-     * @param value - Raw attribute value to parse.
-     * @returns The parsed value or undefined if parsing fails.
-     */
-    const parseValue = (value: string): unknown => {
-      switch (typeParam) {
-        case 'number': {
-          let evaluated: unknown = value
-          try {
-            const fn = compile(value)
-            evaluated = fn(gameData)
-          } catch {
-            // fall back to raw value when evaluation fails
-          }
-          if (typeof evaluated === 'number') return evaluated
-          const num = parseFloat(String(evaluated))
-          return Number.isNaN(num) ? 0 : num
-        }
-        case 'boolean':
-          return value === 'true'
-        case 'object':
-          try {
-            return JSON.parse(value)
-          } catch {
-            return {}
-          }
-        case 'string':
-        default: {
-          const match = value.match(/^(['"`])(.*)\1$/)
-          if (match) return match[2]
-          try {
-            const fn = compile(value)
-            return fn(gameData)
-          } catch {
-            return undefined
-          }
-        }
-      }
-    }
 
     /**
      * Parses a value supplied via the shorthand `:set[key=value]` syntax. Values
@@ -229,8 +174,7 @@ export const useDirectiveHandlers = () => {
           const k = part.slice(0, colonIndex)
           const v = part.slice(colonIndex + 1)
           if (!k || typeof v === 'undefined') continue
-          if (!k) continue
-          if (typeof v !== 'undefined') obj[k.trim()] = parseShorthandValue(v)
+          obj[k.trim()] = parseShorthandValue(v)
         }
         return obj
       }
@@ -263,62 +207,9 @@ export const useDirectiveHandlers = () => {
       }
     }
 
-    const parseNumber = (value: unknown): number => {
-      if (value == null) return 0
-      if (typeof value === 'number') return value
-      if (typeof value !== 'string') return parseNumericValue(value)
-      let evaluated: unknown = value
-      try {
-        const fn = compile(value)
-        evaluated = fn(gameData)
-      } catch {
-        // fall back to raw value when evaluation fails
-      }
-      if (evaluated == null) return 0
-      return parseNumericValue(evaluated)
-    }
-
     if (shorthand) {
-      applyShorthand(shorthand)
-    } else if (isRecord(attrs)) {
-      const key = ensureKey(attrs.key, parent, index)
-      if (key) {
-        if (typeParam === 'range') {
-          const lower = parseNumber(attrs.min)
-          const upper = parseNumber(attrs.max)
-          const val = parseNumber(attrs.value ?? lower)
-          safe[key] = {
-            lower,
-            upper,
-            value: clamp(val, lower, upper)
-          }
-        } else {
-          const rawValue = attrs.value
-          if (typeof rawValue === 'string') {
-            const parsed = parseValue(rawValue)
-            if (typeof parsed !== 'undefined') {
-              const current = gameData[key]
-              if (isRange(current)) {
-                if (typeof parsed === 'number') {
-                  safe[key] = {
-                    ...current,
-                    value: clamp(parsed, current.lower, current.upper)
-                  }
-                } else if (isRange(parsed)) {
-                  safe[key] = {
-                    lower: parsed.lower,
-                    upper: parsed.upper,
-                    value: clamp(parsed.value, parsed.lower, parsed.upper)
-                  }
-                } else {
-                  safe[key] = parsed
-                }
-              } else {
-                safe[key] = parsed
-              }
-            }
-          }
-        }
+      for (const part of shorthand.split(/\s+/)) {
+        if (part) applyShorthand(part)
       }
     }
 


### PR DESCRIPTION
## Summary
- remove legacy long-form syntax for `set` and `setOnce`
- document shorthand `:set[key=value]` and `:setOnce[key=value]` as defaults
- update tests for new shorthand directives

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_689624e5440083229c77a4ec8e55277a