### PR TITLE
feat(campfire): highlight error count and allow clearing

### DIFF
--- a/apps/campfire/__tests__/DebugWindow.test.tsx
+++ b/apps/campfire/__tests__/DebugWindow.test.tsx
@@ -104,20 +104,27 @@ describe('DebugWindow', () => {
     expect(screen.getByText(/"hello"/)).toBeInTheDocument()
   })
 
-  it('shows errors from the game store', () => {
+  it('shows error count and clears errors', () => {
     useStoryDataStore.setState({ storyData: { options: 'debug' } })
     useGameStore.setState(state => ({
       ...state,
-      errors: ['something went wrong']
+      errors: ['first error', 'second error']
     }))
 
     render(<DebugWindow />)
 
-    const errTab = screen.getByRole('button', { name: 'Errors' })
+    const errTab = screen.getByRole('button', { name: 'Errors (2)' })
+    expect(errTab).toHaveClass('text-red-500')
     act(() => {
       errTab.click()
     })
-    expect(screen.getByText('something went wrong')).toBeInTheDocument()
+    expect(screen.getByText(/first error/)).toBeInTheDocument()
+    const clearButton = screen.getByRole('button', { name: 'Clear' })
+    act(() => {
+      clearButton.click()
+    })
+    expect(screen.queryByText('first error')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Errors' })).toBeInTheDocument()
   })
 
   it('shows raw current passage', () => {

--- a/apps/campfire/src/DebugWindow.tsx
+++ b/apps/campfire/src/DebugWindow.tsx
@@ -80,6 +80,7 @@ export const DebugWindow = () => {
   }, [])
   const gameData = useGameStore(state => state.gameData)
   const errors = useGameStore(state => state.errors)
+  const clearErrors = useGameStore(state => state.clearErrors)
   const [visible, setVisible] = useState(true)
   const [minimized, setMinimized] = useState(false)
   const [tab, setTab] = useState<Tab>(TAB_GAME)
@@ -94,6 +95,15 @@ export const DebugWindow = () => {
    */
   const handleCopy = (): void => {
     void navigator.clipboard?.writeText(rawPassage)
+  }
+
+  /**
+   * Clears all recorded errors.
+   *
+   * @returns {void}
+   */
+  const handleClearErrors = (): void => {
+    clearErrors()
   }
 
   useEffect(() => {
@@ -188,13 +198,15 @@ export const DebugWindow = () => {
             </button>
             <button
               type='button'
-              className={`flex-1 p-2 ${tab === TAB_ERRORS ? 'font-bold' : ''}`}
+              className={`flex-1 p-2 ${
+                tab === TAB_ERRORS ? 'font-bold' : ''
+              } ${errors.length ? 'text-red-500' : ''}`}
               onClick={e => {
                 e.stopPropagation()
                 setTab(TAB_ERRORS)
               }}
             >
-              Errors
+              Errors{errors.length ? ` (${errors.length})` : ''}
             </button>
           </div>
           <div className='p-2'>
@@ -233,7 +245,18 @@ export const DebugWindow = () => {
                 {JSON.stringify(translations, null, 2)}
               </pre>
             ) : (
-              <pre className='whitespace-pre-wrap'>{errors.join('\n')}</pre>
+              <div>
+                <button
+                  type='button'
+                  onClick={e => {
+                    e.stopPropagation()
+                    handleClearErrors()
+                  }}
+                >
+                  Clear
+                </button>
+                <pre className='whitespace-pre-wrap'>{errors.join('\n')}</pre>
+              </div>
             )}
           </div>
         </div>

--- a/template.ejs
+++ b/template.ejs
@@ -4,6 +4,20 @@
     <title>{{STORY_NAME}}: {{PASSAGE_NAME}}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+    <style type="text/tailwindcss">
+      @theme {
+        --color-red-50: 254 242 242;
+        --color-red-100: 254 226 226;
+        --color-red-200: 254 202 202;
+        --color-red-300: 252 165 165;
+        --color-red-400: 248 113 113;
+        --color-red-500: 239 68 68;
+        --color-red-600: 220 38 38;
+        --color-red-700: 185 28 28;
+        --color-red-800: 153 27 27;
+        --color-red-900: 127 29 29;
+      }
+    </style>
   </head>
   <body class="absolute inset-0 overflow-hidden">
     <tw-story tags></tw-story>

--- a/template.ejs
+++ b/template.ejs
@@ -6,16 +6,16 @@
     <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
     <style type="text/tailwindcss">
       @theme {
-        --color-red-50: 254 242 242;
-        --color-red-100: 254 226 226;
-        --color-red-200: 254 202 202;
-        --color-red-300: 252 165 165;
-        --color-red-400: 248 113 113;
-        --color-red-500: 239 68 68;
-        --color-red-600: 220 38 38;
-        --color-red-700: 185 28 28;
-        --color-red-800: 153 27 27;
-        --color-red-900: 127 29 29;
+        --color-red-50: 0.9705 0.0129 17.38;
+        --color-red-100: 0.9356 0.0309 17.72;
+        --color-red-200: 0.8845 0.0593 18.33;
+        --color-red-300: 0.8077 0.1035 19.57;
+        --color-red-400: 0.7106 0.1661 22.22;
+        --color-red-500: 0.6368 0.2078 25.33;
+        --color-red-600: 0.5771 0.2152 27.33;
+        --color-red-700: 0.5054 0.1905 27.52;
+        --color-red-800: 0.4437 0.1613 26.9;
+        --color-red-900: 0.3958 0.1331 25.72;
       }
     </style>
   </head>


### PR DESCRIPTION
## Summary
- show error count and highlight error tab when errors exist
- add button to clear recorded errors in debug window
- test error tab count and clear functionality
- define custom red palette in template via Tailwind's @theme

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68995c734e5c8322add4c7e873a8dc8d