### PR TITLE
fix(deck): ensure enter animations run

### DIFF
--- a/apps/campfire/src/components/Deck/Deck.tsx
+++ b/apps/campfire/src/components/Deck/Deck.tsx
@@ -106,7 +106,8 @@ export const Deck = ({
   useEffect(() => {
     const container = slideRef.current
     if (!container) return
-    const [prevEl, currentEl] = Array.from(container.children) as HTMLElement[]
+    const currentEl = container.lastElementChild as HTMLElement | null
+    const prevEl = currentEl?.previousElementSibling as HTMLElement | null
     if (
       currentEl &&
       !(reduceMotion || getTransition(currentVNode, 'enter').type === 'none')


### PR DESCRIPTION
## Summary
- ensure Deck uses last element for entry animations so they run reliably
- test that slide entry animations trigger during navigation

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_689eb13d3d4c83209f7f06a9c6ab3046