### PR TITLE
fix(campfire): remove step stagger attribute

### DIFF
--- a/apps/campfire/__tests__/Sequence.test.tsx
+++ b/apps/campfire/__tests__/Sequence.test.tsx
@@ -251,45 +251,6 @@ describe('Sequence', () => {
     expect(screen.getByText('Second')).toBeInTheDocument()
   })
 
-  it('stagger transitions within a step', () => {
-    render(
-      <Sequence>
-        <Step stagger={100}>
-          <Transition duration={50}>One</Transition>
-          <Transition duration={50}>Two</Transition>
-        </Step>
-      </Sequence>
-    )
-    const first = screen.getByText('One') as HTMLElement
-    const second = screen.getByText('Two') as HTMLElement
-    expect(first.getAttribute('style') ?? '').toContain('transition-delay: 0ms')
-    expect(second.getAttribute('style') ?? '').toContain(
-      'transition-delay: 100ms'
-    )
-  })
-
-  it('waits for staggered transitions before advancing', async () => {
-    render(
-      <Sequence autoplay>
-        <Step stagger={50}>
-          <Transition duration={100}>First</Transition>
-          <Transition duration={100}>Second</Transition>
-        </Step>
-        <Step>Done</Step>
-      </Sequence>
-    )
-    expect(screen.getByText('First')).toBeInTheDocument()
-    expect(screen.queryByText('Done')).toBeNull()
-    await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 120))
-    })
-    expect(screen.queryByText('Done')).toBeNull()
-    await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 40))
-    })
-    expect(screen.getByText('Done')).toBeInTheDocument()
-  })
-
   it('allows nesting sequences within steps', () => {
     render(
       <Sequence>

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -1189,9 +1189,7 @@ export const useDirectiveHandlers = () => {
    */
   const handleStep: DirectiveHandler = (directive, parent, index) => {
     if (!parent || typeof index !== 'number') return
-    const { attrs } = extractAttributes(directive, parent, index, {
-      stagger: { type: 'number' }
-    })
+    const { attrs } = extractAttributes(directive, parent, index, {})
     const container = directive as ContainerDirective
     const children = stripLabel(container.children as RootContent[])
     runBlock(children)


### PR DESCRIPTION
## Summary
- remove stagger prop from Step component and simplify transition timing
- drop support for `stagger` attribute in step directives
- clean up tests referencing step staggering

## Testing
- `bun tsc --pretty false && echo tsc completed`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_689aab49a0a88322b4827ac3d1615b33