### PR TITLE
fix: normalize directive indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,9 @@ Directives are grouped by purpose.
 
 ### Indentation
 
-Directives preserve leading spaces, so they can appear inside other Markdown
-structures. Indent them just like normal text:
+Directives preserve leading whitespace, so they can appear inside other
+Markdown structures. You can use any amount of spaces or tabs—the parser
+ignores the exact indentation:
 
 ```md
 - Step one

--- a/apps/campfire/__tests__/Passage.indentation.test.tsx
+++ b/apps/campfire/__tests__/Passage.indentation.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, beforeEach, expect } from 'bun:test'
+import { render, waitFor } from '@testing-library/react'
+import i18next from 'i18next'
+import { initReactI18next } from 'react-i18next'
+import type { Element } from 'hast'
+import { Passage } from '../src/Passage'
+import { useStoryDataStore } from '@/packages/use-story-data-store'
+import { useGameStore } from '@/packages/use-game-store'
+import { resetStores } from './helpers'
+
+/**
+ * Creates a passage that sets `hp` inside an if directive using the provided indentation.
+ */
+const makePassage = (indent: string): Element => ({
+  type: 'element',
+  tagName: 'tw-passagedata',
+  properties: { pid: '1', name: 'Start' },
+  children: [{ type: 'text', value: `:::if[true]\n${indent}:set[hp=5]\n:::` }]
+})
+
+describe('directive indentation', () => {
+  beforeEach(async () => {
+    document.body.innerHTML = ''
+    resetStores()
+    if (!i18next.isInitialized) {
+      await i18next.use(initReactI18next).init({ lng: 'en-US', resources: {} })
+    } else {
+      await i18next.changeLanguage('en-US')
+      i18next.services.resourceStore.data = {}
+    }
+  })
+
+  const cases: [string, string][] = [
+    ['two spaces', '  '],
+    ['four spaces', '    '],
+    ['tab', '\t']
+  ]
+
+  for (const [label, indent] of cases) {
+    it(`processes directives with ${label}`, async () => {
+      const passage = makePassage(indent)
+      useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+      render(<Passage />)
+      await waitFor(() =>
+        expect((useGameStore.getState().gameData as any).hp).toBe(5)
+      )
+    })
+  }
+})

--- a/apps/campfire/src/Passage.tsx
+++ b/apps/campfire/src/Passage.tsx
@@ -22,6 +22,19 @@ import { If } from './If'
 import { Show } from './Show'
 
 /**
+ * Normalizes directive indentation so Markdown treats directive lines the same
+ * regardless of leading spaces or tabs. Strips tabs or four-or-more spaces
+ * before directive markers.
+ *
+ * @param input - Raw passage text.
+ * @returns Passage text with directive indentation normalized.
+ */
+const normalizeDirectiveIndentation = (input: string): string =>
+  input
+    .replace(/^\t+(?=(:::[^\n]*|:[^\n]*|<<))/gm, '')
+    .replace(/^[ ]{4,}(?=(:::[^\n]*|:[^\n]*|<<))/gm, '')
+
+/**
  * Converts legacy if directive syntax using braces into label-based directives.
  *
  * Remark's directive parser only accepts attribute names with characters valid
@@ -168,7 +181,9 @@ export const Passage = () => {
             : ''
         )
         .join('')
-      const normalized = normalizeIfDirectives(text)
+      const normalized = normalizeIfDirectives(
+        normalizeDirectiveIndentation(text)
+      )
       if (controller.signal.aborted) return
       const file = await processor.process(normalized)
       if (controller.signal.aborted) return


### PR DESCRIPTION
## Summary
- treat directive indentation consistently by stripping leading tabs or four-plus spaces
- document that whitespace before directives is ignored
- test directives with varying indentation levels

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68963b76b4008322868d80cf9093e43a