### PR TITLE
fix: support sequences inside if directives

### DIFF
--- a/apps/campfire/__tests__/Passage.sequence.test.tsx
+++ b/apps/campfire/__tests__/Passage.sequence.test.tsx
@@ -108,4 +108,23 @@ describe('Passage sequence directive', () => {
     expect(await screen.findByText('Foo')).toBeInTheDocument()
     expect(screen.queryByText(':::')).toBeNull()
   })
+
+  it('renders sequences within if directives', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value:
+            ':::sequence\n:::step\nOuter\n:::\n:::\n:::if{true}\n:::sequence\n:::step\nInner\n:::\n:::\n:::\n'
+        }
+      ]
+    }
+
+    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+    expect(() => render(<Passage />)).not.toThrow()
+    expect(await screen.findByText('Inner')).toBeInTheDocument()
+  })
 })

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -904,7 +904,7 @@ export const useDirectiveHandlers = () => {
     const content = JSON.stringify(stripLabel(main))
     const node: Parent = {
       type: 'paragraph',
-      children: [{ type: 'text', value: '' }],
+      children: [],
       data: {
         hName: 'if',
         hProperties: fallback


### PR DESCRIPTION
## Summary
- ensure `if` directives render without placeholder nodes
- add regression test for sequences inside `if` blocks

## Testing
- `npx tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_689bd448a2888322ac1b98d7a65fd8b0