### PR TITLE
fix: add @campfire alias for Storybook

### DIFF
--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import type { StorybookConfig } from '@storybook/preact-vite'
 
 const config: StorybookConfig = {
@@ -5,6 +6,24 @@ const config: StorybookConfig = {
   framework: {
     name: '@storybook/preact-vite',
     options: {}
+  },
+  /**
+   * Extends Storybook's Vite configuration to resolve `@campfire` imports.
+   *
+   * @param config - The existing Vite configuration.
+   * @returns The updated configuration with the `@campfire` alias.
+   */
+  viteFinal: async config => {
+    config.resolve ??= {}
+    config.resolve.alias = [
+      ...(config.resolve.alias ?? []),
+      {
+        find: '@campfire',
+        replacement: path.resolve(__dirname, '../../campfire/src')
+      }
+    ]
+
+    return config
   }
 }
 


### PR DESCRIPTION
## Summary
- resolve `@campfire` imports in Storybook's Vite config so Deck stories run

## Testing
- `bun tsc --noEmit`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_689e5c0ede40832084669415f9d26eae