### PR TITLE
fix: sanitize if directive content for multiple container blocks

### DIFF
--- a/apps/campfire/__tests__/If.directive.test.tsx
+++ b/apps/campfire/__tests__/If.directive.test.tsx
@@ -37,6 +37,30 @@ describe('If directive', () => {
     ).toBeInTheDocument()
   })
 
+  it('does not wrap container directives in paragraphs', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value:
+            ':::if{true}\n  :::trigger{label="One"}\n  :::\n  :::trigger{label="Two"}\n  :::\n:::'
+        }
+      ]
+    }
+    useStoryDataStore.setState({
+      passages: [passage],
+      currentPassageId: '1'
+    })
+    render(<Passage />)
+    const one = await screen.findByRole('button', { name: 'One' })
+    const two = await screen.findByRole('button', { name: 'Two' })
+    expect(one.parentElement?.tagName.toLowerCase()).not.toBe('p')
+    expect(two.parentElement?.tagName.toLowerCase()).not.toBe('p')
+  })
+
   it('skips all directives when condition is false', async () => {
     const passage: Element = {
       type: 'element',

--- a/apps/campfire/src/useDirectiveHandlers.ts
+++ b/apps/campfire/src/useDirectiveHandlers.ts
@@ -887,21 +887,34 @@ export const useDirectiveHandlers = () => {
         child.type === 'containerDirective' &&
         (child as ContainerDirective).name === 'else'
     )
-    let fallback: string | undefined
+    let fallbackNodes: RootContent[] | undefined
     let main = children
     if (elseIndex !== -1) {
       const next = children[elseIndex] as ContainerDirective
       main = children.slice(0, elseIndex)
-      fallback = JSON.stringify(stripLabel(next.children as RootContent[]))
+      fallbackNodes = next.children as RootContent[]
     } else if (elseSiblingIndex !== -1) {
       const next = parent.children[elseSiblingIndex] as ContainerDirective
-      fallback = JSON.stringify(stripLabel(next.children as RootContent[]))
+      fallbackNodes = next.children as RootContent[]
       const markerIndex = removeNode(parent, elseSiblingIndex)
       if (typeof markerIndex === 'number') {
         removeDirectiveMarker(parent, markerIndex)
       }
     }
-    const content = JSON.stringify(stripLabel(main))
+    /**
+     * Strips directive labels, runs preprocessing and removes empty text nodes.
+     *
+     * @param nodes - Nodes to prepare for serialization.
+     * @returns Cleaned array without whitespace-only text nodes.
+     */
+    const processNodes = (nodes: RootContent[]): RootContent[] =>
+      preprocessBlock(stripLabel(nodes)).filter(
+        node => !(node.type === 'text' && (node as MdText).value.trim() === '')
+      )
+    const content = JSON.stringify(processNodes(main))
+    const fallback = fallbackNodes
+      ? JSON.stringify(processNodes(fallbackNodes))
+      : undefined
     const node: Parent = {
       type: 'paragraph',
       children: [],


### PR DESCRIPTION
## Summary
- clean whitespace nodes from `if` directive content to prevent DOM insertion errors
- test that container directives inside `if` render without paragraph wrappers

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_689c11dbf4b083208eace0d94d3f2797