### PR TITLE
fix: preserve if directive content during preprocessing

### DIFF
--- a/apps/campfire/src/components/Passage/__tests__/Passage.sequence.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Passage.sequence.test.tsx
@@ -173,4 +173,24 @@ describe('Passage sequence directive', () => {
     expect(() => render(<Passage />)).not.toThrow()
     expect(await screen.findByText('Inner')).toBeInTheDocument()
   })
+
+  it('does not render sequence steps when if condition is false', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value:
+            ':::sequence\n:::step\nOuter\n:::\n:::\n:::if{false}\n:::sequence\n:::step\n:::transition\nFirst\n:::\n:::\n:::step\n:::transition{delay=450}\nSecond\n:::\n:::\n:::\n'
+        }
+      ]
+    }
+
+    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+    render(<Passage />)
+    expect(screen.queryByText('First')).toBeNull()
+    expect(screen.queryByText('Second')).toBeNull()
+  })
 })

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -910,10 +910,12 @@ export const useDirectiveHandlers = () => {
      * @param nodes - Nodes to prepare for serialization.
      * @returns Cleaned array without whitespace-only text nodes.
      */
-    const processNodes = (nodes: RootContent[]): RootContent[] =>
-      preprocessBlock(stripLabel(nodes)).filter(
+    const processNodes = (nodes: RootContent[]): RootContent[] => {
+      const cloned = stripLabel(nodes).map(node => structuredClone(node))
+      return preprocessBlock(cloned).filter(
         node => !(isTextNode(node) && node.value.trim() === '')
       )
+    }
     const content = JSON.stringify(processNodes(main))
     const fallback = fallbackNodes
       ? JSON.stringify(processNodes(fallbackNodes))


### PR DESCRIPTION
## Summary
- clone directive children before preprocessing to prevent steps from leaking outside `if` blocks
- add regression test for sequences inside false `if` directives

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_689cdf765430832091826eec4c273754