### PR TITLE
ci: run tests only on release-candidate merges

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,7 @@ name: Test
 
 on:
   push:
-    branches: [main]
-  pull_request:
+    branches: [release-candidate]
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- run test workflow only after pushes to release-candidate

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_689e204a844883209161bd97f608c112