### PR TITLE
feat(campfire): remove error section from debug window

### DIFF
--- a/apps/campfire/__tests__/DebugWindow.test.tsx
+++ b/apps/campfire/__tests__/DebugWindow.test.tsx
@@ -104,7 +104,7 @@ describe('DebugWindow', () => {
     expect(screen.getByText(/"hello"/)).toBeInTheDocument()
   })
 
-  it('shows error count and clears errors', () => {
+  it('does not show an error tab', () => {
     useStoryDataStore.setState({ storyData: { options: 'debug' } })
     useGameStore.setState(state => ({
       ...state,
@@ -112,19 +112,7 @@ describe('DebugWindow', () => {
     }))
 
     render(<DebugWindow />)
-
-    const errTab = screen.getByRole('button', { name: 'Errors (2)' })
-    expect(errTab).toHaveClass('text-red-500')
-    act(() => {
-      errTab.click()
-    })
-    expect(screen.getByText(/first error/)).toBeInTheDocument()
-    const clearButton = screen.getByRole('button', { name: 'Clear' })
-    act(() => {
-      clearButton.click()
-    })
-    expect(screen.queryByText('first error')).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Errors' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Errors/ })).toBeNull()
   })
 
   it('shows raw current passage', () => {

--- a/apps/campfire/src/DebugWindow.tsx
+++ b/apps/campfire/src/DebugWindow.tsx
@@ -12,13 +12,11 @@ const TAB_GAME = 'game' as const
 const TAB_STORY = 'story' as const
 const TAB_PASSAGE = 'passage' as const
 const TAB_TRANSLATIONS = 'translations' as const
-const TAB_ERRORS = 'errors' as const
 type Tab =
   | typeof TAB_GAME
   | typeof TAB_STORY
   | typeof TAB_PASSAGE
   | typeof TAB_TRANSLATIONS
-  | typeof TAB_ERRORS
 
 /**
  * Extracts the raw text from a passage element.
@@ -38,7 +36,7 @@ const getRawPassage = (passage: Element | undefined): string => {
 }
 
 /**
- * Renders a debug window showing game, story, translation and error data.
+ * Renders a debug window showing game, story, translation and passage data.
  * Also displays passage information when the debug option is enabled.
  */
 export const DebugWindow = () => {
@@ -79,8 +77,6 @@ export const DebugWindow = () => {
     }
   }, [])
   const gameData = useGameStore(state => state.gameData)
-  const errors = useGameStore(state => state.errors)
-  const clearErrors = useGameStore(state => state.clearErrors)
   const [visible, setVisible] = useState(true)
   const [minimized, setMinimized] = useState(false)
   const [tab, setTab] = useState<Tab>(TAB_GAME)
@@ -95,15 +91,6 @@ export const DebugWindow = () => {
    */
   const handleCopy = (): void => {
     void navigator.clipboard?.writeText(rawPassage)
-  }
-
-  /**
-   * Clears all recorded errors.
-   *
-   * @returns {void}
-   */
-  const handleClearErrors = (): void => {
-    clearErrors()
   }
 
   useEffect(() => {
@@ -196,18 +183,6 @@ export const DebugWindow = () => {
             >
               Translations
             </button>
-            <button
-              type='button'
-              className={`flex-1 p-2 ${
-                tab === TAB_ERRORS ? 'font-bold' : ''
-              } ${errors.length ? 'text-red-500' : ''}`}
-              onClick={e => {
-                e.stopPropagation()
-                setTab(TAB_ERRORS)
-              }}
-            >
-              Errors{errors.length ? ` (${errors.length})` : ''}
-            </button>
           </div>
           <div className='p-2'>
             {tab === TAB_GAME ? (
@@ -244,20 +219,7 @@ export const DebugWindow = () => {
               <pre className='whitespace-pre-wrap'>
                 {JSON.stringify(translations, null, 2)}
               </pre>
-            ) : (
-              <div>
-                <button
-                  type='button'
-                  onClick={e => {
-                    e.stopPropagation()
-                    handleClearErrors()
-                  }}
-                >
-                  Clear
-                </button>
-                <pre className='whitespace-pre-wrap'>{errors.join('\n')}</pre>
-              </div>
-            )}
+            ) : null}
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- remove error tab and related logic from debug window
- update tests for new debug window behavior

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_689bacdfdf9883229cf3f65519db625e