### PR TITLE
feat: remove clearErrors directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,16 +506,6 @@ Change language and handle translations.
   `namespace:key="value"` pair is allowed per directive. Repeat the directive
   for additional translations.
 
-### Error handling
-
-Clear logged errors.
-
-- `clearErrors`: Remove all game errors.
-
-  ```md
-  :clearErrors
-  ```
-
 ## Error codes
 
 Campfire prints error codes to the browser console when it encounters invalid

--- a/apps/campfire/__tests__/Passage.checkpoint.test.tsx
+++ b/apps/campfire/__tests__/Passage.checkpoint.test.tsx
@@ -362,19 +362,4 @@ describe('Passage checkpoint directives', () => {
 
     console.error = orig
   })
-
-  it('clears errors via directive', async () => {
-    useGameStore.setState({ errors: ['oops'] })
-    const passage: Element = {
-      type: 'element',
-      tagName: 'tw-passagedata',
-      properties: { pid: '1', name: 'Start' },
-      children: [{ type: 'text', value: ':clearErrors' }]
-    }
-    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
-    render(<Passage />)
-    await waitFor(() => {
-      expect(useGameStore.getState().errors).toEqual([])
-    })
-  })
 })

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -90,7 +90,6 @@ export const useDirectiveHandlers = () => {
   const restoreCheckpointFn = useGameStore(state => state.restoreCheckpoint)
   const setLoading = useGameStore(state => state.setLoading)
   const addError = useGameStore(state => state.addError)
-  const clearErrors = useGameStore(state => state.clearErrors)
   const currentPassageId = useStoryDataStore(state => state.currentPassageId)
   const setCurrentPassage = useStoryDataStore(state => state.setCurrentPassage)
   const getPassageById = useStoryDataStore(state => state.getPassageById)
@@ -1671,20 +1670,6 @@ export const useDirectiveHandlers = () => {
   }
 
   /**
-   * Handles the `:clearErrors` directive, which removes all logged game errors.
-   * Calls the clearErrors function to reset the error state.
-   *
-   * @param _directive - The directive node representing the clearErrors directive (unused).
-   * @param parent - The parent AST node containing this directive.
-   * @param index - The index of the directive node within its parent.
-   * @returns The new index after removal.
-   */
-  const handleClearErrors: DirectiveHandler = (_directive, parent, index) => {
-    clearErrors()
-    return removeNode(parent, index)
-  }
-
-  /**
    * Handles the `:title` directive, which overrides the page title for the current passage.
    * The directive's value must be wrapped in matching quotes or backticks. If the
    * directive is used inside an included passage, it is ignored. When valid, the
@@ -1827,7 +1812,6 @@ export const useDirectiveHandlers = () => {
       checkpoint: handleCheckpoint,
       clearCheckpoint: handleClearCheckpoint,
       restore: handleRestore,
-      clearErrors: handleClearErrors,
       translations: handleTranslations,
       t: handleTranslate
     }


### PR DESCRIPTION
## Summary
- remove :clearErrors directive and mapping
- drop test referencing :clearErrors
- remove :clearErrors directive docs

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_689974d3eb9083228d13ea2af15daa51