### PR TITLE
feat: apply default heading typography

### DIFF
--- a/apps/campfire/__tests__/Passage.headings.test.tsx
+++ b/apps/campfire/__tests__/Passage.headings.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, beforeEach, expect } from 'bun:test'
+import { render, screen } from '@testing-library/preact'
+import i18next from 'i18next'
+import { initReactI18next } from 'react-i18next'
+import type { Element } from 'hast'
+import { Passage } from '../src/Passage'
+import { useStoryDataStore } from '@/packages/use-story-data-store'
+import { resetStores } from './helpers'
+
+describe('Passage heading styles', () => {
+  beforeEach(async () => {
+    document.body.innerHTML = ''
+    resetStores()
+    if (!i18next.isInitialized) {
+      await i18next.use(initReactI18next).init({ lng: 'en-US', resources: {} })
+    } else {
+      await i18next.changeLanguage('en-US')
+      i18next.services.resourceStore.data = {}
+    }
+  })
+
+  it('applies default font size and weight classes to headings', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [{ type: 'text', value: '# Title\n## Subtitle\n### Section' }]
+    }
+    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+    render(<Passage />)
+    const h1 = await screen.findByRole('heading', { level: 1 })
+    const h2 = screen.getByRole('heading', { level: 2 })
+    const h3 = screen.getByRole('heading', { level: 3 })
+    expect(h1.className).toContain('text-4xl')
+    expect(h1.className).toContain('font-bold')
+    expect(h2.className).toContain('text-3xl')
+    expect(h2.className).toContain('font-bold')
+    expect(h3.className).toContain('text-2xl')
+    expect(h3.className).toContain('font-semibold')
+  })
+})

--- a/apps/campfire/__tests__/Passage.headings.test.tsx
+++ b/apps/campfire/__tests__/Passage.headings.test.tsx
@@ -19,7 +19,7 @@ describe('Passage heading styles', () => {
     }
   })
 
