### PR TITLE
feat: allow standalone OnComplete usage

### DIFF
--- a/apps/campfire/__tests__/Sequence.test.tsx
+++ b/apps/campfire/__tests__/Sequence.test.tsx
@@ -404,27 +404,4 @@ describe('Sequence', () => {
     expect(gameData.b).toBeUndefined()
     console.warn = orig
   })
-
-  it('warns when OnComplete is used outside of Sequence', async () => {
-    resetStores()
-    const root = unified()
-      .use(remarkParse)
-      .use(remarkDirective)
-      .parse(':set[x=1]') as Root
-    const content = JSON.stringify(root.children)
-    const logged: unknown[] = []
-    const orig = console.error
-    console.error = (...args: unknown[]) => {
-      logged.push(args)
-    }
-    render(<OnComplete content={content} />)
-    await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 0))
-    })
-    expect(logged).toHaveLength(1)
-    expect(
-      (useGameStore.getState().gameData as Record<string, unknown>).x
-    ).toBeUndefined()
-    console.error = orig
-  })
 })

--- a/apps/campfire/src/OnComplete.tsx
+++ b/apps/campfire/src/OnComplete.tsx
@@ -11,20 +11,15 @@ export interface OnCompleteProps {
 
 /**
  * Executes serialized directive content when a sequence reaches its final step.
- * Only one instance should be used within a `Sequence`.
+ * Only one instance should be used within a `Sequence`,
+ * though it can also be used independently by manually controlling `run`.
  *
  * @param content - Serialized directive block to process on completion.
- * @param run - Internal flag indicating when to execute.
+ * @param run - Flag indicating when to execute.
  */
 export const OnComplete = ({ content, run }: OnCompleteProps) => {
   const execute = useSerializedDirectiveRunner(content)
   const ranRef = useRef(false)
-
-  useEffect(() => {
-    if (run === undefined) {
-      console.error('OnComplete must be used within a Sequence')
-    }
-  }, [run])
 
   useEffect(() => {
     if (run) {


### PR DESCRIPTION
## Summary
- allow `OnComplete` to be used outside of `Sequence`
- drop warning when `OnComplete` lacks a parent `Sequence`
- adjust tests accordingly

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_6898925cfea88322b8ff9267f32b305c