### PR TITLE
fix: apply transition styles to trigger buttons

### DIFF
--- a/apps/campfire/src/components/Passage/TriggerButton.tsx
+++ b/apps/campfire/src/components/Passage/TriggerButton.tsx
@@ -5,6 +5,7 @@ import remarkCampfire, {
 import type { RootContent, Root } from 'mdast'
 import rfdc from 'rfdc'
 import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
+import type { JSX } from 'preact'
 
 const clone = rfdc()
 
@@ -13,6 +14,7 @@ interface TriggerButtonProps {
   content: string
   children?: string
   disabled?: boolean
+  style?: JSX.CSSProperties
 }
 
 /**
@@ -22,12 +24,14 @@ interface TriggerButtonProps {
  * @param content - Serialized directive block.
  * @param children - Button label.
  * @param disabled - Disables the button when true.
+ * @param style - Optional inline styles.
  */
 export const TriggerButton = ({
   className,
   content,
   children,
-  disabled
+  disabled,
+  style
 }: TriggerButtonProps) => {
   const handlers = useDirectiveHandlers()
   /**
@@ -52,6 +56,7 @@ export const TriggerButton = ({
       type='button'
       className={['campfire-trigger', 'font-libertinus', ...classes].join(' ')}
       disabled={disabled}
+      style={style}
       onClick={() => runBlock(clone(JSON.parse(content)))}
     >
       {children}

--- a/apps/campfire/src/components/Passage/__tests__/Passage.sequence.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Passage.sequence.test.tsx
@@ -134,6 +134,27 @@ describe('Passage sequence directive', () => {
     })
   })
 
+  it('applies transition styles to trigger directives', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value:
+            ':::sequence\n:::step\n:::transition{delay=500}\n:::trigger{label="Fire"}\n:::\n:::\n:::\n'
+        }
+      ]
+    }
+
+    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+    render(<Passage />)
+    const button = await screen.findByRole('button', { name: 'Fire' })
+    expect(button.style.transition).toContain('opacity 300ms ease-in')
+    expect(button.style.transitionDelay).toBe('500ms')
+  })
+
   it('renders sequences within if directives', async () => {
     const passage: Element = {
       type: 'element',


### PR DESCRIPTION
## Summary
- forward inline styles from transitions to trigger buttons so they stay hidden until animation begins
- test trigger buttons receive transition styles

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_689ccf4971f4832087f4aaad1b57a688