### PR TITLE
feat: add useScale hook

### DIFF
--- a/apps/campfire/src/hooks/__tests__/useScale.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/useScale.test.tsx
@@ -1,6 +1,6 @@
 import { render, act } from '@testing-library/preact'
 import { describe, it, expect } from 'bun:test'
-import { useScale } from '@campfire/hooks/useScale'
+import { useScale, MIN_SCALE } from '@campfire/hooks/useScale'
 
 /**
  * Replaces the global ResizeObserver with a mock that allows manual
@@ -53,7 +53,7 @@ describe('useScale', () => {
     expect(currentScale).toBe(2)
   })
 
-  it('prevents scale from dropping below 0.01', () => {
+  it('prevents scale from dropping below the minimum', () => {
     const trigger = setupResizeObserver()
     let currentScale = 1
 
@@ -72,6 +72,6 @@ describe('useScale', () => {
     Object.defineProperty(el, 'clientWidth', { value: 1, configurable: true })
     Object.defineProperty(el, 'clientHeight', { value: 1, configurable: true })
     act(() => trigger())
-    expect(currentScale).toBe(0.01)
+    expect(currentScale).toBe(MIN_SCALE)
   })
 })

--- a/apps/campfire/src/hooks/__tests__/useScale.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/useScale.test.tsx
@@ -1,0 +1,77 @@
+import { render, act } from '@testing-library/preact'
+import { describe, it, expect } from 'bun:test'
+import { useScale } from '@campfire/hooks/useScale'
+
+/**
+ * Replaces the global ResizeObserver with a mock that allows manual
+ * triggering of resize callbacks.
+ *
+ * @returns A function that invokes the stored resize callback.
+ */
+const setupResizeObserver = () => {
+  let callback: ResizeObserverCallback = () => {}
+  class MockResizeObserver {
+    constructor(cb: ResizeObserverCallback) {
+      callback = cb
+    }
+    observe() {}
+    disconnect() {}
+  }
+  // @ts-expect-error override for tests
+  globalThis.ResizeObserver = MockResizeObserver
+  return () => callback([], {} as ResizeObserver)
+}
+
+describe('useScale', () => {
+  it('updates scale when container size changes', () => {
+    const trigger = setupResizeObserver()
+    let currentScale = 0
+
+    /**
+     * Test component that exposes the scale computed by the hook.
+     */
+    const TestComponent = () => {
+      const { ref, scale } = useScale({ width: 100, height: 100 })
+      currentScale = scale
+      return <div ref={ref} />
+    }
+
+    const { container } = render(<TestComponent />)
+    const el = container.firstElementChild as HTMLDivElement
+
+    Object.defineProperty(el, 'clientWidth', { value: 50, configurable: true })
+    Object.defineProperty(el, 'clientHeight', { value: 40, configurable: true })
+    act(() => trigger())
+    expect(currentScale).toBe(0.4)
+
+    Object.defineProperty(el, 'clientWidth', { value: 200, configurable: true })
+    Object.defineProperty(el, 'clientHeight', {
+      value: 300,
+      configurable: true
+    })
+    act(() => trigger())
+    expect(currentScale).toBe(2)
+  })
+
+  it('prevents scale from dropping below 0.01', () => {
+    const trigger = setupResizeObserver()
+    let currentScale = 1
+
+    /**
+     * Test component that uses a large base size to trigger minimum scale.
+     */
+    const TestComponent = () => {
+      const { ref, scale } = useScale({ width: 1000, height: 1000 })
+      currentScale = scale
+      return <div ref={ref} />
+    }
+
+    const { container } = render(<TestComponent />)
+    const el = container.firstElementChild as HTMLDivElement
+
+    Object.defineProperty(el, 'clientWidth', { value: 1, configurable: true })
+    Object.defineProperty(el, 'clientHeight', { value: 1, configurable: true })
+    act(() => trigger())
+    expect(currentScale).toBe(0.01)
+  })
+})

--- a/apps/campfire/src/hooks/useScale.ts
+++ b/apps/campfire/src/hooks/useScale.ts
@@ -1,6 +1,11 @@
 import { useLayoutEffect, useRef, useState } from 'preact/hooks'
 
 /**
+ * Minimum allowed scale factor to ensure content remains visible.
+ */
+export const MIN_SCALE = 0.01
+
+/**
  * Dimensions of the content to scale within the container.
  */
 export interface DeckSize {
@@ -28,7 +33,7 @@ export const useScale = (size: DeckSize) => {
       const { clientWidth: cw, clientHeight: ch } = el
       const sx = cw / size.width
       const sy = ch / size.height
-      const s = Math.max(0.01, Math.min(sx, sy))
+      const s = Math.max(MIN_SCALE, Math.min(sx, sy))
       setScale(s)
     })
 

--- a/apps/campfire/src/hooks/useScale.ts
+++ b/apps/campfire/src/hooks/useScale.ts
@@ -1,0 +1,40 @@
+import { useLayoutEffect, useRef, useState } from 'preact/hooks'
+
+/**
+ * Dimensions of the content to scale within the container.
+ */
+export interface DeckSize {
+  width: number
+  height: number
+}
+
+/**
+ * Observes the container size and computes a scale factor that keeps the
+ * content within the provided dimensions. Returns a ref to attach to the
+ * container element and the current scale value.
+ *
+ * @param size - The natural width and height of the content.
+ * @returns An object containing the `ref` and computed `scale` value.
+ */
+export const useScale = (size: DeckSize) => {
+  const ref = useRef<HTMLDivElement>(null)
+  const [scale, setScale] = useState(1)
+
+  useLayoutEffect(() => {
+    if (!ref.current) return
+
+    const el = ref.current
+    const ro = new ResizeObserver(() => {
+      const { clientWidth: cw, clientHeight: ch } = el
+      const sx = cw / size.width
+      const sy = ch / size.height
+      const s = Math.max(0.01, Math.min(sx, sy))
+      setScale(s)
+    })
+
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [size.height, size.width])
+
+  return { ref, scale } as const
+}


### PR DESCRIPTION
## Summary
- add `useScale` Preact hook that computes container scale using `ResizeObserver`

## Testing
- `bun x prettier --write apps/campfire/src/hooks/useScale.ts`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_689d4e2dfa4c83209f2116ca7edc9fd8