### PR TITLE
feat: rename restore directive to loadCheckpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,9 +431,11 @@ Control the flow between passages or how they appear.
   - `title-show-passage="false"`: Hide the passage name and show only the
     story name.
 
-### Checkpoints & persistence
+### Persistence
 
-Save and restore progress or store data in the browser.
+Save and load progress or store data in the browser.
+
+#### Checkpoints
 
 - `checkpoint`: Save the current game state.
 
@@ -453,10 +455,21 @@ Save and restore progress or store data in the browser.
   Removes the currently stored checkpoint. Only one checkpoint can exist at a
   time, so this directive has no attributes.
 
-- `clearSave`: Remove a stored game state.
+- `loadCheckpoint`: Load a saved checkpoint.
 
   ```md
-  :clearSave{id=SLOT}
+  :loadCheckpoint
+  ```
+
+  Loads the currently stored checkpoint. Only one checkpoint can exist at a
+  time, so this directive has no attributes.
+
+#### Saves
+
+- `save`: Write the current state to local storage.
+
+  ```md
+  :save{id=SLOT}
   ```
 
   Replace `SLOT` with the storage id.
@@ -469,19 +482,10 @@ Save and restore progress or store data in the browser.
 
   Replace `SLOT` with the storage id.
 
-- `restore`: Load a saved state.
+- `clearSave`: Remove a stored game state.
 
   ```md
-  :restore
-  ```
-
-  Loads the currently stored checkpoint. Only one checkpoint can exist at a
-  time, so this directive has no attributes.
-
-- `save`: Write the current state to local storage.
-
-  ```md
-  :save{id=SLOT}
+  :clearSave{id=SLOT}
   ```
 
   Replace `SLOT` with the storage id.

--- a/apps/campfire/__tests__/Passage.checkpoint.test.tsx
+++ b/apps/campfire/__tests__/Passage.checkpoint.test.tsx
@@ -20,7 +20,7 @@ describe('Passage checkpoint directives', () => {
     }
   })
 
