### PR TITLE
feat: add OnComplete component for Sequence

### DIFF
--- a/apps/campfire/src/OnComplete.tsx
+++ b/apps/campfire/src/OnComplete.tsx
@@ -11,6 +11,7 @@ export interface OnCompleteProps {
 
 /**
  * Executes serialized directive content when a sequence reaches its final step.
+ * Only one instance should be used within a `Sequence`.
  *
  * @param content - Serialized directive block to process on completion.
  * @param run - Internal flag indicating when to execute.

--- a/apps/campfire/src/OnComplete.tsx
+++ b/apps/campfire/src/OnComplete.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useRef } from 'react'
+import { useSerializedDirectiveRunner } from './useSerializedDirectiveRunner'
+
+/** Props for the `OnComplete` component. */
+export interface OnCompleteProps {
+  /** Serialized content to run when the sequence completes */
+  content: string
+  /** Internal flag to trigger execution. Supplied by Sequence. */
+  run?: boolean
+}
+
+/**
+ * Executes serialized directive content when a sequence reaches its final step.
+ *
+ * @param content - Serialized directive block to process on completion.
+ * @param run - Internal flag indicating when to execute.
+ */
+export const OnComplete = ({ content, run }: OnCompleteProps) => {
+  const execute = useSerializedDirectiveRunner(content)
+  const ranRef = useRef(false)
+
+  useEffect(() => {
+    if (run === undefined) {
+      console.error('OnComplete must be used within a Sequence')
+    }
+  }, [run])
+
+  useEffect(() => {
+    if (run) {
+      if (!ranRef.current) {
+        execute()
+        ranRef.current = true
+      }
+    } else {
+      ranRef.current = false
+    }
+  }, [run, execute])
+
+  return null
+}

--- a/apps/campfire/src/OnExit.tsx
+++ b/apps/campfire/src/OnExit.tsx
@@ -1,17 +1,5 @@
-import { useEffect, useMemo, useRef } from 'react'
-import { unified } from 'unified'
-import remarkCampfire, {
-  remarkCampfireIndentation
-} from '@/packages/remark-campfire'
-import type { RootContent, Root } from 'mdast'
-import type { ContainerDirective } from 'mdast-util-directive'
-import rfdc from 'rfdc'
-import { compile } from 'expression-eval'
-import { useDirectiveHandlers } from './useDirectiveHandlers'
-import { useGameStore } from '@/packages/use-game-store'
-import { getLabel, stripLabel } from './directives/helpers'
-
-const clone = rfdc()
+import { useEffect, useRef } from 'react'
+import { useSerializedDirectiveRunner } from './useSerializedDirectiveRunner'
 
 /** Props for the `OnExit` component. */
 interface OnExitProps {
@@ -25,70 +13,9 @@ interface OnExitProps {
  * @param content - Serialized directive block to process on exit.
  */
 export const OnExit = ({ content }: OnExitProps) => {
-  const handlers = useDirectiveHandlers()
-  const baseNodes = useMemo<RootContent[]>(() => JSON.parse(content), [content])
+  const run = useSerializedDirectiveRunner(content)
   const cleanupRanRef = useRef(false)
   const generationRef = useRef(0)
-
-  /**
-   * Resolves `if` directives by evaluating their test expressions and
-   * recursively returning the content for the matching branch.
-   *
-   * @param nodes - Nodes to inspect.
-   * @param data - Game data for expression evaluation.
-   * @returns Nodes with conditionals resolved.
-   */
-  const resolveIf = (
-    nodes: RootContent[],
-    data: Record<string, unknown>
-  ): RootContent[] =>
-    nodes.flatMap(node => {
-      if (
-        node.type === 'containerDirective' &&
-        (node as ContainerDirective).name === 'if'
-      ) {
-        const container = node as ContainerDirective
-        const test = getLabel(container) || ''
-        let condition = false
-        try {
-          const fn = compile(test)
-          condition = !!fn(data)
-        } catch {
-          condition = false
-        }
-        const children = stripLabel(container.children as RootContent[])
-        const elseIndex = children.findIndex(
-          child =>
-            child.type === 'containerDirective' &&
-            (child as ContainerDirective).name === 'else'
-        )
-        let branch: RootContent[] = []
-        if (condition) {
-          branch = elseIndex === -1 ? children : children.slice(0, elseIndex)
-        } else if (elseIndex !== -1) {
-          const elseNode = children[elseIndex] as ContainerDirective
-          branch = stripLabel(elseNode.children as RootContent[])
-        }
-        return resolveIf(branch, data)
-      }
-      return [node]
-    })
-
-  /**
-   * Processes a block of nodes with the Campfire remark plugins.
-   *
-   * @param block - Nodes to execute.
-   * @param data - Game data for conditional evaluation.
-   */
-  const runBlock = (block: RootContent[], data: Record<string, unknown>) => {
-    const processed = resolveIf(block, data)
-    if (processed.length === 0) return
-    const root: Root = { type: 'root', children: processed }
-    unified()
-      .use(remarkCampfireIndentation)
-      .use(remarkCampfire, { handlers })
-      .runSync(root)
-  }
 
   useEffect(() => {
     generationRef.current++
@@ -97,16 +24,12 @@ export const OnExit = ({ content }: OnExitProps) => {
       const current = generationRef.current
       queueMicrotask(() => {
         if (generationRef.current === current && !cleanupRanRef.current) {
-          const gameData = useGameStore.getState().gameData as Record<
-            string,
-            unknown
-          >
-          runBlock(clone(baseNodes), gameData)
+          run()
           cleanupRanRef.current = true
         }
       })
     }
-  }, [baseNodes])
+  }, [run])
 
   return null
 }

--- a/apps/campfire/src/Sequence.tsx
+++ b/apps/campfire/src/Sequence.tsx
@@ -4,12 +4,12 @@ import {
   isValidElement,
   useEffect,
   useLayoutEffect,
-  useMemo,
   useState,
   type CSSProperties,
   type ReactElement,
   type ReactNode
 } from 'react'
+import { OnComplete, type OnCompleteProps } from './OnComplete'
 
 interface StepProps {
   /** Content or render function for the step */
@@ -155,13 +155,14 @@ export const Sequence = ({
   rewindAriaLabel
 }: SequenceProps) => {
   const [index, setIndex] = useState(0)
-  const steps = useMemo(
-    () =>
-      Children.toArray(children).filter(
-        (child): child is ReactElement<StepProps> =>
-          isValidElement(child) && child.type === Step
-      ),
-    [children]
+  const childArray = Children.toArray(children)
+  const completeElement = childArray.find(
+    (child): child is ReactElement<OnCompleteProps> =>
+      isValidElement(child) && child.type === OnComplete
+  )
+  const steps = childArray.filter(
+    (child): child is ReactElement<StepProps> =>
+      isValidElement(child) && child.type === Step
   )
   const current = steps[index]
   useEffect(() => {
@@ -221,6 +222,8 @@ export const Sequence = ({
         fastForward: handleFastForward,
         rewind: handleRewind
       })}
+      {completeElement &&
+        cloneElement(completeElement, { run: index === steps.length - 1 })}
       {showRewind && (
         <button type='button' onClick={handleRewind} aria-label={rewindAria}>
           {rewindLabel}

--- a/apps/campfire/src/Sequence.tsx
+++ b/apps/campfire/src/Sequence.tsx
@@ -4,6 +4,7 @@ import {
   isValidElement,
   useEffect,
   useLayoutEffect,
+  useRef,
   useState,
   type CSSProperties,
   type ReactElement,
@@ -209,7 +210,19 @@ export const Sequence = ({
     }
   }, [autoplay, delay, index, steps.length])
 
+  /** Tracks whether the completion handler has already executed. */
+  const completeRan = useRef(false)
+
+  useEffect(() => {
+    completeRan.current = false
+  }, [steps.length])
+
   if (!current) return null
+
+  const runComplete = index === steps.length - 1 && !completeRan.current
+  if (runComplete) {
+    completeRan.current = true
+  }
 
   const isInteractive = typeof current.props.children === 'function'
   const showContinue = !autoplay && !isInteractive && index < steps.length - 1
@@ -230,8 +243,7 @@ export const Sequence = ({
         fastForward: handleFastForward,
         rewind: handleRewind
       })}
-      {completeElement &&
-        cloneElement(completeElement, { run: index === steps.length - 1 })}
+      {completeElement && cloneElement(completeElement, { run: runComplete })}
       {showRewind && (
         <button type='button' onClick={handleRewind} aria-label={rewindAria}>
           {rewindLabel}

--- a/apps/campfire/src/Sequence.tsx
+++ b/apps/campfire/src/Sequence.tsx
@@ -140,6 +140,8 @@ interface RewindOptions {
  * based on the supplied `fastForward` options. Button text and accessible
  * labels may be customized via `continueLabel`, `skipLabel`,
  * `continueAriaLabel`, and `skipAriaLabel` props.
+ * Accepts at most one `OnComplete` child; if multiple are provided only the
+ * first will run and a warning is logged.
  */
 export const Sequence = ({
   children,
@@ -156,10 +158,16 @@ export const Sequence = ({
 }: SequenceProps) => {
   const [index, setIndex] = useState(0)
   const childArray = Children.toArray(children)
-  const completeElement = childArray.find(
+  const completeElements = childArray.filter(
     (child): child is ReactElement<OnCompleteProps> =>
       isValidElement(child) && child.type === OnComplete
   )
+  if (completeElements.length > 1) {
+    console.warn(
+      'Sequence accepts only one <OnComplete> component; additional instances will be ignored.'
+    )
+  }
+  const completeElement = completeElements[0]
   const steps = childArray.filter(
     (child): child is ReactElement<StepProps> =>
       isValidElement(child) && child.type === Step

--- a/apps/campfire/src/useSerializedDirectiveRunner.ts
+++ b/apps/campfire/src/useSerializedDirectiveRunner.ts
@@ -1,0 +1,76 @@
+import { useCallback, useMemo } from 'react'
+import { unified } from 'unified'
+import remarkCampfire, {
+  remarkCampfireIndentation
+} from '@/packages/remark-campfire'
+import type { RootContent, Root } from 'mdast'
+import type { ContainerDirective } from 'mdast-util-directive'
+import rfdc from 'rfdc'
+import { compile } from 'expression-eval'
+import { useDirectiveHandlers } from './useDirectiveHandlers'
+import { useGameStore } from '@/packages/use-game-store'
+import { getLabel, stripLabel } from './directives/helpers'
+
+const clone = rfdc()
+
+/**
+ * Creates a runner for executing serialized directive content.
+ *
+ * @param content - Serialized directive block to execute.
+ * @returns Function that runs the block with current game data.
+ */
+export const useSerializedDirectiveRunner = (content: string) => {
+  const handlers = useDirectiveHandlers()
+  const baseNodes = useMemo<RootContent[]>(() => JSON.parse(content), [content])
+
+  const resolveIf = (
+    nodes: RootContent[],
+    data: Record<string, unknown>
+  ): RootContent[] =>
+    nodes.flatMap(node => {
+      if (
+        node.type === 'containerDirective' &&
+        (node as ContainerDirective).name === 'if'
+      ) {
+        const container = node as ContainerDirective
+        const test = getLabel(container) || ''
+        let condition = false
+        try {
+          const fn = compile(test)
+          condition = !!fn(data)
+        } catch {
+          condition = false
+        }
+        const children = stripLabel(container.children as RootContent[])
+        const elseIndex = children.findIndex(
+          child =>
+            child.type === 'containerDirective' &&
+            (child as ContainerDirective).name === 'else'
+        )
+        let branch: RootContent[] = []
+        if (condition) {
+          branch = elseIndex === -1 ? children : children.slice(0, elseIndex)
+        } else if (elseIndex !== -1) {
+          const elseNode = children[elseIndex] as ContainerDirective
+          branch = stripLabel(elseNode.children as RootContent[])
+        }
+        return resolveIf(branch, data)
+      }
+      return [node]
+    })
+
+  const runBlock = (block: RootContent[], data: Record<string, unknown>) => {
+    const processed = resolveIf(block, data)
+    if (processed.length === 0) return
+    const root: Root = { type: 'root', children: processed }
+    unified()
+      .use(remarkCampfireIndentation)
+      .use(remarkCampfire, { handlers })
+      .runSync(root)
+  }
+
+  return useCallback(() => {
+    const gameData = useGameStore.getState().gameData as Record<string, unknown>
+    runBlock(clone(baseNodes), gameData)
+  }, [baseNodes, handlers])
+}


### PR DESCRIPTION
## Summary
- add OnComplete component for running directives when a Sequence finishes
- execute OnComplete via Sequence and warn when misused
- refactor OnExit and OnComplete to share directive runner

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68980b833ea8832290aeff0211fdd453