### PR TITLE
feat(i18n): support interpolation in t directive

### DIFF
--- a/apps/campfire/__tests__/Passage.i18n.test.tsx
+++ b/apps/campfire/__tests__/Passage.i18n.test.tsx
@@ -121,6 +121,32 @@ describe('Passage i18n directives', () => {
     expect(text).toBeInTheDocument()
   })
 
+  it('supports interpolation with t directive', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value: ':translations[en-US]{translation:greet="Hello, {{name}}!"}'
+        },
+        { type: 'text', value: ':t[greet]{name=player}' }
+      ]
+    }
+
+    useGameStore.setState({ gameData: { player: 'Sam' } })
+    useStoryDataStore.setState({
+      passages: [passage],
+      currentPassageId: '1'
+    })
+
+    render(<Passage />)
+
+    const text = await screen.findByText('Hello, Sam!')
+    expect(text).toBeInTheDocument()
+  })
+
   it('resolves translations inside links', async () => {
     const start: Element = {
       type: 'element',

--- a/apps/campfire/src/Show.tsx
+++ b/apps/campfire/src/Show.tsx
@@ -13,6 +13,8 @@ interface ShowProps {
   'data-i18n-ns'?: string
   /** Pluralization count for the translation */
   'data-i18n-count'?: number
+  /** Interpolation values for the translation */
+  'data-i18n-vars'?: string
 }
 
 /**
@@ -30,10 +32,21 @@ export const Show = (props: ShowProps) => {
   )
   const tKey = props['data-i18n-key']
   if (tKey) {
-    const options = getTranslationOptions({
-      ns: props['data-i18n-ns'],
-      count: props['data-i18n-count']
-    })
+    let vars: Record<string, unknown> = {}
+    if (typeof props['data-i18n-vars'] === 'string') {
+      try {
+        vars = JSON.parse(props['data-i18n-vars']) as Record<string, unknown>
+      } catch {
+        vars = {}
+      }
+    }
+    const options = {
+      ...vars,
+      ...getTranslationOptions({
+        ns: props['data-i18n-ns'],
+        count: props['data-i18n-count']
+      })
+    }
     return <span>{t(tKey, options)}</span>
   }
   const storeKey = props['data-key']


### PR DESCRIPTION
## Summary
- support passing variables to `:t` directive for i18next interpolation
- parse interpolation values in Show component
- verify `:t` directive handles interpolation

## Testing
- `bun tsc`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_689a092f4df48322be58ac27fe1bcd89