### PR TITLE
fix(campfire): wait for step transitions before advancing sequence

### DIFF
--- a/apps/campfire/__tests__/Sequence.test.tsx
+++ b/apps/campfire/__tests__/Sequence.test.tsx
@@ -228,6 +228,29 @@ describe('Sequence', () => {
     expect(wrapper.style.opacity).toBe('1')
   })
 
+  it('waits for transitions before advancing steps in autoplay', async () => {
+    render(
+      <Sequence autoplay>
+        <Step>
+          <Transition duration={100}>First</Transition>
+        </Step>
+        <Step>
+          <Transition duration={100}>Second</Transition>
+        </Step>
+      </Sequence>
+    )
+    expect(screen.getByText('First')).toBeInTheDocument()
+    expect(screen.queryByText('Second')).toBeNull()
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50))
+    })
+    expect(screen.queryByText('Second')).toBeNull()
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 60))
+    })
+    expect(screen.getByText('Second')).toBeInTheDocument()
+  })
+
   it('allows nesting sequences within steps', () => {
     render(
       <Sequence>

--- a/apps/campfire/src/Sequence.tsx
+++ b/apps/campfire/src/Sequence.tsx
@@ -61,12 +61,15 @@ interface TransitionProps {
   children: ComponentChildren
 }
 
+/** Default duration used when a transition does not specify one. */
+const DEFAULT_TRANSITION_DURATION = 300
+
 /**
  * Animates its children using a simple CSS-based transition.
  */
 export const Transition = ({
   type = 'fade-in',
-  duration = 300,
+  duration = DEFAULT_TRANSITION_DURATION,
   children
 }: TransitionProps) => {
   const [visible, setVisible] = useState(false)
@@ -200,12 +203,34 @@ export const Sequence = ({
     }
   }
 
+  /**
+   * Recursively determines the longest transition duration within a step.
+   */
+  const getMaxDuration = (children: ComponentChildren): number => {
+    let max = 0
+    for (const child of toChildArray(children)) {
+      if (!isValidElement(child)) continue
+      if (child.type === Transition) {
+        const props = child.props as TransitionProps
+        const d =
+          typeof props.duration === 'number'
+            ? props.duration
+            : DEFAULT_TRANSITION_DURATION
+        if (d > max) max = d
+      }
+      const nested = getMaxDuration(child.props.children)
+      if (nested > max) max = nested
+    }
+    return max
+  }
+
   useEffect(() => {
-    if (autoplay && index < steps.length - 1) {
-      const id = setTimeout(handleNext, delay)
+    if (autoplay && index < steps.length - 1 && current) {
+      const transitionDelay = getMaxDuration(current.props.children)
+      const id = setTimeout(handleNext, delay + transitionDelay)
       return () => clearTimeout(id)
     }
-  }, [autoplay, delay, index, steps.length])
+  }, [autoplay, delay, index, steps.length, current])
 
   /** Tracks whether the completion handler has already executed. */
   const completeRan = useRef(false)


### PR DESCRIPTION
## Summary
- ensure autoplay sequences respect transition durations
- add test that verifies sequential rendering

## Testing
- `bun test`
- `bun tsc`


------
https://chatgpt.com/codex/tasks/task_e_689a831618ac83229e2b42a022258e24