### PR TITLE
feat: add Sequence and Step components

### DIFF
--- a/apps/campfire/__tests__/Sequence.test.tsx
+++ b/apps/campfire/__tests__/Sequence.test.tsx
@@ -148,4 +148,18 @@ describe('Sequence', () => {
     })
     expect(wrapper.style.opacity).toBe('1')
   })
+
+  it('throws when a Step contains a Sequence', () => {
+    expect(() =>
+      render(
+        <Sequence>
+          <Step>
+            <Sequence>
+              <Step>Inner</Step>
+            </Sequence>
+          </Step>
+        </Sequence>
+      )
+    ).toThrow('Step cannot be the parent of a Sequence')
+  })
 })

--- a/apps/campfire/__tests__/Sequence.test.tsx
+++ b/apps/campfire/__tests__/Sequence.test.tsx
@@ -135,6 +135,74 @@ describe('Sequence', () => {
     ).toBeNull()
   })
 
+  it('rewinds to the previous step by default', () => {
+    render(
+      <Sequence rewind={{ enabled: true }}>
+        <Step>
+          {({ next }) => (
+            <>
+              <div>First</div>
+              <button type='button' onClick={next}>
+                Go
+              </button>
+            </>
+          )}
+        </Step>
+        <Step>Second</Step>
+      </Sequence>
+    )
+    const next = screen.getByRole('button', { name: 'Go' })
+    act(() => {
+      next.click()
+    })
+    expect(screen.getByText('Second')).toBeInTheDocument()
+    const rewind = screen.getByRole('button', {
+      name: 'Rewind to previous step'
+    })
+    act(() => {
+      rewind.click()
+    })
+    expect(screen.getByText('First')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Rewind to previous step' })
+    ).toBeNull()
+  })
+
+  it('rewinds to the beginning when configured', () => {
+    render(
+      <Sequence rewind={{ enabled: true, toStart: true }}>
+        <Step>
+          {({ next }) => (
+            <>
+              <div>First</div>
+              <button type='button' onClick={next}>
+                Go
+              </button>
+            </>
+          )}
+        </Step>
+        <Step>Middle</Step>
+        <Step>End</Step>
+      </Sequence>
+    )
+    const next = screen.getByRole('button', { name: 'Go' })
+    act(() => {
+      next.click()
+    })
+    const continueButton = screen.getByRole('button', {
+      name: 'Continue to next step'
+    })
+    act(() => {
+      continueButton.click()
+    })
+    expect(screen.getByText('End')).toBeInTheDocument()
+    const rewind = screen.getByRole('button', { name: 'Rewind to start' })
+    act(() => {
+      rewind.click()
+    })
+    expect(screen.getByText('First')).toBeInTheDocument()
+  })
+
   it('renders step content with a fade-in transition', async () => {
     render(
       <Sequence>

--- a/apps/campfire/__tests__/Sequence.test.tsx
+++ b/apps/campfire/__tests__/Sequence.test.tsx
@@ -149,29 +149,28 @@ describe('Sequence', () => {
     expect(wrapper.style.opacity).toBe('1')
   })
 
-  it('throws when a Step contains a Sequence', () => {
-    expect(() =>
-      render(
-        <Sequence>
-          <Step>
-            <Sequence>
-              <Step>Inner</Step>
-            </Sequence>
-          </Step>
-        </Sequence>
-      )
-    ).toThrow('Step cannot be the parent of a Sequence')
-  })
-
-  it('throws when a Sequence contains a Sequence', () => {
-    expect(() =>
-      render(
-        <Sequence>
-          <Sequence>
-            <Step>Inner</Step>
+  it('allows nesting sequences within steps', () => {
+    render(
+      <Sequence>
+        <Step>
+          <Sequence continueLabel='Inner next'>
+            <Step>Inner first</Step>
+            <Step>Inner second</Step>
           </Sequence>
-        </Sequence>
-      )
-    ).toThrow('Sequence cannot be the child of a Sequence')
+        </Step>
+        <Step>Outer second</Step>
+      </Sequence>
+    )
+    expect(screen.getByText('Inner first')).toBeInTheDocument()
+    const innerNext = screen.getByRole('button', { name: 'Inner next' })
+    act(() => {
+      innerNext.click()
+    })
+    expect(screen.getByText('Inner second')).toBeInTheDocument()
+    const outerNext = screen.getByRole('button', { name: 'Continue' })
+    act(() => {
+      outerNext.click()
+    })
+    expect(screen.getByText('Outer second')).toBeInTheDocument()
   })
 })

--- a/apps/campfire/__tests__/Sequence.test.tsx
+++ b/apps/campfire/__tests__/Sequence.test.tsx
@@ -11,7 +11,7 @@ describe('Sequence', () => {
       </Sequence>
     )
     expect(screen.getByText('First')).toBeInTheDocument()
-    const button = screen.getByRole('button', { name: 'Continue' })
+    const button = screen.getByRole('button', { name: 'Continue to next step' })
     act(() => {
       button.click()
     })
@@ -25,7 +25,8 @@ describe('Sequence', () => {
         <Step>Second</Step>
       </Sequence>
     )
-    const button = screen.getByRole('button', { name: 'Next step' })
+    const button = screen.getByRole('button', { name: 'Continue to next step' })
+    expect(button).toHaveTextContent('Next step')
     act(() => {
       button.click()
     })
@@ -85,7 +86,7 @@ describe('Sequence', () => {
         <Step>Done</Step>
       </Sequence>
     )
-    const button = screen.getByRole('button', { name: 'Skip' })
+    const button = screen.getByRole('button', { name: 'Skip to next step' })
     act(() => {
       button.click()
     })
@@ -99,7 +100,8 @@ describe('Sequence', () => {
         <Step>Done</Step>
       </Sequence>
     )
-    const button = screen.getByRole('button', { name: 'Fast forward' })
+    const button = screen.getByRole('button', { name: 'Skip to next step' })
+    expect(button).toHaveTextContent('Fast forward')
     act(() => {
       button.click()
     })
@@ -114,7 +116,7 @@ describe('Sequence', () => {
         <Step>End</Step>
       </Sequence>
     )
-    const button = screen.getByRole('button', { name: 'Skip' })
+    const button = screen.getByRole('button', { name: 'Skip to end' })
     act(() => {
       button.click()
     })
@@ -128,7 +130,9 @@ describe('Sequence', () => {
         <Step>Second</Step>
       </Sequence>
     )
-    expect(screen.queryByRole('button', { name: 'Skip' })).toBeNull()
+    expect(
+      screen.queryByRole('button', { name: 'Skip to next step' })
+    ).toBeNull()
   })
 
   it('renders step content with a fade-in transition', async () => {
@@ -153,7 +157,7 @@ describe('Sequence', () => {
     render(
       <Sequence>
         <Step>
-          <Sequence continueLabel='Inner next'>
+          <Sequence continueLabel='Inner next' continueAriaLabel='Inner next'>
             <Step>Inner first</Step>
             <Step>Inner second</Step>
           </Sequence>
@@ -167,10 +171,29 @@ describe('Sequence', () => {
       innerNext.click()
     })
     expect(screen.getByText('Inner second')).toBeInTheDocument()
-    const outerNext = screen.getByRole('button', { name: 'Continue' })
+    const outerNext = screen.getByRole('button', {
+      name: 'Continue to next step'
+    })
     act(() => {
       outerNext.click()
     })
     expect(screen.getByText('Outer second')).toBeInTheDocument()
+  })
+
+  it('allows customizing aria labels', () => {
+    render(
+      <Sequence continueAriaLabel='Advance' skipAriaLabel='Jump ahead'>
+        <Step>First</Step>
+        <Step>Second</Step>
+      </Sequence>
+    )
+    const continueButton = screen.getByRole('button', { name: 'Advance' })
+    const skipButton = screen.getByRole('button', { name: 'Jump ahead' })
+    expect(continueButton).toBeInTheDocument()
+    expect(skipButton).toBeInTheDocument()
+    act(() => {
+      skipButton.click()
+    })
+    expect(screen.getByText('Second')).toBeInTheDocument()
   })
 })

--- a/apps/campfire/__tests__/Sequence.test.tsx
+++ b/apps/campfire/__tests__/Sequence.test.tsx
@@ -78,7 +78,7 @@ describe('Sequence', () => {
     expect(screen.getByText('Second')).toBeInTheDocument()
   })
 
-  it('fastfowards to the next step by default', () => {
+  it('fast-forwards to the next step by default', () => {
     render(
       <Sequence>
         <Step>First</Step>
@@ -106,9 +106,9 @@ describe('Sequence', () => {
     expect(screen.getByText('Done')).toBeInTheDocument()
   })
 
-  it('fastfowards to the end when configured', () => {
+  it('fast-forwards to the end when configured', () => {
     render(
-      <Sequence fastfoward={{ toEnd: true }}>
+      <Sequence fastForward={{ toEnd: true }}>
         <Step>First</Step>
         <Step>Middle</Step>
         <Step>End</Step>
@@ -121,9 +121,9 @@ describe('Sequence', () => {
     expect(screen.getByText('End')).toBeInTheDocument()
   })
 
-  it('ignores fastfoward when disabled', () => {
+  it('ignores fast-forward when disabled', () => {
     render(
-      <Sequence fastfoward={{ enabled: false }}>
+      <Sequence fastForward={{ enabled: false }}>
         <Step>First</Step>
         <Step>Second</Step>
       </Sequence>

--- a/apps/campfire/__tests__/Sequence.test.tsx
+++ b/apps/campfire/__tests__/Sequence.test.tsx
@@ -162,4 +162,16 @@ describe('Sequence', () => {
       )
     ).toThrow('Step cannot be the parent of a Sequence')
   })
+
+  it('throws when a Sequence contains a Sequence', () => {
+    expect(() =>
+      render(
+        <Sequence>
+          <Sequence>
+            <Step>Inner</Step>
+          </Sequence>
+        </Sequence>
+      )
+    ).toThrow('Sequence cannot be the child of a Sequence')
+  })
 })

--- a/apps/campfire/__tests__/Sequence.test.tsx
+++ b/apps/campfire/__tests__/Sequence.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'bun:test'
+import { render, screen, act } from '@testing-library/react'
+import { Sequence, Step, Transition } from '../src/Sequence'
+
+describe('Sequence', () => {
+  it('prompts the user to continue when autoplay is false', () => {
+    render(
+      <Sequence>
+        <Step>First</Step>
+        <Step>Second</Step>
+      </Sequence>
+    )
+    expect(screen.getByText('First')).toBeInTheDocument()
+    const button = screen.getByRole('button', { name: 'Continue' })
+    act(() => {
+      button.click()
+    })
+    expect(screen.getByText('Second')).toBeInTheDocument()
+  })
+
+  it('allows customizing continue button text', () => {
+    render(
+      <Sequence continueLabel='Next step'>
+        <Step>First</Step>
+        <Step>Second</Step>
+      </Sequence>
+    )
+    const button = screen.getByRole('button', { name: 'Next step' })
+    act(() => {
+      button.click()
+    })
+    expect(screen.getByText('Second')).toBeInTheDocument()
+  })
+
+  it('advances automatically when autoplay is true', async () => {
+    render(
+      <Sequence autoplay>
+        <Step>First</Step>
+        <Step>Second</Step>
+      </Sequence>
+    )
+    await screen.findByText('Second')
+    expect(screen.getByText('Second')).toBeInTheDocument()
+  })
+
+  it('supports custom next handlers', () => {
+    render(
+      <Sequence>
+        <Step>
+          {({ next }) => (
+            <button type='button' onClick={next}>
+              Go
+            </button>
+          )}
+        </Step>
+        <Step>Done</Step>
+      </Sequence>
+    )
+    const button = screen.getByRole('button', { name: 'Go' })
+    act(() => {
+      button.click()
+    })
+    expect(screen.getByText('Done')).toBeInTheDocument()
+  })
+
+  it('respects delay when autoplay is true', async () => {
+    render(
+      <Sequence autoplay delay={50}>
+        <Step>First</Step>
+        <Step>Second</Step>
+      </Sequence>
+    )
+    expect(screen.getByText('First')).toBeInTheDocument()
+    expect(screen.queryByText('Second')).toBeNull()
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50))
+    })
+    expect(screen.getByText('Second')).toBeInTheDocument()
+  })
+
+  it('fastfowards to the next step by default', () => {
+    render(
+      <Sequence>
+        <Step>First</Step>
+        <Step>Done</Step>
+      </Sequence>
+    )
+    const button = screen.getByRole('button', { name: 'Skip' })
+    act(() => {
+      button.click()
+    })
+    expect(screen.getByText('Done')).toBeInTheDocument()
+  })
+
+  it('allows customizing skip button text', () => {
+    render(
+      <Sequence skipLabel='Fast forward'>
+        <Step>First</Step>
+        <Step>Done</Step>
+      </Sequence>
+    )
+    const button = screen.getByRole('button', { name: 'Fast forward' })
+    act(() => {
+      button.click()
+    })
+    expect(screen.getByText('Done')).toBeInTheDocument()
+  })
+
+  it('fastfowards to the end when configured', () => {
+    render(
+      <Sequence fastfoward={{ toEnd: true }}>
+        <Step>First</Step>
+        <Step>Middle</Step>
+        <Step>End</Step>
+      </Sequence>
+    )
+    const button = screen.getByRole('button', { name: 'Skip' })
+    act(() => {
+      button.click()
+    })
+    expect(screen.getByText('End')).toBeInTheDocument()
+  })
+
+  it('ignores fastfoward when disabled', () => {
+    render(
+      <Sequence fastfoward={{ enabled: false }}>
+        <Step>First</Step>
+        <Step>Second</Step>
+      </Sequence>
+    )
+    expect(screen.queryByRole('button', { name: 'Skip' })).toBeNull()
+  })
+
+  it('renders step content with a fade-in transition', async () => {
+    render(
+      <Sequence>
+        <Step>
+          <Transition type='fade-in' duration={200}>
+            <div>First</div>
+          </Transition>
+        </Step>
+      </Sequence>
+    )
+    const wrapper = screen.getByText('First').parentElement as HTMLElement
+    expect(wrapper.style.transition).toBe('opacity 200ms ease-in')
+    await act(async () => {
+      await new Promise(requestAnimationFrame)
+    })
+    expect(wrapper.style.opacity).toBe('1')
+  })
+})

--- a/apps/campfire/src/If.tsx
+++ b/apps/campfire/src/If.tsx
@@ -13,6 +13,7 @@ import { useDirectiveHandlers } from './useDirectiveHandlers'
 import { LinkButton } from './LinkButton'
 import { TriggerButton } from './TriggerButton'
 import { Show } from './Show'
+import { Sequence, Step, Transition } from './Sequence'
 
 interface IfProps {
   test: string
@@ -43,7 +44,10 @@ export const If = ({ test, content, fallback }: IfProps) => {
           button: LinkButton,
           trigger: TriggerButton,
           if: If,
-          show: Show
+          show: Show,
+          sequence: Sequence,
+          step: Step,
+          transition: Transition
         }
       })
     proc.parser = (_doc: unknown, file: Root) => ({

--- a/apps/campfire/src/Passage.tsx
+++ b/apps/campfire/src/Passage.tsx
@@ -20,6 +20,7 @@ import { LinkButton } from './LinkButton'
 import { TriggerButton } from './TriggerButton'
 import { If } from './If'
 import { Show } from './Show'
+import { Sequence, Step, Transition } from './Sequence'
 
 const DIRECTIVE_MARKER_PATTERN = '(:::[^\\n]*|:[^\\n]*|<<)'
 
@@ -122,7 +123,10 @@ export const Passage = () => {
             button: LinkButton,
             trigger: TriggerButton,
             if: If,
-            show: Show
+            show: Show,
+            sequence: Sequence,
+            step: Step,
+            transition: Transition
           }
         }),
     [handlers]

--- a/apps/campfire/src/Sequence.tsx
+++ b/apps/campfire/src/Sequence.tsx
@@ -3,6 +3,8 @@ import {
   cloneElement,
   isValidElement,
   useEffect,
+  useLayoutEffect,
+  useMemo,
   useState,
   type CSSProperties,
   type ReactElement,
@@ -70,9 +72,9 @@ export const Transition = ({
   children
 }: TransitionProps) => {
   const [visible, setVisible] = useState(false)
-  useEffect(() => {
-    const id = setTimeout(() => setVisible(true), 0)
-    return () => clearTimeout(id)
+  useLayoutEffect(() => {
+    const id = requestAnimationFrame(() => setVisible(true))
+    return () => cancelAnimationFrame(id)
   }, [])
   const style: CSSProperties =
     type === 'fade-in'
@@ -153,9 +155,13 @@ export const Sequence = ({
   rewindAriaLabel
 }: SequenceProps) => {
   const [index, setIndex] = useState(0)
-  const steps = Children.toArray(children).filter(
-    (child): child is ReactElement<StepProps> =>
-      isValidElement(child) && child.type === Step
+  const steps = useMemo(
+    () =>
+      Children.toArray(children).filter(
+        (child): child is ReactElement<StepProps> =>
+          isValidElement(child) && child.type === Step
+      ),
+    [children]
   )
   const current = steps[index]
   useEffect(() => {

--- a/apps/campfire/src/Sequence.tsx
+++ b/apps/campfire/src/Sequence.tsx
@@ -24,8 +24,17 @@ interface StepProps {
  * Represents a single step within a {@link Sequence}.
  * The content can be static React nodes or a render function
  * receiving `next` and `fastForward` callbacks to control progression.
+ * Cannot contain a {@link Sequence} as a child.
  */
 export const Step = ({ children, next, fastForward }: StepProps) => {
+  if (
+    typeof children !== 'function' &&
+    Children.toArray(children).some(
+      child => isValidElement(child) && child.type === Sequence
+    )
+  ) {
+    throw new Error('Step cannot be the parent of a Sequence')
+  }
   if (typeof children === 'function') {
     return (
       <>

--- a/apps/campfire/src/Sequence.tsx
+++ b/apps/campfire/src/Sequence.tsx
@@ -24,17 +24,8 @@ interface StepProps {
  * Represents a single step within a {@link Sequence}.
  * The content can be static React nodes or a render function
  * receiving `next` and `fastForward` callbacks to control progression.
- * Cannot contain a {@link Sequence} as a child.
  */
 export const Step = ({ children, next, fastForward }: StepProps) => {
-  if (
-    typeof children !== 'function' &&
-    Children.toArray(children).some(
-      child => isValidElement(child) && child.type === Sequence
-    )
-  ) {
-    throw new Error('Step cannot be the parent of a Sequence')
-  }
   if (typeof children === 'function') {
     return (
       <>
@@ -115,8 +106,7 @@ interface FastForwardOptions {
  * Otherwise a "Continue" button is shown for non-interactive steps.
  * A `fastForward` control is provided to skip steps or jump to the end
  * based on the supplied `fastForward` options. Both button labels may be
- * customized via `continueLabel` and `skipLabel` props. Cannot contain
- * another `Sequence` as a direct child.
+ * customized via `continueLabel` and `skipLabel` props.
  */
 export const Sequence = ({
   children,
@@ -127,13 +117,6 @@ export const Sequence = ({
   skipLabel = 'Skip'
 }: SequenceProps) => {
   const [index, setIndex] = useState(0)
-  if (
-    Children.toArray(children).some(
-      child => isValidElement(child) && child.type === Sequence
-    )
-  ) {
-    throw new Error('Sequence cannot be the child of a Sequence')
-  }
   const steps = Children.toArray(children).filter(
     (child): child is ReactElement<StepProps> =>
       isValidElement(child) && child.type === Step

--- a/apps/campfire/src/Sequence.tsx
+++ b/apps/campfire/src/Sequence.tsx
@@ -1,0 +1,179 @@
+import {
+  Children,
+  cloneElement,
+  isValidElement,
+  useEffect,
+  useState,
+  type CSSProperties,
+  type ReactElement,
+  type ReactNode
+} from 'react'
+
+interface StepProps {
+  /** Content or render function for the step */
+  children:
+    | ReactNode
+    | ((controls: { next: () => void; fastForward: () => void }) => ReactNode)
+  /** Callback to advance to the next step. Supplied by Sequence. */
+  next?: () => void
+  /** Callback to fast-forward the sequence. Supplied by Sequence. */
+  fastForward?: () => void
+}
+
+/**
+ * Represents a single step within a {@link Sequence}.
+ * The content can be static React nodes or a render function
+ * receiving `next` and `fastForward` callbacks to control progression.
+ */
+export const Step = ({ children, next, fastForward }: StepProps) => {
+  if (typeof children === 'function') {
+    return (
+      <>
+        {(
+          children as (controls: {
+            next: () => void
+            fastForward: () => void
+          }) => ReactNode
+        )({
+          next: next ?? (() => {}),
+          fastForward: fastForward ?? (() => {})
+        })}
+      </>
+    )
+  }
+  return <>{children}</>
+}
+
+interface TransitionProps {
+  /** Type of transition animation */
+  type?: 'fade-in'
+  /** Duration of the transition in milliseconds */
+  duration?: number
+  /** Content to render with the transition */
+  children: ReactNode
+}
+
+/**
+ * Animates its children using a simple CSS-based transition.
+ */
+export const Transition = ({
+  type = 'fade-in',
+  duration = 300,
+  children
+}: TransitionProps) => {
+  const [visible, setVisible] = useState(false)
+  useEffect(() => {
+    const id = requestAnimationFrame(() => setVisible(true))
+    return () => cancelAnimationFrame(id)
+  }, [])
+  const style: CSSProperties =
+    type === 'fade-in'
+      ? {
+          transition: `opacity ${duration}ms ease-in`,
+          opacity: visible ? 1 : 0
+        }
+      : {}
+  return <div style={style}>{children}</div>
+}
+
+interface SequenceProps {
+  /** Collection of Step elements */
+  children: ReactNode
+  /** Automatically advance through steps without user interaction */
+  autoplay?: boolean
+  /** Delay in milliseconds between automatic steps. Only used when autoplay is true */
+  delay?: number
+  /** Configuration for fast-forward behavior */
+  fastfoward?: FastForwardOptions
+  /** Text for the manual continue button */
+  continueLabel?: string
+  /** Text for the fast-forward skip button */
+  skipLabel?: string
+}
+
+/** Options for configuring fast-forward behavior */
+interface FastForwardOptions {
+  /** Whether fast-forwarding is enabled */
+  enabled?: boolean
+  /** Whether to skip to the end of the sequence when fast-forwarding */
+  toEnd?: boolean
+}
+
+/**
+ * Renders `Step` children sequentially, displaying only the active step.
+ * Each step receives a `next` callback to advance to the following step.
+ * If `autoplay` is true, steps advance automatically after an optional `delay`.
+ * Otherwise a "Continue" button is shown for non-interactive steps.
+ * A `fastForward` control is provided to skip steps or jump to the end
+ * based on the supplied `fastfoward` options. Both button labels may be
+ * customized via `continueLabel` and `skipLabel` props.
+ */
+export const Sequence = ({
+  children,
+  autoplay = false,
+  delay = 0,
+  fastfoward,
+  continueLabel = 'Continue',
+  skipLabel = 'Skip'
+}: SequenceProps) => {
+  const [index, setIndex] = useState(0)
+  const steps = Children.toArray(children).filter(
+    (child): child is ReactElement<StepProps> =>
+      isValidElement(child) && child.type === Step
+  )
+  const current = steps[index]
+  /**
+   * Advances to the next step in the sequence.
+   */
+  const handleNext = () => setIndex(i => Math.min(i + 1, steps.length - 1))
+  /** Fast-forwards either to the next step or the end of the sequence */
+  const handleFastForward = () => {
+    const { enabled = true, toEnd = false } = fastfoward ?? {}
+    if (!enabled) return
+    if (toEnd) {
+      setIndex(steps.length - 1)
+    } else {
+      handleNext()
+    }
+  }
+
+  useEffect(() => {
+    if (autoplay && index < steps.length - 1) {
+      const id = setTimeout(handleNext, delay)
+      return () => clearTimeout(id)
+    }
+  }, [autoplay, delay, index, steps.length])
+
+  if (!current) return null
+
+  const isInteractive = typeof current.props.children === 'function'
+  const showContinue = !autoplay && !isInteractive && index < steps.length - 1
+  const fastForwardEnabled = fastfoward?.enabled !== false
+  const showSkip = fastForwardEnabled && index < steps.length - 1
+
+  return (
+    <>
+      {cloneElement(current, {
+        next: handleNext,
+        fastForward: handleFastForward
+      })}
+      {showContinue && (
+        <button type='button' onClick={handleNext}>
+          {continueLabel}
+        </button>
+      )}
+      {showSkip && (
+        <button type='button' onClick={handleFastForward}>
+          {skipLabel}
+        </button>
+      )}
+    </>
+  )
+}
+
+export {
+  type SequenceProps,
+  type StepProps,
+  type FastForwardOptions,
+  type TransitionProps
+}

--- a/apps/campfire/src/Sequence.tsx
+++ b/apps/campfire/src/Sequence.tsx
@@ -71,8 +71,8 @@ export const Transition = ({
 }: TransitionProps) => {
   const [visible, setVisible] = useState(false)
   useEffect(() => {
-    const id = requestAnimationFrame(() => setVisible(true))
-    return () => cancelAnimationFrame(id)
+    const id = setTimeout(() => setVisible(true), 0)
+    return () => clearTimeout(id)
   }, [])
   const style: CSSProperties =
     type === 'fade-in'

--- a/apps/campfire/src/Sequence.tsx
+++ b/apps/campfire/src/Sequence.tsx
@@ -89,6 +89,10 @@ interface SequenceProps {
   continueLabel?: string
   /** Text for the fast-forward skip button */
   skipLabel?: string
+  /** Accessible label for the manual continue button */
+  continueAriaLabel?: string
+  /** Accessible label for the fast-forward skip button */
+  skipAriaLabel?: string
 }
 
 /** Options for configuring fast-forward behavior */
@@ -105,8 +109,9 @@ interface FastForwardOptions {
  * If `autoplay` is true, steps advance automatically after an optional `delay`.
  * Otherwise a "Continue" button is shown for non-interactive steps.
  * A `fastForward` control is provided to skip steps or jump to the end
- * based on the supplied `fastForward` options. Both button labels may be
- * customized via `continueLabel` and `skipLabel` props.
+ * based on the supplied `fastForward` options. Button text and accessible
+ * labels may be customized via `continueLabel`, `skipLabel`,
+ * `continueAriaLabel`, and `skipAriaLabel` props.
  */
 export const Sequence = ({
   children,
@@ -114,7 +119,9 @@ export const Sequence = ({
   delay = 0,
   fastForward,
   continueLabel = 'Continue',
-  skipLabel = 'Skip'
+  skipLabel = 'Skip',
+  continueAriaLabel = 'Continue to next step',
+  skipAriaLabel
 }: SequenceProps) => {
   const [index, setIndex] = useState(0)
   const steps = Children.toArray(children).filter(
@@ -150,6 +157,8 @@ export const Sequence = ({
   const showContinue = !autoplay && !isInteractive && index < steps.length - 1
   const fastForwardEnabled = fastForward?.enabled !== false
   const showSkip = fastForwardEnabled && index < steps.length - 1
+  const skipAria =
+    skipAriaLabel ?? (fastForward?.toEnd ? 'Skip to end' : 'Skip to next step')
 
   return (
     <>
@@ -158,12 +167,16 @@ export const Sequence = ({
         fastForward: handleFastForward
       })}
       {showContinue && (
-        <button type='button' onClick={handleNext}>
+        <button
+          type='button'
+          onClick={handleNext}
+          aria-label={continueAriaLabel}
+        >
           {continueLabel}
         </button>
       )}
       {showSkip && (
-        <button type='button' onClick={handleFastForward}>
+        <button type='button' onClick={handleFastForward} aria-label={skipAria}>
           {skipLabel}
         </button>
       )}

--- a/apps/campfire/src/Sequence.tsx
+++ b/apps/campfire/src/Sequence.tsx
@@ -115,7 +115,8 @@ interface FastForwardOptions {
  * Otherwise a "Continue" button is shown for non-interactive steps.
  * A `fastForward` control is provided to skip steps or jump to the end
  * based on the supplied `fastForward` options. Both button labels may be
- * customized via `continueLabel` and `skipLabel` props.
+ * customized via `continueLabel` and `skipLabel` props. Cannot contain
+ * another `Sequence` as a direct child.
  */
 export const Sequence = ({
   children,
@@ -126,6 +127,13 @@ export const Sequence = ({
   skipLabel = 'Skip'
 }: SequenceProps) => {
   const [index, setIndex] = useState(0)
+  if (
+    Children.toArray(children).some(
+      child => isValidElement(child) && child.type === Sequence
+    )
+  ) {
+    throw new Error('Sequence cannot be the child of a Sequence')
+  }
   const steps = Children.toArray(children).filter(
     (child): child is ReactElement<StepProps> =>
       isValidElement(child) && child.type === Step

--- a/apps/campfire/src/Sequence.tsx
+++ b/apps/campfire/src/Sequence.tsx
@@ -84,7 +84,7 @@ interface SequenceProps {
   /** Delay in milliseconds between automatic steps. Only used when autoplay is true */
   delay?: number
   /** Configuration for fast-forward behavior */
-  fastfoward?: FastForwardOptions
+  fastForward?: FastForwardOptions
   /** Text for the manual continue button */
   continueLabel?: string
   /** Text for the fast-forward skip button */
@@ -105,14 +105,14 @@ interface FastForwardOptions {
  * If `autoplay` is true, steps advance automatically after an optional `delay`.
  * Otherwise a "Continue" button is shown for non-interactive steps.
  * A `fastForward` control is provided to skip steps or jump to the end
- * based on the supplied `fastfoward` options. Both button labels may be
+ * based on the supplied `fastForward` options. Both button labels may be
  * customized via `continueLabel` and `skipLabel` props.
  */
 export const Sequence = ({
   children,
   autoplay = false,
   delay = 0,
-  fastfoward,
+  fastForward,
   continueLabel = 'Continue',
   skipLabel = 'Skip'
 }: SequenceProps) => {
@@ -128,7 +128,7 @@ export const Sequence = ({
   const handleNext = () => setIndex(i => Math.min(i + 1, steps.length - 1))
   /** Fast-forwards either to the next step or the end of the sequence */
   const handleFastForward = () => {
-    const { enabled = true, toEnd = false } = fastfoward ?? {}
+    const { enabled = true, toEnd = false } = fastForward ?? {}
     if (!enabled) return
     if (toEnd) {
       setIndex(steps.length - 1)
@@ -148,7 +148,7 @@ export const Sequence = ({
 
   const isInteractive = typeof current.props.children === 'function'
   const showContinue = !autoplay && !isInteractive && index < steps.length - 1
-  const fastForwardEnabled = fastfoward?.enabled !== false
+  const fastForwardEnabled = fastForward?.enabled !== false
   const showSkip = fastForwardEnabled && index < steps.length - 1
 
   return (

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,0 @@
-console.log('Hello via Bun!')
-export { applyUserStyles } from 'campfire/src/Story.tsx'
-export { evaluateUserScript } from 'campfire/src/Story.tsx'


### PR DESCRIPTION
## Summary
- add Transition companion to Step for fade-in animations
- register Transition for rendering within passages and conditionals
- export Transition alongside Sequence and Step
- provide keyboard-friendly fast-forward via default Skip button
- remove root `index.ts` entry file
- allow customizing continue and skip button labels

## Testing
- `bun x prettier --write .`
- `bun tsc --noEmit && echo 'tsc ok'`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_6896cb7cbb008322b710388386c5f804