### PR TITLE
fix(campfire): handle triggers in transition directives

### DIFF
--- a/apps/campfire/__tests__/Passage.sequence.test.tsx
+++ b/apps/campfire/__tests__/Passage.sequence.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'bun:test'
-import { render, screen, act } from '@testing-library/preact'
+import { render, screen, act, waitFor } from '@testing-library/preact'
 import i18next from 'i18next'
 import { initReactI18next } from 'react-i18next'
 import type { Element } from 'hast'
@@ -107,6 +107,31 @@ describe('Passage sequence directive', () => {
 
     expect(await screen.findByText('Foo')).toBeInTheDocument()
     expect(screen.queryByText(':::')).toBeNull()
+  })
+
+  it('handles trigger directives inside transitions', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value:
+            ':::sequence\n:::step\n:::transition\n:::trigger{label="Fire"}\n:::set[fired=true]\n:::\n:::\n:::\n'
+        }
+      ]
+    }
+
+    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+    render(<Passage />)
+    const button = await screen.findByRole('button', { name: 'Fire' })
+    act(() => {
+      button.click()
+    })
+    await waitFor(() => {
+      expect(useGameStore.getState().gameData.fired).toBe(true)
+    })
   })
 
   it('renders sequences within if directives', async () => {

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -1191,7 +1191,8 @@ export const useDirectiveHandlers = () => {
     if (!parent || typeof index !== 'number') return
     const { attrs } = extractAttributes(directive, parent, index, {})
     const container = directive as ContainerDirective
-    const children = stripLabel(container.children as RootContent[])
+    const rawChildren = stripLabel(container.children as RootContent[])
+    const children = preprocessBlock(rawChildren)
     runBlock(children)
     const node: Parent = {
       type: 'paragraph',
@@ -1223,7 +1224,8 @@ export const useDirectiveHandlers = () => {
       delay: { type: 'number' }
     })
     const container = directive as ContainerDirective
-    const children = stripLabel(container.children as RootContent[])
+    const rawChildren = stripLabel(container.children as RootContent[])
+    const children = preprocessBlock(rawChildren)
     runBlock(children)
     const node: Parent = {
       type: 'paragraph',


### PR DESCRIPTION
## Summary
- preprocess transition child directives so nested triggers no longer crash
- add regression test covering triggers inside transitions

## Testing
- `bun x prettier --write apps/campfire/src/useDirectiveHandlers.ts apps/campfire/__tests__/Passage.sequence.test.tsx`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_689bdad44498832080a6630866499013