### PR TITLE
feat: support namespace labels in t directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ Change language and handle translations.
 - `t`: Output a translated string.
 
   ```md
-  :t{key=HELLO ns="UI"}
+  :t[UI:HELLO]
   ```
 
   Replace `HELLO` and `UI` with your key and namespace.
@@ -476,7 +476,6 @@ markup. These codes help identify and debug issues in story passages.
 | ----- | ------------------------------------------------------------------ |
 | CF001 | Trigger `label` must be a quoted string. The attribute is ignored. |
 | CF002 | `locale` must be a quoted string. The attribute is ignored.        |
-| CF003 | `ns` must be a quoted string. The attribute is ignored.            |
 
 ## Further reading
 

--- a/apps/campfire/__tests__/Passage.i18n.test.tsx
+++ b/apps/campfire/__tests__/Passage.i18n.test.tsx
@@ -46,7 +46,7 @@ describe('Passage i18n directives', () => {
       type: 'element',
       tagName: 'tw-passagedata',
       properties: { pid: '1', name: 'Start' },
-      children: [{ type: 'text', value: ':t{key=hello}' }]
+      children: [{ type: 'text', value: ':t[hello]' }]
     }
 
     useStoryDataStore.setState({
@@ -75,7 +75,7 @@ describe('Passage i18n directives', () => {
           value:
             ':translations[en-US]{translation:apple_other="{{count}} apples"}'
         },
-        { type: 'text', value: ':t{key=apple count=2}' }
+        { type: 'text', value: ':t[apple]{count=2}' }
       ]
     }
 
@@ -100,7 +100,7 @@ describe('Passage i18n directives', () => {
           type: 'text',
           value: ':translations[en-US]{translation:next="Next"}'
         },
-        { type: 'text', value: '[[:t{key=next}->Next]]' }
+        { type: 'text', value: '[[:t[next]->Next]]' }
       ]
     }
     const next: Element = {
@@ -132,7 +132,7 @@ describe('Passage i18n directives', () => {
           type: 'text',
           value: ':translations[en-US]{ui:goodbye="Au revoir"}'
         },
-        { type: 'text', value: ':t{key=goodbye ns="ui"}' }
+        { type: 'text', value: ':t[ui:goodbye]' }
       ]
     }
 
@@ -155,7 +155,7 @@ describe('Passage i18n directives', () => {
       type: 'element',
       tagName: 'tw-passagedata',
       properties: { pid: '1', name: 'Start' },
-      children: [{ type: 'text', value: ':t{key=hello}' }]
+      children: [{ type: 'text', value: ':t[hello]' }]
     }
 
     useStoryDataStore.setState({
@@ -181,7 +181,7 @@ describe('Passage i18n directives', () => {
       properties: { pid: '1', name: 'Start' },
       children: [
         { type: 'text', value: ':translations[en-US]{ui:greet="Hello there"}' },
-        { type: 'text', value: ':t{key=greet ns="ui"}' }
+        { type: 'text', value: ':t[ui:greet]' }
       ]
     }
 

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -869,22 +869,32 @@ export const useDirectiveHandlers = () => {
    */
   const handleTranslate: DirectiveHandler = (directive, parent, index) => {
     const attrs = (directive.attributes || {}) as Record<string, unknown>
-    const children = directive.children as (RootContent & { name?: string })[]
+    const label = (directive as { label?: string }).label?.trim()
     let key = ''
     let ns: string | undefined
-    if (
-      children.length === 2 &&
-      children[0].type === 'text' &&
-      children[1].type === 'textDirective'
-    ) {
-      ns = (children[0] as MdText).value.trim()
-      key = (children[1] as DirectiveNode).name
-    } else if (children.length === 1 && children[0].type === 'text') {
-      key = (children[0] as MdText).value.trim()
+    if (label) {
+      const [nsPart, keyPart] = label.split(':', 2)
+      if (keyPart !== undefined) {
+        ns = nsPart.trim()
+        key = keyPart.trim()
+      } else {
+        key = nsPart.trim()
+      }
     } else {
-      const label =
-        (directive as { label?: string }).label || toString(directive).trim()
-      if (label) key = label
+      const children = directive.children as (RootContent & { name?: string })[]
+      if (
+        children.length === 2 &&
+        children[0].type === 'text' &&
+        children[1].type === 'textDirective'
+      ) {
+        ns = (children[0] as MdText).value.trim()
+        key = (children[1] as DirectiveNode).name
+      } else if (children.length === 1 && children[0].type === 'text') {
+        key = (children[0] as MdText).value.trim()
+      } else {
+        const text = toString(directive).trim()
+        if (text) key = text
+      }
     }
     if (!key) return removeNode(parent, index)
     if (parent && typeof index === 'number') {

--- a/packages/remark-campfire/__tests__/i18n-quotes.test.ts
+++ b/packages/remark-campfire/__tests__/i18n-quotes.test.ts
@@ -39,15 +39,4 @@ describe('i18n directive attribute quoting', () => {
     expect(node?.attributes).toEqual({})
     expect(file.messages.some(m => m.message.includes('CF002'))).toBe(true)
   })
-
-  it('accepts quoted ns in t', () => {
-    const { node } = parseDirective(':t{key=hello ns="ui"}', 't')
-    expect(node?.attributes).toEqual({ key: 'hello', ns: 'ui' })
-  })
-
-  it('rejects unquoted ns in t', () => {
-    const { node, file } = parseDirective(':t{key=hello ns=ui}', 't')
-    expect(node?.attributes).toEqual({ key: 'hello' })
-    expect(file.messages.some(m => m.message.includes('CF003'))).toBe(true)
-  })
 })

--- a/packages/remark-campfire/index.ts
+++ b/packages/remark-campfire/index.ts
@@ -14,10 +14,6 @@ const MSG_TRIGGER_LABEL_UNQUOTED = `${ERR_TRIGGER_LABEL_UNQUOTED}: trigger label
 const ERR_LOCALE_UNQUOTED = 'CF002'
 /** Error message for unquoted locale attributes */
 const MSG_LOCALE_UNQUOTED = `${ERR_LOCALE_UNQUOTED}: locale must be a quoted string`
-/** Error code for unquoted namespace attributes */
-const ERR_NS_UNQUOTED = 'CF003'
-/** Error message for unquoted namespace attributes */
-const MSG_NS_UNQUOTED = `${ERR_NS_UNQUOTED}: ns must be a quoted string`
 
 export type DirectiveHandlerResult = number | [typeof SKIP, number] | void
 
@@ -194,13 +190,6 @@ const remarkCampfire =
               file,
               MSG_LOCALE_UNQUOTED
             )
-          }
-          if (
-            directive.attributes &&
-            directive.name === 't' &&
-            Object.prototype.hasOwnProperty.call(directive.attributes, 'ns')
-          ) {
-            ensureQuotedAttribute(directive, 'ns', file, MSG_NS_UNQUOTED)
           }
           const handler = options.handlers?.[directive.name]
           if (handler) {


### PR DESCRIPTION
## Summary
- add support for `:t[ns:key]` label syntax
- drop namespace attribute validation
- document new translation directive usage

## Testing
- `bun tsc`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_6896aa7b54288322890ca76b0bbc14da