### PR TITLE
test: ensure show directive works inside markdown tables

### DIFF
--- a/apps/campfire/__tests__/Passage.state.test.tsx
+++ b/apps/campfire/__tests__/Passage.state.test.tsx
@@ -919,6 +919,33 @@ describe('Passage game state directives', () => {
     })
   })
 
+  it('renders show directive inside a markdown table', async () => {
+    useGameStore.setState(state => ({
+      ...state,
+      gameData: { hp: 7 }
+    }))
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value: '| Stat | Value |\n| --- | --- |\n| HP | :show[hp] |'
+        }
+      ]
+    }
+
+    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+
+    render(<Passage />)
+
+    await waitFor(() => {
+      const span = screen.getByText('7')
+      expect(span.closest('tr')?.textContent?.replace(/\s+/g, '')).toBe('HP7')
+    })
+  })
+
   it('unsets game data with the unset directive', async () => {
     useGameStore.setState(state => ({
       ...state,


### PR DESCRIPTION
## Summary
- add regression test for show directive inside markdown tables

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_689a7b0968f08322826ddf2f4ea0392e