### PR TITLE
docs: use Appear in Deck story

### DIFF
--- a/apps/campfire/src/components/Slide/Slide.tsx
+++ b/apps/campfire/src/components/Slide/Slide.tsx
@@ -21,7 +21,10 @@ export type SlideTransition =
 export interface SlideProps {
   /** Optional build steps on this slide (used by the Deck store when active). */
   steps?: number
-  /** Transition metadata consumed by Deck’s WAAPI wrapper. */
+  /**
+   * Transition metadata consumed by Deck’s WAAPI wrapper and exposed via the
+   * `data-transition` attribute.
+   */
   transition?: SlideTransition
   /** Color classes or image background config. */
   background?:
@@ -100,6 +103,7 @@ export const Slide = ({
     <div
       className={`relative w-full h-full overflow-hidden ${bgClass} ${className ?? ''}`}
       style={bgStyle}
+      data-transition={transition ? JSON.stringify(transition) : undefined}
     >
       {children}
     </div>

--- a/apps/campfire/src/components/Slide/__tests__/Slide.test.tsx
+++ b/apps/campfire/src/components/Slide/__tests__/Slide.test.tsx
@@ -63,5 +63,8 @@ describe('Slide', () => {
       duration: 300
     })
     expect(el.style.animationName).toBe('')
+    expect(el.dataset.transition).toBe(
+      JSON.stringify({ type: 'fade', duration: 300 })
+    )
   })
 })

--- a/apps/storybook/src/Deck.stories.tsx
+++ b/apps/storybook/src/Deck.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/preact'
 import { h } from 'preact'
-import { Deck, Slide, Text } from '@campfire/components'
+import { Deck, Slide, Text, Appear } from '@campfire/components'
 
 const meta: Meta<typeof Deck> = {
   component: Deck,
@@ -10,7 +10,9 @@ const meta: Meta<typeof Deck> = {
 export default meta
 
 /**
- * Renders the Deck story with three slides and transitions.
+ * Renders the Deck story with three slides and transitions using the Appear
+ * component to progressively reveal content. Text layers are positioned so
+ * they do not overlap.
  *
  * @returns The rendered Deck element.
  */
@@ -22,9 +24,25 @@ const render: StoryObj<typeof Deck>['render'] = () => (
         exit: { type: 'fade', duration: 300 }
       }}
     >
-      <Text as={'h2'}>
-        <h2 className='text-4xl text-[var(--color-gray-50)]'>Fade Slide</h2>
-      </Text>
+      <Appear at={0}>
+        <Text
+          as='h2'
+          x={80}
+          y={80}
+          size={36}
+          color='var(--color-gray-50)'
+          content='Fade Slide'
+        />
+      </Appear>
+      <Appear at={1}>
+        <Text
+          x={500}
+          y={400}
+          size={24}
+          color='var(--color-gray-50)'
+          content='Second step'
+        />
+      </Appear>
     </Slide>
     <Slide
       transition={{
@@ -32,9 +50,25 @@ const render: StoryObj<typeof Deck>['render'] = () => (
         exit: { type: 'slide', dir: 'right', duration: 300 }
       }}
     >
-      <Text as={'h2'}>
-        <h2 class='text-4xl text-[var(--color-gray-50)]'>Slide Transition</h2>
-      </Text>
+      <Appear at={0}>
+        <Text
+          as='h2'
+          x={80}
+          y={80}
+          size={36}
+          color='var(--color-gray-50)'
+          content='Slide Transition'
+        />
+      </Appear>
+      <Appear at={1}>
+        <Text
+          x={500}
+          y={400}
+          size={24}
+          color='var(--color-gray-50)'
+          content='Second step'
+        />
+      </Appear>
     </Slide>
     <Slide
       transition={{
@@ -42,9 +76,25 @@ const render: StoryObj<typeof Deck>['render'] = () => (
         exit: { type: 'zoom', duration: 300 }
       }}
     >
-      <Text as={'h2'}>
-        <h2 class='text-4xl text-[var(--color-gray-50)]'>Zoom Slide</h2>
-      </Text>
+      <Appear at={0}>
+        <Text
+          as='h2'
+          x={80}
+          y={80}
+          size={36}
+          color='var(--color-gray-50)'
+          content='Zoom Slide'
+        />
+      </Appear>
+      <Appear at={1}>
+        <Text
+          x={500}
+          y={400}
+          size={24}
+          color='var(--color-gray-50)'
+          content='Second step'
+        />
+      </Appear>
     </Slide>
   </Deck>
 )


### PR DESCRIPTION
## Summary
- demonstrate step-by-step content in Deck stories using Appear
- position text layers to avoid overlap

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_689e83e09b2883208a79c3d745e1a5f0