### PR TITLE
feat: remove math directive and evaluate set expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,15 +218,6 @@ Create or modify lists of values.
 
 Read or compute data without mutating state.
 
-- `math`: Perform a calculation and store the result under a key.
-
-  ```md
-  :math[HP + VALUE]{key=RESULT}
-  ```
-
-  Replace `RESULT` with the key to store and `HP`/`VALUE` with numbers or
-  keys. Use `:show` to display stored values.
-
 - `show`: Display a key's value.
 
   ```md

--- a/apps/campfire/__tests__/Passage.state.test.tsx
+++ b/apps/campfire/__tests__/Passage.state.test.tsx
@@ -144,6 +144,28 @@ describe('Passage game state directives', () => {
     })
   })
 
+  it('evaluates expressions in set directive', async () => {
+    useGameStore.setState(state => ({
+      ...state,
+      gameData: { key_1: 1, key_b: 2, key_c: 3 }
+    }))
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [{ type: 'text', value: ':set[num=(key_1+key_b) * key_c]' }]
+    }
+
+    useStoryDataStore.setState({
+      passages: [passage],
+      currentPassageId: '1'
+    })
+
+    render(<Passage />)
+
+    await waitFor(() => expect(useGameStore.getState().gameData.num).toBe(9))
+  })
+
   it('batches state updates into one change', async () => {
     const unsetCalls: string[] = []
     const origUnset = useGameStore.getState().unsetGameData
@@ -622,61 +644,6 @@ describe('Passage game state directives', () => {
         'c'
       ])
     )
-  })
-
-  it('requires a key and does not display results', async () => {
-    useGameStore.setState(state => ({
-      ...state,
-      gameData: { x: 3 }
-    }))
-    const passage: Element = {
-      type: 'element',
-      tagName: 'tw-passagedata',
-      properties: { pid: '1', name: 'Start' },
-      children: [{ type: 'text', value: 'Result: :math[x * 2]' }]
-    }
-
-    useStoryDataStore.setState({
-      passages: [passage],
-      currentPassageId: '1'
-    })
-
-    render(<Passage />)
-
-    await screen.findByText('Result:')
-    expect(screen.queryByText('Result: 6')).toBeNull()
-    expect(useGameStore.getState().gameData.x).toBe(3)
-  })
-
-  it('can set state with math directive', async () => {
-    useGameStore.setState(state => ({
-      ...state,
-      gameData: { hp: 5 }
-    }))
-    const passage: Element = {
-      type: 'element',
-      tagName: 'tw-passagedata',
-      properties: { pid: '1', name: 'Start' },
-      children: [
-        {
-          type: 'text',
-          value: 'HP: :math[hp + 1]{key=hp} :show[hp]'
-        }
-      ]
-    }
-
-    useStoryDataStore.setState({
-      passages: [passage],
-      currentPassageId: '1'
-    })
-
-    render(<Passage />)
-
-    await waitFor(() => {
-      const span = screen.getByText('6')
-      expect(span.closest('p')?.textContent?.replace(/\s+/g, '')).toBe('HP:6')
-    })
-    expect(useGameStore.getState().gameData.hp).toBe(6)
   })
 
   it('renders game data with show directive', async () => {

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -212,9 +212,19 @@ export const useDirectiveHandlers = () => {
       }
     }
 
+    /**
+     * Splits shorthand string into `key=value` pairs, allowing spaces within
+     * expressions.
+     *
+     * @param input - The raw shorthand string.
+     * @returns An array of `key=value` pairs.
+     */
+    const extractPairs = (input: string): string[] =>
+      input.match(/[^\s]+=\s*[^]+?(?=(?:\s+[^\s]+=)|$)/g) || []
+
     if (shorthand) {
-      for (const part of shorthand.split(/\s+/)) {
-        if (part) applyShorthand(part)
+      for (const part of extractPairs(shorthand)) {
+        applyShorthand(part)
       }
     }
 
@@ -320,50 +330,6 @@ export const useDirectiveHandlers = () => {
       lockedKeys = state.getLockedKeys()
     }
 
-    return removeNode(parent, index)
-  }
-
-  /**
-   * Evaluates a mathematical or JavaScript expression in the context of the current game data
-   * and stores the result under the provided key. The directive does not display any output.
-   */
-  const handleMath: DirectiveHandler = (directive, parent, index) => {
-    const { attrs, key } = extractAttributes(
-      directive,
-      parent,
-      index,
-      {
-        key: { type: 'string', required: true },
-        expr: { type: 'string', expression: false }
-      },
-      { keyAttr: 'key' }
-    )
-    if (!key) return index
-
-    let expr = toString(directive).trim()
-    if (!expr) {
-      expr = attrs.expr || ''
-      if (!expr) {
-        const raw = directive.attributes || {}
-        const first = Object.keys(raw)[0]
-        expr =
-          first && first !== 'key'
-            ? String((raw as Record<string, unknown>)[first])
-            : ''
-      }
-    }
-
-    let value: unknown
-    try {
-      const fn = compile(expr)
-      value = fn(gameData)
-    } catch (error) {
-      console.error('Error evaluating math expression:', expr, error)
-      value = ''
-    }
-
-    state.setValue(key, value)
-    gameData = state.getState()
     return removeNode(parent, index)
   }
 
@@ -1266,7 +1232,6 @@ export const useDirectiveHandlers = () => {
         p: Parent | undefined,
         i: number | undefined
       ) => handleArray(d, p, i, true),
-      math: handleMath,
       show: handleShow,
       random: handleRandom,
       pop: handlePop,


### PR DESCRIPTION
## Summary
- drop `math` directive and rely on `set` for calculations
- allow `set` shorthand to parse expressions with spaces
- document and test expression evaluation via `:set`

## Testing
- `bun x prettier --write apps/campfire/src/useDirectiveHandlers.ts apps/campfire/__tests__/Passage.state.test.tsx README.md`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_689636edfb9c83228dd2541640dd5cc5