### PR TITLE
feat(deck): add gray background

### DIFF
--- a/apps/campfire/src/components/Deck/Deck.tsx
+++ b/apps/campfire/src/components/Deck/Deck.tsx
@@ -86,7 +86,7 @@ export const Deck = ({
   return (
     <div
       ref={hostRef}
-      className={`relative w-full h-full overflow-hidden ${className ?? ''}`}
+      className={`relative w-full h-full overflow-hidden bg-gray-100 dark:bg-gray-900 ${className ?? ''}`}
       style={themeStyle}
     >
       <div

--- a/apps/campfire/src/components/Deck/__tests__/Deck.test.tsx
+++ b/apps/campfire/src/components/Deck/__tests__/Deck.test.tsx
@@ -41,6 +41,15 @@ describe('Deck', () => {
     expect(screen.getByText('Slide 1')).toBeInTheDocument()
   })
 
+  it('uses gray backgrounds for light and dark modes', () => {
+    const { container } = render(
+      <Deck>
+        <div>Slide 1</div>
+      </Deck>
+    )
+    expect(container.firstChild).toHaveClass('bg-gray-100', 'dark:bg-gray-900')
+  })
+
   it('advances and reverses slides via click and keyboard', () => {
     render(
       <Deck>


### PR DESCRIPTION
## Summary
- apply predefined gray background to Deck component
- test default gray styling for Deck
- support light and dark mode backgrounds

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_689db25e837c832085602a0303b4aefe