### PR TITLE
fix: remove stray directive markers in sequence steps

### DIFF
--- a/apps/campfire/__tests__/Passage.sequence.test.tsx
+++ b/apps/campfire/__tests__/Passage.sequence.test.tsx
@@ -65,4 +65,27 @@ describe('Passage sequence directive', () => {
     expect(await screen.findByText('How are you?')).toBeInTheDocument()
     expect(screen.queryByText(':::transition')).toBeNull()
   })
+
+  it('renders multiple transitions across sequence steps', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value:
+            ':::sequence\n:::step\n:::transition\nOne\n:::\n:::\n:::step\n:::transition\nTwo\n:::\n:::\n:::step\n:::transition\nThree\n:::\n:::\n:::\n'
+        }
+      ]
+    }
+
+    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+    render(<Passage />)
+
+    expect(await screen.findByText('One')).toBeInTheDocument()
+    expect(await screen.findByText('Two')).toBeInTheDocument()
+    expect(await screen.findByText('Three')).toBeInTheDocument()
+    expect(screen.queryByText(':::transition')).toBeNull()
+  })
 })

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -833,14 +833,15 @@ export const useDirectiveHandlers = () => {
    */
   const removeDirectiveMarker = (parent: Parent, index: number) => {
     const marker = parent.children[index]
-    if (
-      marker &&
-      marker.type === 'paragraph' &&
-      marker.children.length === 1 &&
-      isTextNode(marker.children[0]) &&
-      marker.children[0].value.trim() === DIRECTIVE_MARKER
-    ) {
-      parent.children.splice(index, 1)
+    if (!marker || marker.type !== 'paragraph') return
+    if (marker.children.every(isTextNode)) {
+      const combined = marker.children
+        .map(child => (child as MdText).value)
+        .join('')
+        .trim()
+      if (combined === DIRECTIVE_MARKER) {
+        parent.children.splice(index, 1)
+      }
     }
   }
 

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -834,7 +834,7 @@ export const useDirectiveHandlers = () => {
   const removeDirectiveMarker = (parent: Parent, index: number) => {
     const marker = parent.children[index]
     if (!marker || marker.type !== 'paragraph') return
-    if (marker.children.every(isTextNode)) {
+    if (marker.children.length > 0 && marker.children.every(isTextNode)) {
       const combined = marker.children
         .map(child => (child as MdText).value)
         .join('')


### PR DESCRIPTION
## Summary
- handle directive markers that include surrounding whitespace
- ensure nested sequence transitions render correctly

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_689a395b5f448322a2fe93d7353333a2