### PR TITLE
fix(campfire): strip extra directive markers

### DIFF
--- a/apps/campfire/__tests__/Passage.sequence.test.tsx
+++ b/apps/campfire/__tests__/Passage.sequence.test.tsx
@@ -88,4 +88,24 @@ describe('Passage sequence directive', () => {
     expect(await screen.findByText('Three')).toBeInTheDocument()
     expect(screen.queryByText(':::transition')).toBeNull()
   })
+
+  it('does not render stray colons when directives close consecutively', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value: ':::sequence\n:::step\n:::transition\nFoo\n:::\n:::\n:::\n'
+        }
+      ]
+    }
+
+    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+    render(<Passage />)
+
+    expect(await screen.findByText('Foo')).toBeInTheDocument()
+    expect(screen.queryByText(':::')).toBeNull()
+  })
 })

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -826,7 +826,8 @@ export const useDirectiveHandlers = () => {
   const isTextNode = (node: RootContent): node is MdText => node.type === 'text'
 
   /**
-   * Removes a paragraph containing only the directive marker from the parent.
+   * Removes a paragraph containing only directive markers from the parent.
+   * Supports multiple markers separated by whitespace or collapsed together.
    *
    * @param parent - The parent node that may contain the marker.
    * @param index - The index of the potential marker node.
@@ -839,7 +840,12 @@ export const useDirectiveHandlers = () => {
         .map(child => (child as MdText).value)
         .join('')
         .trim()
-      if (combined === DIRECTIVE_MARKER) {
+      const stripped = combined.replace(/\s+/g, '')
+      if (
+        stripped.length > 0 &&
+        /^:+$/.test(stripped) &&
+        stripped.length % DIRECTIVE_MARKER.length === 0
+      ) {
         parent.children.splice(index, 1)
       }
     }


### PR DESCRIPTION
## Summary
- handle consecutive directive markers in nested directives
- test sequence rendering does not leave stray colons

## Testing
- `bun tsc`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_689a7e3370e8832295325860b76cecff