### PR TITLE
feat: update :random directive API

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,16 +121,24 @@ Operations that set, update, or remove scalar values.
   :setOnce[visited=true]
   ```
 
-  Replace `visited` with the key to lock on first use.
+Replace `visited` with the key to lock on first use.
 
-- `random`: Assign a random integer. This directive is leaf-only and cannot wrap
+- `random`: Assign a random value. This directive is leaf-only and cannot wrap
   content.
 
   ```md
-  :random{key=HP min=MIN max=MAX}
+  :random[HP]{min=MIN max=MAX}
   ```
 
   Replace `HP` with the key and `MIN`/`MAX` with bounds.
+
+  ```md
+  :random[pick]{from=[A,B,C]}
+  :random[pick]{from=ITEMS}
+  ```
+
+  Replace `pick` with the key to store the result and supply either a literal
+  array or a state key after `from`.
 
 - `unset`: Remove a key from state. This directive is leaf-only and cannot wrap
   content.

--- a/apps/campfire/__tests__/Passage.state.test.tsx
+++ b/apps/campfire/__tests__/Passage.state.test.tsx
@@ -483,7 +483,7 @@ describe('Passage game state directives', () => {
       type: 'element',
       tagName: 'tw-passagedata',
       properties: { pid: '1', name: 'Start' },
-      children: [{ type: 'text', value: ':random{key=pick from=items}' }]
+      children: [{ type: 'text', value: ':random[pick]{from=items}' }]
     }
 
     useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
@@ -494,6 +494,25 @@ describe('Passage game state directives', () => {
       const { gameData } = useGameStore.getState()
       expect(['a', 'b', 'c']).toContain(gameData.pick)
       expect(gameData.items).toEqual(['a', 'b', 'c'])
+    })
+  })
+
+  it('stores a random integer within bounds with random directive', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [{ type: 'text', value: ':random[roll]{min=1 max=6}' }]
+    }
+
+    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+
+    render(<Passage />)
+
+    await waitFor(() => {
+      const { gameData } = useGameStore.getState()
+      expect(gameData.roll).toBeGreaterThanOrEqual(1)
+      expect(gameData.roll).toBeLessThanOrEqual(6)
     })
   })
 

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -402,24 +402,33 @@ export const useDirectiveHandlers = () => {
     return index
   }
 
+  /**
+   * Stores a random value in the provided key. Supports selecting a random
+   * item from an array or generating a random integer within a range.
+   *
+   * @param directive - The `random` directive node being processed.
+   * @param parent - The parent AST node containing this directive.
+   * @param index - The index of the directive within its parent.
+   */
   const handleRandom: DirectiveHandler = (directive, parent, index) => {
-    const { attrs, key } = extractAttributes(
+    const label = (directive as { label?: string }).label || toString(directive)
+    const key = ensureKey(label?.trim(), parent, index)
+    if (!key) return index
+
+    const { attrs } = extractAttributes(
       directive,
       parent,
       index,
       {
-        key: { type: 'string', required: true },
-        options: { type: 'array' },
         from: { type: 'array' },
         min: { type: 'number' },
         max: { type: 'number' }
       },
-      { state: gameData, keyAttr: 'key' }
+      { state: gameData }
     )
-    if (!key) return index
 
     let value: unknown
-    const optionList = (attrs.options || attrs.from) as unknown[] | undefined
+    const optionList = attrs.from as unknown[] | undefined
     if (optionList && optionList.length) {
       value = getRandomItem(optionList)
     } else {


### PR DESCRIPTION
## Summary
- switch `:random` to bracket key syntax
- allow choosing from array or state key via `from`
- document and test new `:random` directive variants

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68989ba88c748322bf30d77a87a05fa0