### PR TITLE
fix: apply slide transitions

### DIFF
--- a/apps/campfire/src/components/Appear/Appear.tsx
+++ b/apps/campfire/src/components/Appear/Appear.tsx
@@ -1,10 +1,12 @@
 import { type ComponentChildren, type JSX } from 'preact'
 import { useEffect, useRef, useState } from 'preact/hooks'
 import { useDeckStore } from '@campfire/use-deck-store'
+import { type Transition } from '@campfire/components/Slide/Slide'
 import {
-  type Transition,
-  type Direction
-} from '@campfire/components/Slide/Slide'
+  defaultTransition,
+  prefersReducedMotion,
+  runAnimation
+} from '@campfire/components/transition'
 
 export interface AppearProps {
   at?: number
@@ -14,95 +16,6 @@ export interface AppearProps {
   interruptBehavior?: 'jumpToEnd' | 'cancel'
   children: ComponentChildren
 }
-
-const defaultTransition: Transition = { type: 'fade', duration: 300 }
-
-/**
- * Returns whether the user prefers reduced motion.
- *
- * @returns True if reduced motion is preferred.
- */
-const prefersReducedMotion = (): boolean =>
-  typeof window !== 'undefined' &&
-  window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true
-
-/**
- * Builds keyframes for the given transition and mode.
- *
- * @param transition - Transition configuration.
- * @param mode - Whether the animation is entering or exiting.
- * @returns A sequence of keyframes.
- */
-const buildKeyframes = (
-  transition: Transition,
-  mode: 'in' | 'out'
-): Keyframe[] => {
-  switch (transition.type) {
-    case 'fade':
-      return mode === 'in'
-        ? [{ opacity: 0 }, { opacity: 1 }]
-        : [{ opacity: 1 }, { opacity: 0 }]
-    case 'slide': {
-      const offset = 40
-      const dir: Direction = transition.dir ?? 'up'
-      let axis: 'X' | 'Y' = 'Y'
-      let from = -offset
-      if (dir === 'left') {
-        axis = 'X'
-        from = -offset
-      } else if (dir === 'right') {
-        axis = 'X'
-        from = offset
-      } else if (dir === 'down') {
-        axis = 'Y'
-        from = offset
-      }
-      const start = `translate${axis}(${from}px)`
-      const end = `translate${axis}(0px)`
-      return mode === 'in'
-        ? [
-            { transform: start, opacity: 0 },
-            { transform: end, opacity: 1 }
-          ]
-        : [
-            { transform: end, opacity: 1 },
-            { transform: start, opacity: 0 }
-          ]
-    }
-    case 'zoom':
-      return mode === 'in'
-        ? [
-            { transform: 'scale(0.95)', opacity: 0 },
-            { transform: 'scale(1)', opacity: 1 }
-          ]
-        : [
-            { transform: 'scale(1)', opacity: 1 },
-            { transform: 'scale(0.95)', opacity: 0 }
-          ]
-    default:
-      return []
-  }
-}
-
-/**
- * Runs a WAAPI animation for the provided element and transition.
- *
- * @param el - Target element.
- * @param transition - Transition configuration.
- * @param mode - Whether this is an enter or exit animation.
- * @returns The created animation instance.
- */
-const runAnimation = (
-  el: HTMLElement,
-  transition: Transition,
-  mode: 'in' | 'out'
-): Animation =>
-  el.animate(buildKeyframes(transition, mode), {
-    duration: transition.duration ?? 300,
-    easing: transition.easing ?? 'ease',
-    delay: transition.delay ?? 0,
-    fill: 'forwards'
-  })
 
 /**
  * Gradually reveals or hides content based on the current deck step.

--- a/apps/campfire/src/components/Deck/Deck.tsx
+++ b/apps/campfire/src/components/Deck/Deck.tsx
@@ -6,9 +6,18 @@ import {
   type JSX,
   type VNode
 } from 'preact'
-import { useEffect, useMemo } from 'preact/hooks'
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import { useDeckStore } from '@campfire/use-deck-store'
 import { useScale, type DeckSize } from '@campfire/hooks/useScale'
+import {
+  defaultTransition,
+  prefersReducedMotion,
+  runAnimation
+} from '@campfire/components/transition'
+import {
+  type Transition,
+  type SlideTransition
+} from '@campfire/components/Slide/Slide'
 
 export type ThemeTokens = Record<string, string | number>
 
@@ -52,6 +61,60 @@ export const Deck = ({
   const prev = useDeckStore(state => state.prev)
   const goTo = useDeckStore(state => state.goTo)
   const setSlidesCount = useDeckStore(state => state.setSlidesCount)
+
+  const [currentVNode, setCurrentVNode] = useState(slides[0] as VNode)
+  const [prevVNode, setPrevVNode] = useState<VNode | null>(null)
+  const slideRef = useRef<HTMLDivElement>(null)
+  const reduceMotion = prefersReducedMotion()
+  const firstRenderRef = useRef(true)
+
+  /**
+   * Retrieves the transition configuration for a slide and mode.
+   *
+   * @param slide - Slide vnode.
+   * @param mode - Whether the slide is entering or exiting.
+   * @returns Transition configuration.
+   */
+  const getTransition = (slide: VNode, mode: 'enter' | 'exit'): Transition => {
+    const t: SlideTransition | undefined = (slide.props as any).transition
+    if (!t) return defaultTransition
+    if ('type' in t) return t
+    return t[mode] ?? defaultTransition
+  }
+
+  useEffect(() => {
+    if (firstRenderRef.current) {
+      firstRenderRef.current = false
+      return
+    }
+    const nextVNode = slides[currentSlide] as VNode
+    setPrevVNode(currentVNode)
+    setCurrentVNode(nextVNode)
+  }, [currentSlide, slides, currentVNode])
+
+  useEffect(() => {
+    const container = slideRef.current
+    if (!container) return
+    const [prevEl, currentEl] = Array.from(container.children) as HTMLElement[]
+    if (
+      currentEl &&
+      !(reduceMotion || getTransition(currentVNode, 'enter').type === 'none')
+    ) {
+      runAnimation(currentEl, getTransition(currentVNode, 'enter'), 'in')
+    }
+    if (prevVNode && prevEl) {
+      if (reduceMotion || getTransition(prevVNode, 'exit').type === 'none') {
+        setPrevVNode(null)
+      } else {
+        const anim = runAnimation(
+          prevEl,
+          getTransition(prevVNode, 'exit'),
+          'out'
+        )
+        anim.finished.then(() => setPrevVNode(null))
+      }
+    }
+  }, [currentVNode, prevVNode, reduceMotion])
 
   useEffect(() => {
     setSlidesCount(slides.length)
@@ -116,6 +179,7 @@ export const Deck = ({
       style={themeStyle}
     >
       <div
+        ref={slideRef}
         style={{
           width: size.width,
           height: size.height,
@@ -125,7 +189,8 @@ export const Deck = ({
         className='absolute left-1/2 top-1/2'
         onClick={next}
       >
-        {slides[currentSlide]}
+        {prevVNode}
+        {currentVNode}
       </div>
     </div>
   )

--- a/apps/campfire/src/components/Deck/Deck.tsx
+++ b/apps/campfire/src/components/Deck/Deck.tsx
@@ -69,6 +69,17 @@ export const Deck = ({
   const firstRenderRef = useRef(true)
 
   /**
+   * Type guard to determine whether props include a transition configuration.
+   *
+   * @param props - Props to test.
+   * @returns True if the props contain a transition.
+   */
+  const hasTransition = (
+    props: unknown
+  ): props is { transition?: SlideTransition } =>
+    typeof props === 'object' && props !== null && 'transition' in props
+
+  /**
    * Retrieves the transition configuration for a slide and mode.
    *
    * @param slide - Slide vnode.
@@ -76,7 +87,7 @@ export const Deck = ({
    * @returns Transition configuration.
    */
   const getTransition = (slide: VNode, mode: 'enter' | 'exit'): Transition => {
-    const t: SlideTransition | undefined = (slide.props as any).transition
+    const t = hasTransition(slide.props) ? slide.props.transition : undefined
     if (!t) return defaultTransition
     if ('type' in t) return t
     return t[mode] ?? defaultTransition

--- a/apps/campfire/src/components/Deck/Deck.tsx
+++ b/apps/campfire/src/components/Deck/Deck.tsx
@@ -101,7 +101,7 @@ export const Deck = ({
     const nextVNode = slides[currentSlide] as VNode
     setPrevVNode(currentVNode)
     setCurrentVNode(nextVNode)
-  }, [currentSlide, slides, currentVNode])
+  }, [currentSlide, slides])
 
   useEffect(() => {
     const container = slideRef.current

--- a/apps/campfire/src/components/Deck/__tests__/Deck.test.tsx
+++ b/apps/campfire/src/components/Deck/__tests__/Deck.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'bun:test'
 import { render, screen, fireEvent, act } from '@testing-library/preact'
 import { Deck } from '@campfire/components/Deck/Deck'
+import { Slide } from '@campfire/components/Slide/Slide'
 import { useDeckStore } from '@campfire/use-deck-store'
 
 /**
@@ -27,6 +28,11 @@ beforeEach(() => {
   globalThis.ResizeObserver = StubResizeObserver
   resetStore()
   document.body.innerHTML = ''
+  ;(HTMLElement.prototype as any).animate = () => ({
+    finished: Promise.resolve({} as Animation),
+    cancel() {},
+    finish() {}
+  })
 })
 
 describe('Deck', () => {
@@ -62,7 +68,7 @@ describe('Deck', () => {
       fireEvent.click(inner)
     })
     expect(useDeckStore.getState().currentSlide).toBe(1)
-    expect(screen.getByText('Slide 2')).toBeInTheDocument()
+    expect(screen.getAllByText('Slide 2')[0]).toBeInTheDocument()
     act(() => {
       window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft' }))
     })
@@ -85,5 +91,53 @@ describe('Deck', () => {
       window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home' }))
     })
     expect(useDeckStore.getState().currentSlide).toBe(0)
+  })
+
+  it('applies slide transition type and duration', async () => {
+    class StubAnimation {
+      finished: Promise<void>
+      private resolve!: () => void
+      constructor() {
+        this.finished = new Promise<void>(res => {
+          this.resolve = res
+        })
+        setTimeout(() => this.finish(), 0)
+      }
+      cancel() {
+        this.resolve()
+      }
+      finish() {
+        this.resolve()
+      }
+    }
+    const calls: Array<{
+      keyframes: Keyframe[]
+      options: KeyframeAnimationOptions
+    }> = []
+    // @ts-expect-error override animate
+    HTMLElement.prototype.animate = (
+      k: Keyframe[],
+      o: KeyframeAnimationOptions
+    ) => {
+      calls.push({ keyframes: k, options: o })
+      return new StubAnimation()
+    }
+    render(
+      <Deck>
+        <Slide transition={{ exit: { type: 'zoom', duration: 500 } }}>
+          One
+        </Slide>
+        <Slide>Two</Slide>
+      </Deck>
+    )
+    act(() => {
+      useDeckStore.getState().next()
+    })
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 0))
+    })
+    const zoomCall = calls.find(c => c.options.duration === 500)
+    expect(zoomCall).toBeTruthy()
+    expect(zoomCall?.keyframes[0].transform).toBe('scale(1)')
   })
 })

--- a/apps/campfire/src/components/transition.ts
+++ b/apps/campfire/src/components/transition.ts
@@ -1,0 +1,96 @@
+import {
+  type Transition,
+  type Direction
+} from '@campfire/components/Slide/Slide'
+
+/**
+ * Returns whether the user prefers reduced motion.
+ *
+ * @returns True if reduced motion is preferred.
+ */
+export const prefersReducedMotion = (): boolean =>
+  typeof window !== 'undefined' &&
+  window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true
+
+/**
+ * Default transition used when none is provided.
+ */
+export const defaultTransition: Transition = { type: 'fade', duration: 300 }
+
+/**
+ * Builds keyframes for the given transition and mode.
+ *
+ * @param transition - Transition configuration.
+ * @param mode - Whether the animation is entering or exiting.
+ * @returns A sequence of keyframes.
+ */
+export const buildKeyframes = (
+  transition: Transition,
+  mode: 'in' | 'out'
+): Keyframe[] => {
+  switch (transition.type) {
+    case 'fade':
+      return mode === 'in'
+        ? [{ opacity: 0 }, { opacity: 1 }]
+        : [{ opacity: 1 }, { opacity: 0 }]
+    case 'slide': {
+      const offset = 40
+      const dir: Direction = transition.dir ?? 'up'
+      let axis: 'X' | 'Y' = 'Y'
+      let from = -offset
+      if (dir === 'left') {
+        axis = 'X'
+        from = -offset
+      } else if (dir === 'right') {
+        axis = 'X'
+        from = offset
+      } else if (dir === 'down') {
+        axis = 'Y'
+        from = offset
+      }
+      const start = `translate${axis}(${from}px)`
+      const end = `translate${axis}(0px)`
+      return mode === 'in'
+        ? [
+            { transform: start, opacity: 0 },
+            { transform: end, opacity: 1 }
+          ]
+        : [
+            { transform: end, opacity: 1 },
+            { transform: start, opacity: 0 }
+          ]
+    }
+    case 'zoom':
+      return mode === 'in'
+        ? [
+            { transform: 'scale(0.95)', opacity: 0 },
+            { transform: 'scale(1)', opacity: 1 }
+          ]
+        : [
+            { transform: 'scale(1)', opacity: 1 },
+            { transform: 'scale(0.95)', opacity: 0 }
+          ]
+    default:
+      return []
+  }
+}
+
+/**
+ * Runs a WAAPI animation for the provided element and transition.
+ *
+ * @param el - Target element.
+ * @param transition - Transition configuration.
+ * @param mode - Whether this is an enter or exit animation.
+ * @returns The created animation instance.
+ */
+export const runAnimation = (
+  el: HTMLElement,
+  transition: Transition,
+  mode: 'in' | 'out'
+): Animation =>
+  el.animate(buildKeyframes(transition, mode), {
+    duration: transition.duration ?? 300,
+    easing: transition.easing ?? 'ease',
+    delay: transition.delay ?? 0,
+    fill: 'forwards'
+  })

--- a/apps/campfire/src/components/transition.ts
+++ b/apps/campfire/src/components/transition.ts
@@ -29,6 +29,8 @@ export const buildKeyframes = (
   mode: 'in' | 'out'
 ): Keyframe[] => {
   switch (transition.type) {
+    case 'none':
+      return []
     case 'fade':
       return mode === 'in'
         ? [{ opacity: 0 }, { opacity: 1 }]


### PR DESCRIPTION
## Summary
- add shared transition helpers
- animate deck slides using their transition type and duration
- cover deck transition behavior with tests

## Testing
- `bun tsc`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_689e9494924c83209b882e8ca67b4fe5