### PR TITLE
docs: add input tables for directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,11 @@ Operations that set, update, or remove scalar values.
   booleans, values wrapped in `{}` as objects, purely numeric values as numbers
   and any other value is evaluated as an expression or state reference.
 
+  | Input | Description                  |
+  | ----- | ---------------------------- |
+  | key   | State key to assign          |
+  | value | Value or expression to store |
+
   ```md
   :set[health=100]
   :set[playerName="John"]
@@ -145,7 +150,12 @@ Operations that set, update, or remove scalar values.
   :setOnce[visited=true]
   ```
 
-Replace `visited` with the key to lock on first use.
+  | Input | Description                  |
+  | ----- | ---------------------------- |
+  | key   | State key to set once        |
+  | value | Value to assign on first use |
+
+  Replace `visited` with the key to lock on first use.
 
 - `random`: Assign a random value. This directive is leaf-only and cannot wrap
   content.
@@ -158,22 +168,31 @@ Replace `visited` with the key to lock on first use.
 
   ```md
   :random[pick]{from=['a string',some_key,true,42]}
-  ```
-
   :random[pick]{from=items}
-
   ```
 
   Replace `pick` with the key to store the result and supply either a literal
   array or a state key after `from`.
 
-  ```
+  | Input | Description                                     |
+  | ----- | ----------------------------------------------- |
+  | key   | State key to assign                             |
+  | min   | Minimum value for numeric range                 |
+  | max   | Maximum value for numeric range                 |
+  | from  | Array or state key to select a random item from |
 
 - `randomOnce`: Assign a random value once and lock the key.
 
   ```md
   :randomOnce[roll]{min=1 max=6}
   ```
+
+  | Input | Description                                     |
+  | ----- | ----------------------------------------------- |
+  | key   | State key to assign                             |
+  | min   | Minimum value for numeric range                 |
+  | max   | Maximum value for numeric range                 |
+  | from  | Array or state key to select a random item from |
 
   Use this to store a random value that should not change on subsequent runs.
 
@@ -183,6 +202,10 @@ Replace `visited` with the key to lock on first use.
   ```md
   :unset{key=visited}
   ```
+
+  | Input | Description         |
+  | ----- | ------------------- |
+  | key   | State key to remove |
 
   Replace `visited` with the key to remove.
 
@@ -204,6 +227,11 @@ Create or modify lists of values.
   automatically converted to strings, numbers, or booleans and may include
   expressions evaluated against the current state.
 
+  | Input | Description                      |
+  | ----- | -------------------------------- |
+  | key   | Name of the array to create      |
+  | [...] | Initial values in array notation |
+
 - `arrayOnce`: Create an array only if it has not been set.
 
   ```md
@@ -213,6 +241,11 @@ Create or modify lists of values.
   This behaves like `array` but locks the key after execution, preventing
   further changes.
 
+  | Input | Description                      |
+  | ----- | -------------------------------- |
+  | key   | Name of the array to create      |
+  | [...] | Initial values in array notation |
+
 - `concat`: Combine arrays.
 
   ```md
@@ -220,6 +253,11 @@ Create or modify lists of values.
   ```
 
   Replace `items` with the target array and `moreItems` with the source.
+
+  | Input | Description                    |
+  | ----- | ------------------------------ |
+  | key   | Target array to modify         |
+  | value | Array whose items are appended |
 
 - `pop`: Remove the last item. Use `into` to store it.
 
@@ -229,6 +267,11 @@ Create or modify lists of values.
 
   Replace `items` with the array and `lastItem` with the storage key.
 
+  | Input | Description                            |
+  | ----- | -------------------------------------- |
+  | key   | Array to modify                        |
+  | into  | Optional key to store the removed item |
+
 - `push`: Add items to the end of an array.
 
   ```md
@@ -237,6 +280,11 @@ Create or modify lists of values.
 
   Replace `items` with the array and `newItem` with items to add.
 
+  | Input | Description     |
+  | ----- | --------------- |
+  | key   | Array to modify |
+  | value | Items to append |
+
 - `shift`: Remove the first item. Use `into` to store it.
 
   ```md
@@ -244,6 +292,11 @@ Create or modify lists of values.
   ```
 
   Replace `items` with the array and `firstItem` with the storage key.
+
+  | Input | Description                            |
+  | ----- | -------------------------------------- |
+  | key   | Array to modify                        |
+  | into  | Optional key to store the removed item |
 
 - `splice`: Remove items at an index and optionally insert new ones. Use `into`
   to store removed items.
