### PR TITLE
fix(appear): handle slide transitions for multiple elements

### DIFF
--- a/apps/campfire/src/components/Appear/Appear.tsx
+++ b/apps/campfire/src/components/Appear/Appear.tsx
@@ -46,8 +46,9 @@ export const Appear = ({
   const prevStepRef = useRef(currentStep)
   const prevSlideRef = useRef(currentSlide)
   const jumped =
-    prevSlideRef.current !== currentSlide ||
-    Math.abs(prevStepRef.current - currentStep) > 1
+    Math.abs(prevSlideRef.current - currentSlide) > 1 ||
+    (prevSlideRef.current === currentSlide &&
+      Math.abs(prevStepRef.current - currentStep) > 1)
   useEffect(() => {
     prevStepRef.current = currentStep
     prevSlideRef.current = currentSlide

--- a/apps/campfire/src/components/Slide/__tests__/Slide.test.tsx
+++ b/apps/campfire/src/components/Slide/__tests__/Slide.test.tsx
@@ -27,6 +27,24 @@ class StubResizeObserver {
 beforeEach(() => {
   // @ts-expect-error override for tests
   globalThis.ResizeObserver = StubResizeObserver
+  class StubAnimation {
+    finished: Promise<void>
+    private resolve!: () => void
+    constructor() {
+      this.finished = new Promise<void>(res => {
+        this.resolve = res
+      })
+      setTimeout(() => this.finish(), 0)
+    }
+    cancel() {
+      this.resolve()
+    }
+    finish() {
+      this.resolve()
+    }
+  }
+  // @ts-expect-error override animate
+  HTMLElement.prototype.animate = () => new StubAnimation()
   resetStore()
   document.body.innerHTML = ''
 })

--- a/apps/campfire/src/components/Slide/__tests__/SlideDirective.test.tsx
+++ b/apps/campfire/src/components/Slide/__tests__/SlideDirective.test.tsx
@@ -39,6 +39,24 @@ class StubResizeObserver {
 beforeEach(() => {
   globalThis.ResizeObserver =
     StubResizeObserver as unknown as typeof ResizeObserver
+  class StubAnimation {
+    finished: Promise<void>
+    private resolve!: () => void
+    constructor() {
+      this.finished = new Promise<void>(res => {
+        this.resolve = res
+      })
+      setTimeout(() => this.finish(), 0)
+    }
+    cancel() {
+      this.resolve()
+    }
+    finish() {
+      this.resolve()
+    }
+  }
+  // @ts-expect-error override animate
+  HTMLElement.prototype.animate = () => new StubAnimation()
   resetDeckStore()
   resetStores()
   document.body.innerHTML = ''

--- a/apps/storybook/src/Deck.stories.tsx
+++ b/apps/storybook/src/Deck.stories.tsx
@@ -11,8 +11,9 @@ export default meta
 
 /**
  * Renders the Deck story with three slides and transitions using the Appear
- * component to progressively reveal content. Text layers are positioned so
- * they do not overlap.
+ * component to progressively reveal content. The first slide demonstrates
+ * three sequential Appear elements to showcase entrance and exit animations.
+ * Text layers are positioned so they do not overlap.
  *
  * @returns The rendered Deck element.
  */
@@ -41,6 +42,15 @@ const render: StoryObj<typeof Deck>['render'] = () => (
           size={24}
           color='var(--color-gray-50)'
           content='Second step'
+        />
+      </Appear>
+      <Appear at={2}>
+        <Text
+          x={500}
+          y={500}
+          size={24}
+          color='var(--color-gray-50)'
+          content='Third step'
         />
       </Appear>
     </Slide>


### PR DESCRIPTION
## Summary
- ensure Appear components run exit transitions when navigating slides
- showcase multiple sequential Appear elements in Deck story
- stabilize slide tests with WAAPI animation stubs

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_689f38bf43848320bf4e1a206ead1920