### PR TITLE
fix: enforce exclusive random directive attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,6 @@ both. When using a numeric range, both `min` and `max` are required.
 | max   | Maximum value for numeric range                 |
 | from  | Array or state key to select a random item from |
 
-Provide either `min`/`max` or `from`.
 
 - `randomOnce`: Assign a random value once and lock the key.
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ both. When using a numeric range, both `min` and `max` are required.
 | max   | Maximum value for numeric range                 |
 | from  | Array or state key to select a random item from |
 
-Provide either `min`/`max` or `from`.
+**For both `random` and `randomOnce`, provide either `min`/`max` or `from`.**
 
 Use this to store a random value that should not change on subsequent runs.
 

--- a/README.md
+++ b/README.md
@@ -171,15 +171,18 @@ Operations that set, update, or remove scalar values.
   :random[pick]{from=items}
   ```
 
-  Replace `pick` with the key to store the result and supply either a literal
-  array or a state key after `from`.
+Replace `pick` with the key to store the result and supply either a literal
+array or a state key after `from`. Use either `min`/`max` _or_ `from`, but not
+both. When using a numeric range, both `min` and `max` are required.
 
-  | Input | Description                                     |
-  | ----- | ----------------------------------------------- |
-  | key   | State key to assign                             |
-  | min   | Minimum value for numeric range                 |
-  | max   | Maximum value for numeric range                 |
-  | from  | Array or state key to select a random item from |
+| Input | Description                                     |
+| ----- | ----------------------------------------------- |
+| key   | State key to assign                             |
+| min   | Minimum value for numeric range                 |
+| max   | Maximum value for numeric range                 |
+| from  | Array or state key to select a random item from |
+
+Provide either `min`/`max` or `from`.
 
 - `randomOnce`: Assign a random value once and lock the key.
 
@@ -187,14 +190,16 @@ Operations that set, update, or remove scalar values.
   :randomOnce[roll]{min=1 max=6}
   ```
 
-  | Input | Description                                     |
-  | ----- | ----------------------------------------------- |
-  | key   | State key to assign                             |
-  | min   | Minimum value for numeric range                 |
-  | max   | Maximum value for numeric range                 |
-  | from  | Array or state key to select a random item from |
+| Input | Description                                     |
+| ----- | ----------------------------------------------- |
+| key   | State key to assign                             |
+| min   | Minimum value for numeric range                 |
+| max   | Maximum value for numeric range                 |
+| from  | Array or state key to select a random item from |
 
-  Use this to store a random value that should not change on subsequent runs.
+Provide either `min`/`max` or `from`.
+
+Use this to store a random value that should not change on subsequent runs.
 
 - `unset`: Remove a key from state. This directive is leaf-only and cannot wrap
   content.


### PR DESCRIPTION
## Summary
- prevent using `from` with `min`/`max` in `:random`
- document random directive attribute exclusivity
- test random directive error cases

## Testing
- `bun tsc`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_689ce1c668b0832096088ed763bb1de0