### PR TITLE
refactor: remove error codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,14 +521,7 @@ Change language and handle translations.
   `namespace:key="value"` pair is allowed per directive. Repeat the directive
   for additional translations.
 
-## Error codes
-
-Campfire prints error codes to the browser console when it encounters invalid
-markup. These codes help identify and debug issues in story passages.
-
-| Code  | Meaning                                                            |
-| ----- | ------------------------------------------------------------------ |
-| CF001 | Trigger `label` must be a quoted string. The attribute is ignored. |
+Campfire prints descriptive error messages to the browser console when it encounters invalid markup.
 
 ## Further reading
 

--- a/packages/remark-campfire/__tests__/trigger-label.test.ts
+++ b/packages/remark-campfire/__tests__/trigger-label.test.ts
@@ -41,7 +41,11 @@ describe('trigger label attribute', () => {
   it('rejects unquoted labels', () => {
     const { node, file } = parseTrigger(':::trigger{label=Fire}\n:::')
     expect(node?.attributes).toEqual({})
-    expect(file.messages.some(m => m.message.includes('CF001'))).toBe(true)
+    expect(
+      file.messages.some(m =>
+        m.message.includes('trigger label must be a quoted string')
+      )
+    ).toBe(true)
   })
 
   it('rejects mismatched quotes', () => {

--- a/packages/remark-campfire/index.ts
+++ b/packages/remark-campfire/index.ts
@@ -6,10 +6,8 @@ import type { SKIP } from 'unist-util-visit'
 import type { VFile } from 'vfile'
 import type { DirectiveNode } from './helpers'
 
-/** Error code for unquoted trigger labels */
-const ERR_TRIGGER_LABEL_UNQUOTED = 'CF001'
 /** Error message for unquoted trigger labels */
-const MSG_TRIGGER_LABEL_UNQUOTED = `${ERR_TRIGGER_LABEL_UNQUOTED}: trigger label must be a quoted string`
+const MSG_TRIGGER_LABEL_UNQUOTED = 'trigger label must be a quoted string'
 
 export type DirectiveHandlerResult = number | [typeof SKIP, number] | void
 


### PR DESCRIPTION
## Summary
- remove error code constants from remark-campfire
- update trigger label tests to match descriptive error message
- drop README section describing error codes

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_689b5dbec268832280db63aad52bcb54