### PR TITLE
feat: add shorthand translations syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,14 +445,22 @@ Change language and handle translations.
 
   Replace `HELLO` and `UI` with your key and namespace.
 
-- `translations`: Add multiple translations.
+- `translations`: Add translations.
 
   ```md
   :translations{ns="UI" locale="LANG-CODE" hello="BONJOUR"}
   ```
 
-  Replace `UI` with the namespace, `LANG-CODE` with the locale and adjust
-  keys.
+  Replace `UI` with the namespace, `LANG-CODE` with the locale and adjust keys.
+
+  To add a single translation using shorthand syntax, supply the locale as the
+  directive label and provide one `namespace:key="value"` pair:
+
+  ```md
+  :translations[LANG-CODE]{UI:hello="BONJOUR"}
+  ```
+
+  Only one pair is allowed when using the shorthand.
 
 ### Error handling
 


### PR DESCRIPTION
## Summary
- support `:translations[lng]{namespace:key="value"}` shorthand in Campfire directives
- handle malformed shorthand inputs with descriptive errors
- retain attribute-based translation loading as fallback
- add tests for translations shorthand, including error when multiple pairs provided
- document translations shorthand in README

## Testing
- `bun x prettier --write README.md`
- `bun tsc && echo 'tsc ok'`
- `bun test >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_689664f50a148322b2e4f7d070ceb488