### PR TITLE
feat: support batch in onExit and prevent nested batches

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,8 +340,8 @@ Run directives on specific passage events or group actions.
   ```
 
   Only one `onExit` block is allowed per passage. Its contents are hidden, and it
-  supports only the following directives: `if`, `set`, `setOnce`, `array`, `arrayOnce`, and
-  `unset`.
+  supports only the following directives: `if`, `set`, `setOnce`, `array`, `arrayOnce`, `unset`, and
+  `batch`.
 
 - `trigger`: Render a button that runs directives when clicked.
 

--- a/apps/campfire/__tests__/Passage.lifecycle.test.tsx
+++ b/apps/campfire/__tests__/Passage.lifecycle.test.tsx
@@ -138,6 +138,25 @@ describe('Passage lifecycle directives', () => {
     expect(useGameStore.getState().errors).toEqual([])
   })
 
+  it('runs batch directives inside onExit blocks', async () => {
+    const root = unified()
+      .use(remarkParse)
+      .use(remarkDirective)
+      .parse(':::batch\n:set[a=1]\n:push{key=items value=sword}\n:::') as Root
+    const content = JSON.stringify(root.children)
+    const { unmount } = render(<OnExit content={content} />)
+    act(() => {
+      unmount()
+    })
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 0))
+    })
+    const data = useGameStore.getState().gameData as Record<string, unknown>
+    expect(data.a).toBe(1)
+    expect(data.items).toEqual(['sword'])
+    expect(useGameStore.getState().errors).toEqual([])
+  })
+
   it('executes onExit directives only once on unmount', async () => {
     const root = unified()
       .use(remarkParse)
@@ -218,7 +237,7 @@ describe('Passage lifecycle directives', () => {
 
     await waitFor(() => {
       expect(useGameStore.getState().errors).toEqual([
-        'onExit only supports directives: set, setOnce, array, arrayOnce, unset, if'
+        'onExit only supports directives: set, setOnce, array, arrayOnce, unset, if, batch'
       ])
       expect(logged).toHaveLength(1)
     })

--- a/apps/campfire/__tests__/Passage.state.test.tsx
+++ b/apps/campfire/__tests__/Passage.state.test.tsx
@@ -207,6 +207,34 @@ describe('Passage game state directives', () => {
     expect(unsetCalls).toEqual(['old'])
     useGameStore.setState({ unsetGameData: origUnset })
   })
+
+  it('ignores nested batch directives', async () => {
+    useGameStore.getState().init({})
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value: ':::batch\n:set[a=1]\n:::batch\n:set[a=2]\n:::\n:::'
+        }
+      ]
+    }
+
+    useStoryDataStore.setState({
+      passages: [passage],
+      currentPassageId: '1'
+    })
+
+    render(<Passage />)
+
+    await waitFor(() =>
+      expect(
+        (useGameStore.getState().gameData as Record<string, unknown>).a
+      ).toBe(1)
+    )
+  })
   it('locks keys with setOnce', async () => {
     const passage: Element = {
       type: 'element',

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -783,7 +783,8 @@ export const useDirectiveHandlers = () => {
       const msg = 'Nested batch directives are not allowed'
       console.error(msg)
       addError(msg)
-      return removeNode(parent, index)
+      parent.children.splice(index, 1)
+      return index
     }
     const container = directive as ContainerDirective
     const content = stripLabel(container.children as RootContent[])

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -42,7 +42,8 @@ const ALLOWED_ONEXIT_DIRECTIVES = new Set([
   'array',
   'arrayOnce',
   'unset',
-  'if'
+  'if',
+  'batch'
 ])
 
 /**
@@ -771,9 +772,19 @@ export const useDirectiveHandlers = () => {
   /**
    * Executes a block of directives against a temporary state and commits
    * the resulting changes in a single update.
+   * Nested batch directives are ignored.
    */
   const handleBatch: DirectiveHandler = (directive, parent, index) => {
     if (!parent || typeof index !== 'number') return
+    if (
+      parent.type === 'containerDirective' &&
+      (parent as ContainerDirective).name === 'batch'
+    ) {
+      const msg = 'Nested batch directives are not allowed'
+      console.error(msg)
+      addError(msg)
+      return removeNode(parent, index)
+    }
     const container = directive as ContainerDirective
     const content = stripLabel(container.children as RootContent[])
 


### PR DESCRIPTION
## Summary
- allow `batch` directives inside `onExit`
- reject nested `batch` directives
- document new `onExit` support for `batch`

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_6898b6b2c0048322951150ff2d84334a