### PR TITLE
refactor: tree-shake react runtime imports

### DIFF
--- a/apps/campfire/src/If.tsx
+++ b/apps/campfire/src/If.tsx
@@ -1,5 +1,5 @@
 import { useMemo, type ReactNode } from 'react'
-import * as runtime from 'react/jsx-runtime'
+import { Fragment, jsx, jsxs } from 'react/jsx-runtime'
 import { unified } from 'unified'
 import remarkGfm from 'remark-gfm'
 import remarkCampfire from '@/packages/remark-campfire'
@@ -35,9 +35,9 @@ export const If = ({ test, content, fallback }: IfProps) => {
       .use(remarkRehype)
       .use(rehypeCampfire)
       .use(rehypeReact, {
-        Fragment: runtime.Fragment,
-        jsx: runtime.jsx,
-        jsxs: runtime.jsxs,
+        Fragment,
+        jsx,
+        jsxs,
         components: {
           button: LinkButton,
           trigger: TriggerButton,

--- a/apps/campfire/src/Passage.tsx
+++ b/apps/campfire/src/Passage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
-import * as runtime from 'react/jsx-runtime'
+import { Fragment, jsx, jsxs } from 'react/jsx-runtime'
 import { unified } from 'unified'
 import remarkParse from 'remark-parse'
 import remarkGfm from 'remark-gfm'
@@ -114,9 +114,9 @@ export const Passage = () => {
         .use(remarkRehype)
         .use(rehypeCampfire)
         .use(rehypeReact, {
-          Fragment: runtime.Fragment,
-          jsx: runtime.jsx,
-          jsxs: runtime.jsxs,
+          Fragment,
+          jsx,
+          jsxs,
           components: {
             button: LinkButton,
             trigger: TriggerButton,


### PR DESCRIPTION
## Summary
- replace wildcard React JSX runtime imports with named imports for tree shaking

## Testing
- `bun tsc`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_6898001c50a8832299b9322f291a53af