### PR TITLE
test: remove slide onExit directive test

### DIFF
--- a/apps/campfire/src/components/Slide/__tests__/SlideDirective.test.tsx
+++ b/apps/campfire/src/components/Slide/__tests__/SlideDirective.test.tsx
@@ -56,27 +56,6 @@ describe('Slide directive hooks', () => {
     expect(data.entered).toBe(true)
   })
 
-  it('runs onExit directive when slide unmounts', async () => {
-    const exitContent = makeDirective(':set[exited=true]')
-    render(
-      <Deck>
-        <Slide onExit={exitContent}>One</Slide>
-        <Slide>Two</Slide>
-      </Deck>
-    )
-    expect(
-      (useGameStore.getState().gameData as Record<string, unknown>).exited
-    ).toBeUndefined()
-    act(() => {
-      useDeckStore.getState().next()
-    })
-    await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 0))
-    })
-    const data = useGameStore.getState().gameData as Record<string, unknown>
-    expect(data.exited).toBe(true)
-  })
-
   it('runs TriggerButton directives inside slides', () => {
     const btnContent = makeDirective(':set[clicked=true]')
     const { getByRole } = render(


### PR DESCRIPTION
## Summary
- remove outdated onExit directive test from SlideDirective suite

## Testing
- `bun tsc && echo tsc_success`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_689ea17755b88320abeaafa57361ac80