@@ -254,6 +307,14 @@ Create or modify lists of values.
 
   Replace `items` with the array and adjust attributes as needed.
 
+  | Input | Description                         |
+  | ----- | ----------------------------------- |
+  | key   | Array to modify                     |
+  | index | Starting index for removal          |
+  | count | Number of items to remove           |
+  | value | Items to insert                     |
+  | into  | Optional key to store removed items |
+
 - `unshift`: Add items to the start of an array.
 
   ```md
@@ -261,6 +322,11 @@ Create or modify lists of values.
   ```
 
   Replace `items` with the array and `newItem` with items to add.
+
+  | Input | Description      |
+  | ----- | ---------------- |
+  | key   | Array to modify  |
+  | value | Items to prepend |
 
 ### Data retrieval & evaluation
 
@@ -273,6 +339,10 @@ Read or compute data without mutating state.
   ```
 
   Replace `hp` with the key to display.
+
+  | Input | Description          |
+  | ----- | -------------------- |
+  | key   | State key to display |
 
 ### Conditional logic
 
@@ -342,6 +412,10 @@ Run content only when conditions hold.
 
   Replace the keys with those from your game data.
 
+  | Input      | Description                                  |
+  | ---------- | -------------------------------------------- |
+  | expression | JavaScript condition evaluated against state |
+
 - `once`: Run content once per key.
 
   ```md
@@ -351,6 +425,10 @@ Run content only when conditions hold.
   ```
 
   Replace `SCENE` with a unique key for the block.
+
+  | Input | Description                      |
+  | ----- | -------------------------------- |
+  | key   | Unique key identifying the block |
 
 ### Event & trigger blocks
 
@@ -368,6 +446,10 @@ Run directives on specific passage events or group actions.
 
   Supports only the following directives: `if`, `set`, `setOnce`, `array`, `arrayOnce`, `unset`, `random`, and `randomOnce`. Nested `batch` directives are not allowed.
 
+  | Input    | Description                  |
+  | -------- | ---------------------------- |
+  | _(none)_ | This directive has no inputs |
+
 - `onExit`: Run data directives once when leaving the passage.
 
   ```md
@@ -380,6 +462,10 @@ Run directives on specific passage events or group actions.
   supports only the following directives: `if`, `set`, `setOnce`, `array`, `arrayOnce`, `unset`, `random`,
   `randomOnce`, and `batch`.
 
+  | Input    | Description                  |
+  | -------- | ---------------------------- |
+  | _(none)_ | This directive has no inputs |
+
 - `trigger`: Render a button that runs directives when clicked.
 
   ```md
@@ -391,6 +477,12 @@ Run directives on specific passage events or group actions.
   The `label` attribute must be a quoted string using matching single-, double-,
   or backtick quotes. Replace the label, classes, disabled state, and directives
   as needed.
+
+  | Input    | Description                            |
+  | -------- | -------------------------------------- |
+  | label    | Text displayed on the button           |
+  | class    | Optional space-separated classes       |
+  | disabled | Optional boolean to disable the button |
 
 ### Sequences & transitions
 
@@ -414,6 +506,14 @@ Reveal content step by step and animate its appearance.
   with `continueLabel` and `skipLabel`. The `fastForward` attribute accepts an
   object for advanced control.
 
+  | Input         | Description                              |
+  | ------------- | ---------------------------------------- |
+  | autoplay      | Automatically advance steps when true    |
+  | delay         | Time in ms between automatic advances    |
+  | continueLabel | Text for the continue button             |
+  | skipLabel     | Text for the skip button                 |
+  | fastForward   | Object controlling fast-forward behavior |
+
 - `step`: Define a single stage within a sequence.
 
   ```md
@@ -424,6 +524,10 @@ Reveal content step by step and animate its appearance.
 
   Steps may contain `transition` blocks and other directives.
 
+  | Input    | Description                  |
+  | -------- | ---------------------------- |
+  | _(none)_ | This directive has no inputs |
+
 - `transition`: Animate the appearance of content within a step.
 
   ```md
@@ -433,6 +537,12 @@ Reveal content step by step and animate its appearance.
   ```
 
   `type` currently supports `fade-in`. `duration` and `delay` are in milliseconds.
+
+  | Input    | Description                        |
+  | -------- | ---------------------------------- |
+  | type     | Animation style (e.g., `fade-in`)  |
+  | duration | Animation length in milliseconds   |
+  | delay    | Time in ms before animation starts |
 
 ### Navigation & composition
 
