### PR TITLE
feat(storybook): add Deck component story

### DIFF
--- a/apps/storybook/src/Deck.stories.tsx
+++ b/apps/storybook/src/Deck.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/preact'
+import { h } from 'preact'
+import { Deck, Slide } from '@campfire/components'
+
+const meta: Meta<typeof Deck> = {
+  component: Deck,
+  title: 'Campfire/Deck'
+}
+
+export default meta
+
+/**
+ * Renders the Deck story with three slides and transitions.
+ *
+ * @returns The rendered Deck element.
+ */
+const render: StoryObj<typeof Deck>['render'] = () => (
+  <Deck className='w-[800px] h-[600px]'>
+    <Slide
+      transition={{
+        enter: { type: 'fade', duration: 300 },
+        exit: { type: 'fade', duration: 300 }
+      }}
+    >
+      <h2 class='text-4xl'>Fade Slide</h2>
+    </Slide>
+    <Slide
+      transition={{
+        enter: { type: 'slide', dir: 'left', duration: 300 },
+        exit: { type: 'slide', dir: 'right', duration: 300 }
+      }}
+    >
+      <h2 class='text-4xl'>Slide Transition</h2>
+    </Slide>
+    <Slide
+      transition={{
+        enter: { type: 'zoom', duration: 300 },
+        exit: { type: 'zoom', duration: 300 }
+      }}
+    >
+      <h2 class='text-4xl'>Zoom Slide</h2>
+    </Slide>
+  </Deck>
+)
+
+export const WithTransitions: StoryObj<typeof Deck> = { render }


### PR DESCRIPTION
## Summary
- add Storybook story for Deck with multiple slides and transitions

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_689e59c021dc83209a0c8a9bcfe0ccb3