### PR TITLE
feat: add sequence directive

### DIFF
--- a/apps/campfire/__tests__/Passage.sequence.test.tsx
+++ b/apps/campfire/__tests__/Passage.sequence.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach } from 'bun:test'
+import { render, screen, act } from '@testing-library/preact'
+import i18next from 'i18next'
+import { initReactI18next } from 'react-i18next'
+import type { Element } from 'hast'
+import { Passage } from '../src/Passage'
+import { useStoryDataStore } from '@/packages/use-story-data-store'
+import { useGameStore } from '@/packages/use-game-store'
+import { resetStores } from './helpers'
+
+describe('Passage sequence directive', () => {
+  beforeEach(async () => {
+    document.body.innerHTML = ''
+    resetStores()
+    if (!i18next.isInitialized) {
+      await i18next.use(initReactI18next).init({
+        lng: 'en-US',
+        resources: {}
+      })
+    } else {
+      await i18next.changeLanguage('en-US')
+      i18next.services.resourceStore.data = {}
+    }
+  })
+
+  it('renders sequence steps and runs onComplete content', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value:
+            ':::sequence\n:::step\nFirst\n:::\n:::step\nSecond\n:::\n:::onComplete\n:set[done=true]\n:::\n:::\n'
+        }
+      ]
+    }
+
+    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+    render(<Passage />)
+
+    expect(await screen.findByText('First')).toBeInTheDocument()
+    expect(await screen.findByText('Second')).toBeInTheDocument()
+  })
+})

--- a/apps/campfire/src/Passage.tsx
+++ b/apps/campfire/src/Passage.tsx
@@ -22,6 +22,7 @@ import { If } from './If'
 import { Show } from './Show'
 import { OnExit } from './OnExit'
 import { Sequence, Step, Transition } from './Sequence'
+import { OnComplete } from './OnComplete'
 
 const DIRECTIVE_MARKER_PATTERN = '(:::[^\\n]*|:[^\\n]*|<<)'
 
@@ -126,7 +127,8 @@ export const Passage = () => {
             onExit: OnExit,
             sequence: Sequence,
             step: Step,
-            transition: Transition
+            transition: Transition,
+            onComplete: OnComplete
           }
         }),
     [handlers]


### PR DESCRIPTION
## Summary
- add sequence, step, transition, and onComplete directive handlers
- register new components for passage rendering
- test sequence directive behavior

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_689922df46648322b8ceaacf7a28b88c