-  it('applies default font size and weight classes to headings', async () => {
+  it('applies default font family, size, and weight classes to headings', async () => {
     const passage: Element = {
       type: 'element',
       tagName: 'tw-passagedata',
@@ -31,11 +31,14 @@ describe('Passage heading styles', () => {
     const h1 = await screen.findByRole('heading', { level: 1 })
     const h2 = screen.getByRole('heading', { level: 2 })
     const h3 = screen.getByRole('heading', { level: 3 })
+    expect(h1.className).toContain('font-cormorant')
     expect(h1.className).toContain('text-4xl')
     expect(h1.className).toContain('font-bold')
+    expect(h2.className).toContain('font-cormorant')
     expect(h2.className).toContain('text-3xl')
-    expect(h2.className).toContain('font-bold')
+    expect(h2.className).toContain('font-semibold')
+    expect(h3.className).toContain('font-cormorant')
     expect(h3.className).toContain('text-2xl')
-    expect(h3.className).toContain('font-semibold')
+    expect(h3.className).toContain('font-medium')
   })
 })

--- a/apps/campfire/src/Passage.tsx
+++ b/apps/campfire/src/Passage.tsx
@@ -11,6 +11,7 @@ import rehypeCampfire from '@/packages/rehype-campfire'
 import rehypeReact from 'rehype-react'
 import type { Text, Content } from 'hast'
 import { useDirectiveHandlers } from './useDirectiveHandlers'
+import { remarkHeadingStyles } from './remarkHeadingStyles'
 import { isTitleOverridden, clearTitleOverride } from './titleState'
 import {
   useStoryDataStore,
@@ -113,6 +114,7 @@ export const Passage = () => {
         .use(remarkGfm)
         .use(remarkDirective)
         .use(remarkCampfire, { handlers })
+        .use(remarkHeadingStyles)
         .use(remarkRehype)
         .use(rehypeCampfire)
         .use(rehypeReact, {

--- a/apps/campfire/src/remarkHeadingStyles.ts
+++ b/apps/campfire/src/remarkHeadingStyles.ts
@@ -21,9 +21,9 @@ export const remarkHeadingStyles = () => (tree: Root) => {
     if (!node.data) node.data = {}
     if (!node.data.hProperties) node.data.hProperties = {}
     const existing = node.data.hProperties.className
-    const classes: (string | number)[] = Array.isArray(existing)
-      ? [...existing]
-      : typeof existing === 'string' || typeof existing === 'number'
+    const classes: string[] = Array.isArray(existing)
+      ? existing.filter((c): c is string => typeof c === 'string')
+      : typeof existing === 'string'
         ? [existing]
         : []
     classes.push(cls)

--- a/apps/campfire/src/remarkHeadingStyles.ts
+++ b/apps/campfire/src/remarkHeadingStyles.ts
@@ -1,0 +1,32 @@
+import { visit } from 'unist-util-visit'
+import type { Root } from 'mdast'
+
+/**
+ * Applies default Tailwind font size and weight classes to Markdown heading nodes.
+ *
+ * @returns Transformer attaching class names to heading elements.
+ */
+export const remarkHeadingStyles = () => (tree: Root) => {
+  visit(tree, 'heading', node => {
+    const mapping: Record<number, string> = {
+      1: 'text-4xl font-bold',
+      2: 'text-3xl font-bold',
+      3: 'text-2xl font-semibold',
+      4: 'text-xl font-semibold',
+      5: 'text-lg font-semibold',
+      6: 'text-base font-semibold'
+    }
+    const cls = mapping[node.depth]
+    if (!cls) return
+    if (!node.data) node.data = {}
+    if (!node.data.hProperties) node.data.hProperties = {}
+    const existing = node.data.hProperties.className
+    const classes: (string | number)[] = Array.isArray(existing)
+      ? [...existing]
+      : typeof existing === 'string' || typeof existing === 'number'
+        ? [existing]
+        : []
+    classes.push(cls)
+    node.data.hProperties.className = classes
+  })
+}

--- a/apps/campfire/src/remarkHeadingStyles.ts
+++ b/apps/campfire/src/remarkHeadingStyles.ts
@@ -2,19 +2,19 @@ import { visit } from 'unist-util-visit'
 import type { Root } from 'mdast'
 
 /**
- * Applies default Tailwind font size and weight classes to Markdown heading nodes.
+ * Applies default Tailwind font family, size, and weight classes to Markdown heading nodes.
  *
  * @returns Transformer attaching class names to heading elements.
  */
 export const remarkHeadingStyles = () => (tree: Root) => {
   visit(tree, 'heading', node => {
     const mapping: Record<number, string> = {
-      1: 'text-4xl font-bold',
-      2: 'text-3xl font-bold',
-      3: 'text-2xl font-semibold',
-      4: 'text-xl font-semibold',
-      5: 'text-lg font-semibold',
-      6: 'text-base font-semibold'
+      1: 'font-cormorant text-4xl font-bold',
+      2: 'font-cormorant text-3xl font-semibold',
+      3: 'font-cormorant text-2xl font-medium',
+      4: 'font-cormorant text-xl font-normal',
+      5: 'font-cormorant text-lg font-normal',
+      6: 'font-cormorant text-base font-light'
     }
     const cls = mapping[node.depth]
     if (!cls) return

--- a/template.ejs
+++ b/template.ejs
@@ -3,9 +3,16 @@
   <head>
     <title>{{STORY_NAME}}: {{PASSAGE_NAME}}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Cormorant:ital,wght@0,300..700;1,300..700&display=swap"
+      rel="stylesheet"
+    />
     <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
     <style type="text/tailwindcss">
       @theme {
+        --font-cormorant: "Cormorant", serif;
         --color-red-50: oklch(0.971 0.013 17.38);
         --color-red-100: oklch(0.936 0.032 17.717);
         --color-red-200: oklch(0.885 0.062 18.334);
@@ -17,6 +24,14 @@
         --color-red-800: oklch(0.444 0.177 26.899);
         --color-red-900: oklch(0.396 0.141 25.723);
         --color-red-950: oklch(0.258 0.092 26.042);
+      }
+
+      @layer utilities {
+        .font-cormorant {
+          font-family: var(--font-cormorant);
+          font-optical-sizing: auto;
+          font-style: normal;
+        }
       }
     </style>
   </head>


### PR DESCRIPTION
## Summary
- add remark plugin to apply default Tailwind typography to headings
- integrate plugin into passage markdown pipeline
- test that headings receive expected classes

## Testing
- `bun tsc && echo "tsc success"`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_689bb64b0cf483208392cc5a24fa0078