### PR TITLE
fix: handle string arrays in random directive

### DIFF
--- a/apps/campfire/__tests__/Passage.state.test.tsx
+++ b/apps/campfire/__tests__/Passage.state.test.tsx
@@ -497,6 +497,24 @@ describe('Passage game state directives', () => {
     })
   })
 
+  it('handles string arrays in random directive', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [{ type: 'text', value: ":random[pick]{from=['a','b','c']}" }]
+    }
+
+    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+
+    render(<Passage />)
+
+    await waitFor(() => {
+      const { gameData } = useGameStore.getState()
+      expect(['a', 'b', 'c']).toContain(gameData.pick)
+    })
+  })
+
   it('stores a random integer within bounds with random directive', async () => {
     const passage: Element = {
       type: 'element',

--- a/packages/remark-campfire/__tests__/attributes.test.ts
+++ b/packages/remark-campfire/__tests__/attributes.test.ts
@@ -38,6 +38,11 @@ describe('remarkCampfire attribute parsing', () => {
     expect(node?.attributes).toEqual({ items: "1,'two'" })
   })
 
+  it('parses attribute values containing brackets', () => {
+    const node = parseDirective(":test{items=['one','two']}")
+    expect(node?.attributes).toEqual({ items: "['one','two']" })
+  })
+
   it('ignores attributes with unsafe characters', () => {
     const node = parseDirective(":test{items=1,'<script>'}")
     expect(node?.attributes).toEqual({})

--- a/packages/remark-campfire/index.ts
+++ b/packages/remark-campfire/index.ts
@@ -90,7 +90,7 @@ const parseFallbackAttributes = (
   const match = textNode.value.match(/^\{([\w-]+)=([^}]*)\}$/)
   if (match) {
     const [, name, raw] = match
-    if (/^[\w\s.,'"`-]*$/.test(raw)) {
+    if (/^[\w\s.,'"`\[\]-]*$/.test(raw)) {
       directive.attributes = { [name]: raw }
       parent.children.splice(index + 1, 1)
     } else {


### PR DESCRIPTION
## Summary
- allow square brackets in fallback directive attribute parsing
- test parsing attribute values with brackets
- support string arrays in random directive

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_6898afcc528c8322bfc369a838056870