### PR TITLE
fix: handle false-like strings in If directive

### DIFF
--- a/apps/campfire/src/components/Passage/If.tsx
+++ b/apps/campfire/src/components/Passage/If.tsx
@@ -70,7 +70,15 @@ export const If = ({ test, content, fallback }: IfProps) => {
       has: () => true,
       get: (obj, key) => (obj as Record<string, unknown>)[key as string]
     })
-    condition = !!fn(proxy)
+    const result = fn(proxy)
+    condition =
+      typeof result === 'string'
+        ? result.trim() !== '' &&
+          result !== 'false' &&
+          result !== '0' &&
+          result !== 'null' &&
+          result !== 'undefined'
+        : !!result
   } catch {
     condition = false
   }

--- a/apps/campfire/src/components/Passage/__tests__/If.sequence.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/If.sequence.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach } from 'bun:test'
+import { render, screen } from '@testing-library/preact'
+import type { Element } from 'hast'
+import { Passage } from '@campfire/components/Passage/Passage'
+import { useStoryDataStore } from '@/packages/use-story-data-store'
+import { resetStores } from '@campfire/test-utils/helpers'
+
+// ensure AGENTS instructions: we will run format etc; root instructions apply.
+
+describe('If with sequence', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    resetStores()
+  })
+
+  it('does not render sequence when condition is false', () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value:
+            ':set[showNext=false]\n\n:::if{showNext}\n  :::sequence\n    :::step\n      :::transition\n      Moving on...\n      :::\n    :::\n    :::step\n      :::transition{delay=450}\n      Next slide\n      :::\n    :::\n  :::\n:::'
+        }
+      ]
+    }
+    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+    render(<Passage />)
+    expect(screen.queryByText('Next slide')).toBeNull()
+    expect(screen.queryByText('Moving on...')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- treat string values like `"false"` or `"0"` as falsy when evaluating `If` conditions
- add regression test ensuring sequences inside `If` blocks don't render when the condition is false

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_689cf64c794083209bb6bdafd5ecb5f3