### PR TITLE
feat(campfire): add transition staggering

### DIFF
--- a/apps/campfire/__tests__/Sequence.test.tsx
+++ b/apps/campfire/__tests__/Sequence.test.tsx
@@ -251,6 +251,45 @@ describe('Sequence', () => {
     expect(screen.getByText('Second')).toBeInTheDocument()
   })
 
+  it('stagger transitions within a step', () => {
+    render(
+      <Sequence>
+        <Step stagger={100}>
+          <Transition duration={50}>One</Transition>
+          <Transition duration={50}>Two</Transition>
+        </Step>
+      </Sequence>
+    )
+    const first = screen.getByText('One') as HTMLElement
+    const second = screen.getByText('Two') as HTMLElement
+    expect(first.getAttribute('style') ?? '').toContain('transition-delay: 0ms')
+    expect(second.getAttribute('style') ?? '').toContain(
+      'transition-delay: 100ms'
+    )
+  })
+
+  it('waits for staggered transitions before advancing', async () => {
+    render(
+      <Sequence autoplay>
+        <Step stagger={50}>
+          <Transition duration={100}>First</Transition>
+          <Transition duration={100}>Second</Transition>
+        </Step>
+        <Step>Done</Step>
+      </Sequence>
+    )
+    expect(screen.getByText('First')).toBeInTheDocument()
+    expect(screen.queryByText('Done')).toBeNull()
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 120))
+    })
+    expect(screen.queryByText('Done')).toBeNull()
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 40))
+    })
+    expect(screen.getByText('Done')).toBeInTheDocument()
+  })
+
   it('allows nesting sequences within steps', () => {
     render(
       <Sequence>

--- a/apps/campfire/src/Sequence.tsx
+++ b/apps/campfire/src/Sequence.tsx
@@ -40,8 +40,6 @@ export const Step = ({
   rewind,
   stagger = 0
 }: StepProps) => {
-  const stepStagger =
-    typeof stagger === 'number' ? stagger : Number(stagger) || 0
   const content =
     typeof children === 'function'
       ? (
@@ -63,9 +61,8 @@ export const Step = ({
       if (!isValidElement(child)) return child
       if (child.type === Transition) {
         const props = child.props as TransitionProps
-        const delay =
-          (typeof props.delay === 'number' ? props.delay : 0) + offset
-        offset += stepStagger
+        const delay = (props.delay ?? 0) + offset
+        offset += stagger
         return cloneElement(child as VNode<TransitionProps>, { delay })
       }
       if (child.props?.children) {
@@ -245,13 +242,9 @@ export const Sequence = ({
         if (!isValidElement(child)) continue
         if (child.type === Transition) {
           const props = child.props as TransitionProps
-          const d =
-            typeof props.duration === 'number'
-              ? props.duration
-              : DEFAULT_TRANSITION_DURATION
-          const delay =
-            (typeof props.delay === 'number' ? props.delay : 0) + offset
-          const total = delay + d
+          const duration = props.duration ?? DEFAULT_TRANSITION_DURATION
+          const delay = (props.delay ?? 0) + offset
+          const total = delay + duration
           if (total > max) max = total
           offset += stagger
         }
@@ -268,9 +261,7 @@ export const Sequence = ({
     if (autoplay && index < steps.length - 1 && current) {
       const transitionDelay = getMaxDuration(
         current.props.children || [],
-        typeof current.props.stagger === 'number'
-          ? current.props.stagger
-          : Number(current.props.stagger) || 0
+        current.props.stagger ?? 0
       )
       const id = setTimeout(handleNext, delay + transitionDelay)
       return () => clearTimeout(id)

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -1189,13 +1189,16 @@ export const useDirectiveHandlers = () => {
    */
   const handleStep: DirectiveHandler = (directive, parent, index) => {
     if (!parent || typeof index !== 'number') return
+    const { attrs } = extractAttributes(directive, parent, index, {
+      stagger: { type: 'number' }
+    })
     const container = directive as ContainerDirective
     const children = stripLabel(container.children as RootContent[])
     runBlock(children)
     const node: Parent = {
       type: 'paragraph',
       children,
-      data: { hName: 'step' }
+      data: { hName: 'step', hProperties: attrs }
     }
     const newIndex = replaceWithIndentation(directive, parent, index, [
       node as RootContent
@@ -1218,7 +1221,8 @@ export const useDirectiveHandlers = () => {
     if (!parent || typeof index !== 'number') return
     const { attrs } = extractAttributes(directive, parent, index, {
       type: { type: 'string' },
-      duration: { type: 'number' }
+      duration: { type: 'number' },
+      delay: { type: 'number' }
     })
     const container = directive as ContainerDirective
     const children = stripLabel(container.children as RootContent[])


### PR DESCRIPTION
## Summary
- allow Step to stagger Transition children
- support delayed transitions and respect them in autoplay
- add directive attributes for stagger and delay

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_689a9aa2642c8322833959d05caccd01