@@ -448,6 +558,10 @@ Control the flow between passages or how they appear.
   When using the `passage` attribute, unquoted strings are treated as keys in the
   game state.
 
+  | Input   | Description                            |
+  | ------- | -------------------------------------- |
+  | passage | Target passage name, pid, or state key |
+
 - `include`: Embed another passage's content.
 
   ```md
@@ -457,6 +571,10 @@ Control the flow between passages or how they appear.
   Use quotes or backticks for passage names. Unquoted numbers include by pid.
   When using the `passage` attribute, unquoted strings are treated as keys in the
   game state. Nested includes are limited to 10 levels to prevent infinite loops.
+
+  | Input   | Description                                |
+  | ------- | ------------------------------------------ |
+  | passage | Passage name, pid, or state key to include |
 
 - `title`: Set the document title.
 
@@ -473,6 +591,10 @@ Control the flow between passages or how they appear.
   - `title-show-passage="false"`: Hide the passage name and show only the
     story name.
 
+  | Input | Description                         |
+  | ----- | ----------------------------------- |
+  | text  | Title text displayed in the browser |
+
 ### Persistence
 
 Save and load progress or store data in the browser.
@@ -488,6 +610,11 @@ Save and load progress or store data in the browser.
   Replace `SAVE-ID` with a key and `LABEL` with a description. Saving a new
   checkpoint replaces any existing checkpoint.
 
+  | Input | Description                          |
+  | ----- | ------------------------------------ |
+  | id    | Key used to store the checkpoint     |
+  | label | Description shown for the checkpoint |
+
 - `clearCheckpoint`: Remove the saved checkpoint.
 
   ```md
@@ -497,6 +624,10 @@ Save and load progress or store data in the browser.
   Removes the currently stored checkpoint. Only one checkpoint can exist at a
   time, so this directive has no attributes.
 
+  | Input    | Description                  |
+  | -------- | ---------------------------- |
+  | _(none)_ | This directive has no inputs |
+
 - `loadCheckpoint`: Load a saved checkpoint.
 
   ```md
@@ -505,6 +636,10 @@ Save and load progress or store data in the browser.
 
   Loads the currently stored checkpoint. Only one checkpoint can exist at a
   time, so this directive has no attributes.
+
+  | Input    | Description                  |
+  | -------- | ---------------------------- |
+  | _(none)_ | This directive has no inputs |
 
 #### Saves
 
@@ -516,6 +651,10 @@ Save and load progress or store data in the browser.
 
   Replace `SLOT` with the storage id.
 
+  | Input | Description                   |
+  | ----- | ----------------------------- |
+  | id    | Storage key for the save slot |
+
 - `load`: Load state from local storage.
 
   ```md
@@ -524,6 +663,10 @@ Save and load progress or store data in the browser.
 
   Replace `SLOT` with the storage id.
 
+  | Input | Description              |
+  | ----- | ------------------------ |
+  | id    | Storage key to load from |
+
 - `clearSave`: Remove a stored game state.
 
   ```md
@@ -531,6 +674,10 @@ Save and load progress or store data in the browser.
   ```
 
   Replace `SLOT` with the storage id.
+
+  | Input | Description           |
+  | ----- | --------------------- |
+  | id    | Storage key to remove |
 
 ### Localization & internationalization
 
@@ -544,6 +691,10 @@ Change language and handle translations.
 
   Replace `lang` with a locale like `fr`.
 
+  | Input  | Description             |
+  | ------ | ----------------------- |
+  | locale | Locale code to activate |
+
 - `t`: Output a translated string. Use the optional `count` attribute for
   pluralization.
 
@@ -552,6 +703,11 @@ Change language and handle translations.
   ```
 
   Replace `apple` and `ui` with your key and namespace.
+
+  | Input  | Description                          |
+  | ------ | ------------------------------------ |
+  | ns:key | Namespace and key of the translation |
+  | count  | Optional count for pluralization     |
 
 - `translations`: Add a translation.
 
@@ -562,6 +718,12 @@ Change language and handle translations.
   Replace `lang` with the locale and `ui` with the namespace. Only one
   `namespace:key="value"` pair is allowed per directive. Repeat the directive
   for additional translations.
+
+  | Input  | Description                     |
+  | ------ | ------------------------------- |
+  | locale | Locale code for the translation |
+  | ns:key | Namespace and key to translate  |
+  | value  | Translated string               |
 
 Campfire prints descriptive error messages to the browser console when it encounters invalid markup.
 


### PR DESCRIPTION
## Summary
- document inputs for every directive using tables in README

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_689bb504bfe8832083a321751e4efc4f