### PR TITLE
fix: avoid redundant range updates

### DIFF
--- a/apps/campfire/__tests__/StateManager.test.ts
+++ b/apps/campfire/__tests__/StateManager.test.ts
@@ -58,4 +58,12 @@ describe('StateManager', () => {
     manager.setRange('hp', 0, 10, 20)
     expect(manager.getValue('hp')).toEqual({ min: 0, max: 10, value: 10 })
   })
+
+  it('avoids updates when range value is unchanged', () => {
+    const manager = createStateManager<Record<string, unknown>>()
+    manager.setRange('hp', 0, 10, 5)
+    const initial = useGameStore.getState().gameData.hp
+    manager.setRange('hp', 0, 10, 5)
+    expect(useGameStore.getState().gameData.hp).toBe(initial)
+  })
 })

--- a/apps/campfire/src/stateManager.ts
+++ b/apps/campfire/src/stateManager.ts
@@ -129,7 +129,18 @@ export class StateManager<T extends Record<string, unknown>> {
     }
   }
 
-  /** Stores a range value at the provided path. */
+  /**
+   * Stores a range value at the provided path.
+   *
+   * Avoids triggering state updates when the clamped value does not change,
+   * preventing unnecessary re-renders.
+   *
+   * @param path - Dot separated path where the range should be stored.
+   * @param min - Minimum allowed value for the range.
+   * @param max - Maximum allowed value for the range.
+   * @param value - Current value to assign within the range.
+   * @param opts - Additional options controlling assignment behavior.
+   */
   setRange = (
     path: string,
     min: number,
@@ -137,7 +148,17 @@ export class StateManager<T extends Record<string, unknown>> {
     value: number,
     opts: SetOptions = {}
   ) => {
-    this.setValue(path, { min, max, value: clamp(value, min, max) }, opts)
+    const clamped = clamp(value, min, max)
+    const existing = this.getValue(path) as RangeValue | undefined
+    if (
+      existing &&
+      existing.min === min &&
+      existing.max === max &&
+      existing.value === clamped
+    )
+      return
+
+    this.setValue(path, { min, max, value: clamped }, opts)
   }
 
   /** Removes a value from the provided path. */


### PR DESCRIPTION
## Summary
- skip state updates when a range's value remains within existing bounds
- test that `setRange` ignores unchanged values

## Testing
- `bun test`
- `bun tsc`


------
https://chatgpt.com/codex/tasks/task_e_689951f62d5483228a84352403e73e3c