### PR TITLE
feat: add deck store for slide navigation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -95,6 +95,14 @@
         "unist-util-visit": "^5.0.0",
       },
     },
+    "packages/use-deck-store": {
+      "name": "use-deck-store",
+      "version": "0.0.0",
+      "dependencies": {
+        "immer": "^10.1.1",
+        "zustand": "^5.0.6",
+      },
+    },
     "packages/use-game-store": {
       "name": "use-game-store",
       "version": "0.0.0",
@@ -1174,6 +1182,8 @@
     "universal-user-agent": ["universal-user-agent@6.0.1", "", {}, "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="],
 
     "unplugin-utils": ["unplugin-utils@0.2.4", "", { "dependencies": { "pathe": "^2.0.2", "picomatch": "^4.0.2" } }, "sha512-8U/MtpkPkkk3Atewj1+RcKIjb5WBimZ/WSLhhR3w6SsIj8XJuKTacSP8g+2JhfSGw0Cb125Y+2zA/IzJZDVbhA=="],
+
+    "use-deck-store": ["use-deck-store@workspace:packages/use-deck-store"],
 
     "use-game-store": ["use-game-store@workspace:packages/use-game-store"],
 

--- a/packages/use-deck-store/__tests__/index.test.ts
+++ b/packages/use-deck-store/__tests__/index.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach } from 'bun:test'
+import { useDeckStore } from '../index'
+
+beforeEach(() => {
+  useDeckStore.setState({
+    currentSlide: 0,
+    currentStep: 0,
+    maxSteps: 0,
+    slidesCount: 0
+  })
+})
+
+describe('useDeckStore', () => {
+  it('updates slide and step counts', () => {
+    useDeckStore.getState().setSlidesCount(5)
+    useDeckStore.getState().setMaxSteps(2)
+    expect(useDeckStore.getState().slidesCount).toBe(5)
+    expect(useDeckStore.getState().maxSteps).toBe(2)
+  })
+
+  it('advances through steps and slides', () => {
+    useDeckStore.getState().setSlidesCount(2)
+    useDeckStore.getState().setMaxSteps(1)
+    useDeckStore.getState().next()
+    expect(useDeckStore.getState().currentStep).toBe(1)
+    useDeckStore.getState().next()
+    expect(useDeckStore.getState().currentSlide).toBe(1)
+    expect(useDeckStore.getState().currentStep).toBe(0)
+    expect(useDeckStore.getState().maxSteps).toBe(0)
+  })
+
+  it('moves back through steps and slides', () => {
+    useDeckStore.getState().setSlidesCount(2)
+    useDeckStore.getState().setMaxSteps(1)
+    useDeckStore.getState().next()
+    useDeckStore.getState().next()
+    useDeckStore.getState().prev()
+    expect(useDeckStore.getState().currentSlide).toBe(0)
+    expect(useDeckStore.getState().currentStep).toBe(0)
+  })
+
+  it('jumps to a specific slide and step', () => {
+    useDeckStore.getState().setSlidesCount(3)
+    useDeckStore.getState().goTo(2, 1)
+    expect(useDeckStore.getState().currentSlide).toBe(2)
+    expect(useDeckStore.getState().currentStep).toBe(1)
+    expect(useDeckStore.getState().maxSteps).toBe(0)
+  })
+})

--- a/packages/use-deck-store/index.ts
+++ b/packages/use-deck-store/index.ts
@@ -1,0 +1,86 @@
+import { produce } from 'immer'
+import { create } from 'zustand'
+
+export interface DeckState {
+  /** Currently active slide index */
+  currentSlide: number
+  /** Currently active step within the slide */
+  currentStep: number
+  /** Maximum number of steps for the current slide */
+  maxSteps: number
+  /** Total number of slides */
+  slidesCount: number
+  /** Update the total slide count */
+  setSlidesCount: (n: number) => void
+  /** Update the maximum steps for the current slide */
+  setMaxSteps: (n: number) => void
+  /** Advance to the next step or slide */
+  next: () => void
+  /** Go back to the previous step or slide */
+  prev: () => void
+  /** Jump to a specific slide and step */
+  goTo: (slide: number, step?: number) => void
+}
+
+export const useDeckStore = create<DeckState>((set, get) => ({
+  currentSlide: 0,
+  currentStep: 0,
+  maxSteps: 0,
+  slidesCount: 0,
+  setSlidesCount: n =>
+    set(
+      produce((state: DeckState) => {
+        state.slidesCount = n
+      })
+    ),
+  setMaxSteps: n =>
+    set(
+      produce((state: DeckState) => {
+        state.maxSteps = n
+      })
+    ),
+  next: () => {
+    const { currentStep, maxSteps, currentSlide, slidesCount } = get()
+    if (currentStep < maxSteps) {
+      set(
+        produce((state: DeckState) => {
+          state.currentStep += 1
+        })
+      )
+    } else if (currentSlide < slidesCount - 1) {
+      set(
+        produce((state: DeckState) => {
+          state.currentSlide += 1
+          state.currentStep = 0
+          state.maxSteps = 0
+        })
+      )
+    }
+  },
+  prev: () => {
+    const { currentStep, currentSlide } = get()
+    if (currentStep > 0) {
+      set(
+        produce((state: DeckState) => {
+          state.currentStep -= 1
+        })
+      )
+    } else if (currentSlide > 0) {
+      set(
+        produce((state: DeckState) => {
+          state.currentSlide -= 1
+          state.currentStep = 0
+          state.maxSteps = 0
+        })
+      )
+    }
+  },
+  goTo: (slide, step = 0) =>
+    set(
+      produce((state: DeckState) => {
+        state.currentSlide = slide
+        state.currentStep = step
+        state.maxSteps = 0
+      })
+    )
+}))

--- a/packages/use-deck-store/package.json
+++ b/packages/use-deck-store/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "use-deck-store",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "test": "bun test"
+  },
+  "dependencies": {
+    "immer": "^10.1.1",
+    "zustand": "^5.0.6"
+  }
+}

--- a/packages/use-deck-store/tsconfig.json
+++ b/packages/use-deck-store/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "types": ["bun", "preact"]
+  },
+  "extends": "../../tsconfig.json"
+}


### PR DESCRIPTION
## Summary
- add `useDeckStore` for managing slide and step progression
- ensure immutable state updates via Immer `produce`
- test deck navigation behaviors

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_689d2e1d64a8832090b4fb89c746a8d9