### PR TITLE
fix: support random directive attributes in batch blocks

### DIFF
--- a/apps/campfire/__tests__/Passage.lifecycle.test.tsx
+++ b/apps/campfire/__tests__/Passage.lifecycle.test.tsx
@@ -176,6 +176,23 @@ describe('Passage lifecycle directives', () => {
     expect(data.roll).toBeLessThanOrEqual(6)
   })
 
+  it('handles array-based random directives inside batch within onExit blocks', async () => {
+    const root = unified()
+      .use(remarkParse)
+      .use(remarkDirective)
+      .parse(":::batch\n:random[item]{from=['a','b','c']}\n:::") as Root
+    const content = JSON.stringify(root.children)
+    const { unmount } = render(<OnExit content={content} />)
+    act(() => {
+      unmount()
+    })
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 0))
+    })
+    const data = useGameStore.getState().gameData as Record<string, unknown>
+    expect(['a', 'b', 'c']).toContain(data.item)
+  })
+
   it('locks keys with randomOnce inside onExit blocks', async () => {
     const root = unified()
       .use(remarkParse)

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -140,6 +140,19 @@ export const useDirectiveHandlers = () => {
   }
 
   /**
+   * Preprocesses directive children to handle fallback attributes before validation.
+   * Runs the remarkCampfire plugin without handlers so only attribute parsing occurs.
+   *
+   * @param nodes - Directive child nodes to preprocess.
+   * @returns The mutated array of child nodes.
+   */
+  const preprocessBlock = (nodes: RootContent[]): RootContent[] => {
+    const root: Root = { type: 'root', children: nodes }
+    unified().use(remarkCampfireIndentation).use(remarkCampfire).runSync(root)
+    return root.children as RootContent[]
+  }
+
+  /**
    * Resets per-passage directive state such as checkpoints and onExit usage.
    * Clears existing checkpoint identifiers and error flags, resets OnExit tracking,
    * and updates the last processed passage identifier.
@@ -808,8 +821,9 @@ export const useDirectiveHandlers = () => {
     const container = directive as ContainerDirective
     const allowed = ALLOWED_BATCH_DIRECTIVES
     const rawChildren = stripLabel(container.children as RootContent[])
+    const processedChildren = preprocessBlock(rawChildren)
     const [filtered, invalid, nested] = filterDirectiveChildren(
-      rawChildren,
+      processedChildren,
       allowed,
       BANNED_BATCH_DIRECTIVES
     )


### PR DESCRIPTION
## Summary
- handle fallback attribute parsing before validating batch contents
- test random directive with array values inside batch on exit

## Testing
- `bun tsc --noEmit`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_689930ad788c8322abc8f4bebf167752