### PR TITLE
feat(campfire): highlight error count and allow clearing

### DIFF
--- a/apps/campfire/__tests__/DebugWindow.test.tsx
+++ b/apps/campfire/__tests__/DebugWindow.test.tsx
@@ -104,20 +104,27 @@ describe('DebugWindow', () => {
     expect(screen.getByText(/"hello"/)).toBeInTheDocument()
   })
 
-  it('shows errors from the game store', () => {
+  it('shows error count and clears errors', () => {
     useStoryDataStore.setState({ storyData: { options: 'debug' } })
     useGameStore.setState(state => ({
       ...state,
-      errors: ['something went wrong']
+      errors: ['first error', 'second error']
     }))
 
     render(<DebugWindow />)
 
-    const errTab = screen.getByRole('button', { name: 'Errors' })
+    const errTab = screen.getByRole('button', { name: 'Errors (2)' })
+    expect(errTab).toHaveClass('text-red-500')
     act(() => {
       errTab.click()
     })
-    expect(screen.getByText('something went wrong')).toBeInTheDocument()
+    expect(screen.getByText(/first error/)).toBeInTheDocument()
+    const clearButton = screen.getByRole('button', { name: 'Clear' })
+    act(() => {
+      clearButton.click()
+    })
+    expect(screen.queryByText('first error')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Errors' })).toBeInTheDocument()
   })
 
   it('shows raw current passage', () => {

--- a/apps/campfire/src/DebugWindow.tsx
+++ b/apps/campfire/src/DebugWindow.tsx
@@ -80,6 +80,7 @@ export const DebugWindow = () => {
   }, [])
   const gameData = useGameStore(state => state.gameData)
   const errors = useGameStore(state => state.errors)
+  const clearErrors = useGameStore(state => state.clearErrors)
   const [visible, setVisible] = useState(true)
   const [minimized, setMinimized] = useState(false)
   const [tab, setTab] = useState<Tab>(TAB_GAME)
@@ -94,6 +95,15 @@ export const DebugWindow = () => {
    */
   const handleCopy = (): void => {
     void navigator.clipboard?.writeText(rawPassage)
+  }
+
+  /**
+   * Clears all recorded errors.
+   *
+   * @returns {void}
+   */
+  const handleClearErrors = (): void => {
+    clearErrors()
   }
 
   useEffect(() => {
@@ -188,13 +198,15 @@ export const DebugWindow = () => {
             </button>
             <button
               type='button'
-              className={`flex-1 p-2 ${tab === TAB_ERRORS ? 'font-bold' : ''}`}
+              className={`flex-1 p-2 ${
+                tab === TAB_ERRORS ? 'font-bold' : ''
+              } ${errors.length ? 'text-red-500' : ''}`}
               onClick={e => {
                 e.stopPropagation()
                 setTab(TAB_ERRORS)
               }}
             >
-              Errors
+              Errors{errors.length ? ` (${errors.length})` : ''}
             </button>
           </div>
           <div className='p-2'>
@@ -233,7 +245,18 @@ export const DebugWindow = () => {
                 {JSON.stringify(translations, null, 2)}
               </pre>
             ) : (
-              <pre className='whitespace-pre-wrap'>{errors.join('\n')}</pre>
+              <div>
+                <button
+                  type='button'
+                  onClick={e => {
+                    e.stopPropagation()
+                    handleClearErrors()
+                  }}
+                >
+                  Clear
+                </button>
+                <pre className='whitespace-pre-wrap'>{errors.join('\n')}</pre>
+              </div>
             )}
           </div>
         </div>

--- a/template.ejs
+++ b/template.ejs
@@ -4,6 +4,21 @@
     <title>{{STORY_NAME}}: {{PASSAGE_NAME}}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+    <style type="text/tailwindcss">
+      @theme {
+        --color-red-50: oklch(0.971 0.013 17.38);
+        --color-red-100: oklch(0.936 0.032 17.717);
+        --color-red-200: oklch(0.885 0.062 18.334);
+        --color-red-300: oklch(0.808 0.114 19.571);
+        --color-red-400: oklch(0.704 0.191 22.216);
+        --color-red-500: oklch(0.637 0.237 25.331);
+        --color-red-600: oklch(0.577 0.245 27.325);
+        --color-red-700: oklch(0.505 0.213 27.518);
+        --color-red-800: oklch(0.444 0.177 26.899);
+        --color-red-900: oklch(0.396 0.141 25.723);
+        --color-red-950: oklch(0.258 0.092 26.042);
+      }
+    </style>
   </head>
   <body class="absolute inset-0 overflow-hidden">
     <tw-story tags></tw-story>


### PR DESCRIPTION
## Summary
- show error count and highlight error tab when errors exist
- add button to clear recorded errors in debug window
- define red color palette using oklch via Tailwind @theme

## Testing
- `bun x prettier --write . --ignore-unknown`
- `bun tsc && echo tsc-complete`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68995c734e5c8322add4c7e873a8dc8d