### PR TITLE
fix(sequence): handle string autoplay

### DIFF
--- a/apps/campfire/src/components/Passage/Sequence/__tests__/Sequence.test.tsx
+++ b/apps/campfire/src/components/Passage/Sequence/__tests__/Sequence.test.tsx
@@ -29,6 +29,21 @@ describe('Sequence', () => {
     expect(screen.getByText('Second')).toBeInTheDocument()
   })
 
+  it('treats the string "false" as disabled autoplay', () => {
+    render(
+      <Sequence autoplay='false'>
+        <Step>First</Step>
+        <Step>Second</Step>
+      </Sequence>
+    )
+    expect(screen.getByText('First')).toBeInTheDocument()
+    const button = screen.getByRole('button', { name: 'Continue to next step' })
+    act(() => {
+      button.click()
+    })
+    expect(screen.getByText('Second')).toBeInTheDocument()
+  })
+
   it('allows customizing continue button text', () => {
     render(
       <Sequence continueLabel='Next step'>


### PR DESCRIPTION
## Summary
- treat string values for `autoplay` as booleans so `autoplay="false"` disables autoplay
- test that sequence respects string `false`

## Testing
- `bun tsc`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_689cc64b234483209fe4d4f8415b8420