### PR TITLE
fix(onExit): remove stray colons after batch

### DIFF
--- a/apps/campfire/__tests__/Passage.lifecycle.test.tsx
+++ b/apps/campfire/__tests__/Passage.lifecycle.test.tsx
@@ -158,6 +158,29 @@ describe('Passage lifecycle directives', () => {
     expect(useGameStore.getState().errors).toEqual([])
   })
 
+  it('does not render stray colons when batch is inside onExit', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value: 'Visible\n:::onExit\n:::batch\n:set[a=1]\n:::\n:::\n'
+        }
+      ]
+    }
+
+    useStoryDataStore.setState({
+      passages: [passage],
+      currentPassageId: '1'
+    })
+
+    render(<Passage />)
+    await screen.findByText('Visible')
+    expect(screen.queryByText(':::')).toBeNull()
+  })
+
   it('executes onExit directives only once on unmount', async () => {
     const root = unified()
       .use(remarkParse)

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -986,6 +986,16 @@ export const useDirectiveHandlers = () => {
     const newIndex = replaceWithIndentation(directive, parent, index, [
       node as RootContent
     ])
+    const next = parent.children[newIndex + 1]
+    if (
+      next &&
+      next.type === 'paragraph' &&
+      next.children.length === 1 &&
+      next.children[0].type === 'text' &&
+      next.children[0].value.trim() === ':::'
+    ) {
+      parent.children.splice(newIndex + 1, 1)
+    }
     return [SKIP, newIndex]
   }
 


### PR DESCRIPTION
## Summary
- ensure onExit handler strips stray `:::` nodes left after nested directives
- test that batch in onExit no longer renders `:::`

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_6898caed798c8322a18d91943fff5a53