### PR TITLE
feat: support if directives in onExit

### DIFF
--- a/apps/campfire/__tests__/Passage.lifecycle.test.tsx
+++ b/apps/campfire/__tests__/Passage.lifecycle.test.tsx
@@ -120,6 +120,25 @@ describe('Passage lifecycle directives', () => {
     ).toBe(5)
   })
 
+  it('processes if directives inside onExit blocks', async () => {
+    const root = unified()
+      .use(remarkParse)
+      .use(remarkDirective)
+      .parse(':::if[false]\n:set[a=1]\n:::else\n:set[b=2]\n:::') as Root
+    const content = JSON.stringify(root.children)
+    const { unmount } = render(<OnExit content={content} />)
+    act(() => {
+      unmount()
+    })
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 0))
+    })
+    const data = useGameStore.getState().gameData as Record<string, unknown>
+    expect(data.a).toBeUndefined()
+    expect(data.b).toBe(2)
+    expect(useGameStore.getState().errors).toEqual([])
+  })
+
   it('executes onExit directives only once on unmount', async () => {
     const root = unified()
       .use(remarkParse)
@@ -204,7 +223,7 @@ describe('Passage lifecycle directives', () => {
 
     await waitFor(() => {
       expect(useGameStore.getState().errors).toEqual([
-        'onExit only supports data directives: set, setOnce, array, arrayOnce, unset'
+        'onExit only supports directives: set, setOnce, array, arrayOnce, unset, if'
       ])
       expect(logged).toHaveLength(1)
     })

--- a/apps/campfire/src/OnExit.tsx
+++ b/apps/campfire/src/OnExit.tsx
@@ -78,10 +78,10 @@ export const OnExit = ({ content }: OnExitProps) => {
    * Processes a block of nodes with the Campfire remark plugins.
    *
    * @param block - Nodes to execute.
+   * @param data - Game data for conditional evaluation.
    */
-  const runBlock = (block: RootContent[]) => {
-    const gameData = useGameStore.getState().gameData as Record<string, unknown>
-    const processed = resolveIf(block, gameData)
+  const runBlock = (block: RootContent[], data: Record<string, unknown>) => {
+    const processed = resolveIf(block, data)
     if (processed.length === 0) return
     const root: Root = { type: 'root', children: processed }
     unified()
@@ -97,7 +97,11 @@ export const OnExit = ({ content }: OnExitProps) => {
       const current = generationRef.current
       queueMicrotask(() => {
         if (generationRef.current === current && !cleanupRanRef.current) {
-          runBlock(clone(baseNodes))
+          const gameData = useGameStore.getState().gameData as Record<
+            string,
+            unknown
+          >
+          runBlock(clone(baseNodes), gameData)
           cleanupRanRef.current = true
         }
       })

--- a/apps/campfire/src/OnExit.tsx
+++ b/apps/campfire/src/OnExit.tsx
@@ -4,8 +4,12 @@ import remarkCampfire, {
   remarkCampfireIndentation
 } from '@/packages/remark-campfire'
 import type { RootContent, Root } from 'mdast'
+import type { ContainerDirective } from 'mdast-util-directive'
 import rfdc from 'rfdc'
+import { compile } from 'expression-eval'
 import { useDirectiveHandlers } from './useDirectiveHandlers'
+import { useGameStore } from '@/packages/use-game-store'
+import { getLabel, stripLabel } from './directives/helpers'
 
 const clone = rfdc()
 
@@ -27,12 +31,58 @@ export const OnExit = ({ content }: OnExitProps) => {
   const generationRef = useRef(0)
 
   /**
+   * Resolves `if` directives by evaluating their test expressions and
+   * recursively returning the content for the matching branch.
+   *
+   * @param nodes - Nodes to inspect.
+   * @returns Nodes with conditionals resolved.
+   */
+  const resolveIf = (nodes: RootContent[]): RootContent[] =>
+    nodes.flatMap(node => {
+      if (
+        node.type === 'containerDirective' &&
+        (node as ContainerDirective).name === 'if'
+      ) {
+        const container = node as ContainerDirective
+        const test = getLabel(container) || ''
+        let condition = false
+        try {
+          const fn = compile(test)
+          const data = useGameStore.getState().gameData as Record<
+            string,
+            unknown
+          >
+          condition = !!fn(data)
+        } catch {
+          condition = false
+        }
+        const children = stripLabel(container.children as RootContent[])
+        const elseIndex = children.findIndex(
+          child =>
+            child.type === 'containerDirective' &&
+            (child as ContainerDirective).name === 'else'
+        )
+        let branch: RootContent[] = []
+        if (condition) {
+          branch = elseIndex === -1 ? children : children.slice(0, elseIndex)
+        } else if (elseIndex !== -1) {
+          const elseNode = children[elseIndex] as ContainerDirective
+          branch = stripLabel(elseNode.children as RootContent[])
+        }
+        return resolveIf(branch)
+      }
+      return [node]
+    })
+
+  /**
    * Processes a block of nodes with the Campfire remark plugins.
    *
    * @param block - Nodes to execute.
    */
   const runBlock = (block: RootContent[]) => {
-    const root: Root = { type: 'root', children: block }
+    const processed = resolveIf(block)
+    if (processed.length === 0) return
+    const root: Root = { type: 'root', children: processed }
     unified()
       .use(remarkCampfireIndentation)
       .use(remarkCampfire, { handlers })

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -41,7 +41,8 @@ const ALLOWED_ONEXIT_DIRECTIVES = new Set([
   'setOnce',
   'array',
   'arrayOnce',
-  'unset'
+  'unset',
+  'if'
 ])
 
 export const useDirectiveHandlers = () => {
@@ -835,7 +836,7 @@ export const useDirectiveHandlers = () => {
     node.type === 'textDirective'
 
   /**
-   * Filters `onExit` directive children to allowed data directives.
+   * Filters `onExit` directive children to allowed directives.
    *
    * @param children - Raw nodes inside the directive.
    * @param allowed - Set of permitted directive names.
@@ -888,7 +889,7 @@ export const useDirectiveHandlers = () => {
     const [filtered, invalid] = filterOnExitChildren(rawChildren, allowed)
     if (invalid) {
       const allowedList = [...allowed].join(', ')
-      const msg = `onExit only supports data directives: ${allowedList}`
+      const msg = `onExit only supports directives: ${allowedList}`
       console.error(msg)
       addError(msg)
     }


### PR DESCRIPTION
## Summary
- allow `onExit` to include `if` directives
- evaluate conditional branches within `onExit`
- cover `onExit` `if` handling with tests and update error messaging

## Testing
- `bun tsc --diagnostics`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_6897efdb95b083229b2ae13d87e9b472