-  it('saves and restores game state with checkpoints', async () => {
+  it('saves and loads game state with checkpoints', async () => {
     const start: Element = {
       type: 'element',
       tagName: 'tw-passagedata',
@@ -39,7 +39,7 @@ describe('Passage checkpoint directives', () => {
       children: [
         {
           type: 'text',
-          value: ':::set[hp=1]\n:::\n:restore'
+          value: ':::set[hp=1]\n:::\n:loadCheckpoint'
         }
       ]
     }
@@ -89,7 +89,7 @@ describe('Passage checkpoint directives', () => {
     })
   })
 
-  it('ignores checkpoint and restore directives in included passages', async () => {
+  it('ignores checkpoint and loadCheckpoint directives in included passages', async () => {
     const start: Element = {
       type: 'element',
       tagName: 'tw-passagedata',
@@ -108,7 +108,7 @@ describe('Passage checkpoint directives', () => {
       children: [
         {
           type: 'text',
-          value: ':::set[hp=1]\n:::\n:restore:checkpoint{id=cp2}'
+          value: ':::set[hp=1]\n:::\n:loadCheckpoint:checkpoint{id=cp2}'
         }
       ]
     }
@@ -335,7 +335,7 @@ describe('Passage checkpoint directives', () => {
     expect(useGameStore.getState().loading).toBe(false)
   })
 
-  it('stores error when restore cannot find a checkpoint', async () => {
+  it('stores error when loadCheckpoint cannot find a checkpoint', async () => {
     const logged: unknown[] = []
     const orig = console.error
     console.error = (...args: unknown[]) => {
@@ -346,7 +346,7 @@ describe('Passage checkpoint directives', () => {
       type: 'element',
       tagName: 'tw-passagedata',
       properties: { pid: '1', name: 'Start' },
-      children: [{ type: 'text', value: ':restore' }]
+      children: [{ type: 'text', value: ':loadCheckpoint' }]
     }
 
     useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -87,7 +87,7 @@ export const useDirectiveHandlers = () => {
   }
   const saveCheckpoint = useGameStore(state => state.saveCheckpoint)
   const removeCheckpoint = useGameStore(state => state.removeCheckpoint)
-  const restoreCheckpointFn = useGameStore(state => state.restoreCheckpoint)
+  const loadCheckpointFn = useGameStore(state => state.loadCheckpoint)
   const setLoading = useGameStore(state => state.setLoading)
   const addError = useGameStore(state => state.addError)
   const currentPassageId = useStoryDataStore(state => state.currentPassageId)
@@ -1672,17 +1672,21 @@ export const useDirectiveHandlers = () => {
   }
 
   /**
-   * Handles the `:restore` directive, which loads the saved checkpoint. If the
-   * directive is used inside an included passage, it is ignored.
+   * Handles the `:loadCheckpoint` directive, which loads the saved checkpoint.
+   * If the directive is used inside an included passage, it is ignored.
    *
-   * @param directive - The directive node representing `:restore`.
+   * @param directive - The directive node representing `:loadCheckpoint`.
    * @param parent - The parent AST node containing this directive.
    * @param index - The index of this directive within the parent's children.
    * @returns The index at which processing should continue.
    */
-  const handleRestore: DirectiveHandler = (_directive, parent, index) => {
+  const handleLoadCheckpoint: DirectiveHandler = (
+    _directive,
+    parent,
+    index
+  ) => {
     if (includeDepth > 0) return removeNode(parent, index)
-    const cp = restoreCheckpointFn()
+    const cp = loadCheckpointFn()
     if (cp?.currentPassageId) {
       setCurrentPassage(cp.currentPassageId)
     }
@@ -1851,7 +1855,7 @@ export const useDirectiveHandlers = () => {
       clearSave: handleClearSave,
       checkpoint: handleCheckpoint,
       clearCheckpoint: handleClearCheckpoint,
-      restore: handleRestore,
+      loadCheckpoint: handleLoadCheckpoint,
       translations: handleTranslations,
       t: handleTranslate
     }

--- a/packages/use-game-store/__tests__/index.test.ts
+++ b/packages/use-game-store/__tests__/index.test.ts
@@ -52,7 +52,7 @@ describe('useGameStore', () => {
     expect(useGameStore.getState().onceKeys).toEqual({})
   })
 
-  it('saves and restores checkpoints', () => {
+  it('saves and loads checkpoints', () => {
     useGameStore.getState().setGameData({ health: 10 })
     useGameStore.getState().saveCheckpoint('cp1', {
       gameData: { ...useGameStore.getState().gameData },
@@ -62,13 +62,13 @@ describe('useGameStore', () => {
       label: 'Start'
     })
     useGameStore.getState().setGameData({ health: 5 })
-    const cp = useGameStore.getState().restoreCheckpoint('cp1')
+    const cp = useGameStore.getState().loadCheckpoint('cp1')
     expect(useGameStore.getState().gameData).toEqual({ health: 10 })
     expect(cp?.currentPassageId).toBe('1')
     expect(cp?.timestamp).toBeGreaterThan(0)
   })
 
-  it('restores the existing checkpoint when no id is provided', () => {
+  it('loads the existing checkpoint when no id is provided', () => {
     useGameStore.getState().setGameData({ health: 10 })
     useGameStore.getState().saveCheckpoint('cp1', {
       gameData: { ...useGameStore.getState().gameData },
@@ -88,18 +88,18 @@ describe('useGameStore', () => {
     expect(useGameStore.getState().checkpoints.cp1).toBeUndefined()
     expect(useGameStore.getState().checkpoints.cp2).toBeDefined()
     useGameStore.getState().setGameData({ health: 1 })
-    const cp = useGameStore.getState().restoreCheckpoint()
+    const cp = useGameStore.getState().loadCheckpoint()
     expect(useGameStore.getState().gameData).toEqual({ health: 5 })
     expect(cp?.label).toBe('Second')
   })
 
-  it('logs and stores an error when restoring a nonexistent checkpoint', () => {
+  it('logs and stores an error when loading a nonexistent checkpoint', () => {
     const errors: unknown[] = []
     const orig = console.error
     console.error = (...args: unknown[]) => {
       errors.push(args)
     }
-    const cp = useGameStore.getState().restoreCheckpoint('missing')
+    const cp = useGameStore.getState().loadCheckpoint('missing')
     expect(cp).toBeUndefined()
     expect(errors).toHaveLength(1)
     expect(useGameStore.getState().errors).toEqual([

--- a/packages/use-game-store/index.ts
+++ b/packages/use-game-store/index.ts
@@ -43,12 +43,12 @@ export interface GameState<T = Record<string, unknown>> {
    */
   saveCheckpoint: (id: string, checkpoint: CheckpointData<T>) => void
   /**
-   * Restore a checkpoint and return its data. If no ID is provided, restores
-   * the currently stored checkpoint.
+   * Load a checkpoint and return its data. If no ID is provided, loads the
+   * currently stored checkpoint.
    *
-   * @param id - Optional identifier of the checkpoint to restore.
+   * @param id - Optional identifier of the checkpoint to load.
    */
-  restoreCheckpoint: (id?: string) => Checkpoint<T> | undefined
+  loadCheckpoint: (id?: string) => Checkpoint<T> | undefined
   /** Remove a checkpoint */
   removeCheckpoint: (id: string) => void
 }
@@ -161,12 +161,12 @@ export const useGameStore = create(
         })
       ),
     /**
-     * Restores a checkpoint.
+     * Loads a checkpoint.
      *
-     * @param id - Optional identifier of the checkpoint to restore.
-     * @returns The restored checkpoint, if found.
+     * @param id - Optional identifier of the checkpoint to load.
+     * @returns The loaded checkpoint, if found.
      */
-    restoreCheckpoint: id => {
+    loadCheckpoint: id => {
       const cps = get().checkpoints
       const cp = id ? cps[id] : Object.values(cps)[0]
       if (cp) {


### PR DESCRIPTION
## Summary
- rename `:restore` directive and related API to `loadCheckpoint`
- group checkpoint directives and save directives under separate headers

## Testing
- `bun tsc && echo tsc passed`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_689a1c6bc6cc8322b141ae6d78f58c70