### PR TITLE
feat: simplify array directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,20 +151,22 @@ Create or modify lists of values.
 - `array`: Create an array.
 
   ```md
-  :array{ITEMS=1,2,'three',"four"}
+  :array[ITEMS=[1,2,'three',"four"]]
   ```
 
-  Replace `ITEMS` with the array name. Wrap string values in single quotes,
-  double quotes or backticks. Unquoted values are parsed as numbers or booleans
-  when possible.
+  Replace `ITEMS` with the array name. The directive accepts a single
+  `key=[...]` pair where the value is in array notation. Items are
+  automatically converted to strings, numbers or booleans and may include
+  expressions evaluated against the current state.
 
 - `arrayOnce`: Create an array only if it has not been set.
 
   ```md
-  :arrayOnce{VISITED='FOREST',"CAVE"}
+  :arrayOnce[VISITED=['FOREST',"CAVE"]]
   ```
 
-  Replace `VISITED` with the array name. Quoted values are treated as strings.
+  This behaves like `array` but locks the key after execution, preventing
+  further changes.
 
 - `concat`: Combine arrays.
 

--- a/apps/campfire/__tests__/Passage.state.test.tsx
+++ b/apps/campfire/__tests__/Passage.state.test.tsx
@@ -271,6 +271,7 @@ describe('Passage game state directives', () => {
   })
 
   it('sets arrays with array directive', async () => {
+    useGameStore.setState(state => ({ ...state, gameData: { base: 2 } }))
     const passage: Element = {
       type: 'element',
       tagName: 'tw-passagedata',
@@ -278,7 +279,7 @@ describe('Passage game state directives', () => {
       children: [
         {
           type: 'text',
-          value: ":array{items=1,'two',false}"
+          value: ":array[items=[1,'two',false,base+3]]"
         }
       ]
     }
@@ -291,7 +292,12 @@ describe('Passage game state directives', () => {
     render(<Passage />)
 
     await waitFor(() =>
-      expect(useGameStore.getState().gameData.items).toEqual([1, 'two', false])
+      expect(useGameStore.getState().gameData.items).toEqual([
+        1,
+        'two',
+        false,
+        5
+      ])
     )
   })
 
@@ -300,7 +306,7 @@ describe('Passage game state directives', () => {
       type: 'element',
       tagName: 'tw-passagedata',
       properties: { pid: '1', name: 'Start' },
-      children: [{ type: 'text', value: ':arrayOnce{nums=1,2}' }]
+      children: [{ type: 'text', value: ':arrayOnce[nums=[1,2]]' }]
     }
 
     useStoryDataStore.setState({

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -288,7 +288,16 @@ export const useDirectiveHandlers = () => {
       for (let i = 0; i < input.length; i++) {
         const ch = input[i]
         if (quote) {
-          if (ch === quote && input[i - 1] !== '\\') quote = null
+          // Count consecutive backslashes before the quote
+          if (ch === quote) {
+            let backslashCount = 0;
+            let j = i - 1;
+            while (j >= 0 && input[j] === '\\') {
+              backslashCount++;
+              j--;
+            }
+            if (backslashCount % 2 === 0) quote = null;
+          }
           current += ch
           continue
         }


### PR DESCRIPTION
## Summary
- simplify `array` and `arrayOnce` directives to `key=[...]` syntax
- evaluate array items and support expression values
- document and test new array directives

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_6896731d50708322879bf219ae28ef3c