### PR TITLE
fix: optimize store bindings and hook usage

### DIFF
--- a/apps/campfire/src/components/Appear/Appear.tsx
+++ b/apps/campfire/src/components/Appear/Appear.tsx
@@ -118,7 +118,10 @@ export const Appear = ({
   interruptBehavior = 'jumpToEnd',
   children
 }: AppearProps): JSX.Element | null => {
-  const { currentStep, currentSlide, maxSteps, setMaxSteps } = useDeckStore()
+  const currentStep = useDeckStore(state => state.currentStep)
+  const currentSlide = useDeckStore(state => state.currentSlide)
+  const maxSteps = useDeckStore(state => state.maxSteps)
+  const setMaxSteps = useDeckStore(state => state.setMaxSteps)
   const [present, setPresent] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
   const animationRef = useRef<Animation | null>(null)

--- a/apps/campfire/src/components/Deck/Deck.tsx
+++ b/apps/campfire/src/components/Deck/Deck.tsx
@@ -47,7 +47,11 @@ export const Deck = ({
       ),
     [children]
   )
-  const { currentSlide, next, prev, goTo, setSlidesCount } = useDeckStore()
+  const currentSlide = useDeckStore(state => state.currentSlide)
+  const next = useDeckStore(state => state.next)
+  const prev = useDeckStore(state => state.prev)
+  const goTo = useDeckStore(state => state.goTo)
+  const setSlidesCount = useDeckStore(state => state.setSlidesCount)
 
   useEffect(() => {
     setSlidesCount(slides.length)

--- a/apps/campfire/src/components/Slide/Slide.tsx
+++ b/apps/campfire/src/components/Slide/Slide.tsx
@@ -50,7 +50,8 @@ export const Slide = ({
   onExit,
   children
 }: SlideProps): JSX.Element => {
-  const { maxSteps, setMaxSteps } = useDeckStore()
+  const maxSteps = useDeckStore(state => state.maxSteps)
+  const setMaxSteps = useDeckStore(state => state.setMaxSteps)
   const runEnter = useSerializedDirectiveRunner(onEnter ?? '[]')
   const runExit = useSerializedDirectiveRunner(onExit ?? '[]')
   const cleanupRanRef = useRef(false)

--- a/apps/campfire/src/hooks/useSerializedDirectiveRunner.ts
+++ b/apps/campfire/src/hooks/useSerializedDirectiveRunner.ts
@@ -69,8 +69,9 @@ export const useSerializedDirectiveRunner = (content: string) => {
       .runSync(root)
   }
 
+  const gameData = useGameStore(state => state.gameData)
+
   return useCallback(() => {
-    const gameData = useGameStore.getState().gameData as Record<string, unknown>
-    runBlock(clone(baseNodes), gameData)
-  }, [baseNodes, handlers])
+    runBlock(clone(baseNodes), gameData as Record<string, unknown>)
+  }, [baseNodes, handlers, gameData])
 }


### PR DESCRIPTION
## Summary
- use Zustand selectors for deck store bindings
- avoid calling `useGameStore` inside `useCallback`

## Testing
- `bun tsc`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_689e63a8ccc4832081c0b24b97973b04