### PR TITLE
test: extract stub animation utility

### DIFF
--- a/apps/campfire/src/components/Appear/__tests__/Appear.test.tsx
+++ b/apps/campfire/src/components/Appear/__tests__/Appear.test.tsx
@@ -4,6 +4,7 @@ import { Deck } from '@campfire/components/Deck/Deck'
 import { Slide } from '@campfire/components/Slide/Slide'
 import { Appear } from '@campfire/components/Appear/Appear'
 import { useDeckStore } from '@campfire/use-deck-store'
+import { StubAnimation } from '@campfire/test-utils/stub-animation'
 
 /**
  * Resets the deck store to a clean initial state.
@@ -33,22 +34,6 @@ beforeEach(() => {
 
 describe('Appear', () => {
   it('toggles visibility at the configured steps', async () => {
-    class StubAnimation {
-      finished: Promise<void>
-      private resolve!: () => void
-      constructor() {
-        this.finished = new Promise<void>(res => {
-          this.resolve = res
-        })
-        setTimeout(() => this.finish(), 0)
-      }
-      cancel() {
-        this.resolve()
-      }
-      finish() {
-        this.resolve()
-      }
-    }
     // @ts-expect-error override animate
     HTMLElement.prototype.animate = () => new StubAnimation()
 
@@ -70,22 +55,6 @@ describe('Appear', () => {
   })
 
   it('runs exit animation and unmounts after completion', async () => {
-    class StubAnimation {
-      finished: Promise<void>
-      private resolve!: () => void
-      constructor() {
-        this.finished = new Promise<void>(res => {
-          this.resolve = res
-        })
-        setTimeout(() => this.finish(), 0)
-      }
-      cancel() {
-        this.resolve()
-      }
-      finish() {
-        this.resolve()
-      }
-    }
     // @ts-expect-error override animate
     HTMLElement.prototype.animate = () => new StubAnimation()
 

--- a/apps/campfire/src/components/Deck/__tests__/Deck.test.tsx
+++ b/apps/campfire/src/components/Deck/__tests__/Deck.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, act } from '@testing-library/preact'
 import { Deck } from '@campfire/components/Deck/Deck'
 import { Slide } from '@campfire/components/Slide/Slide'
 import { useDeckStore } from '@campfire/use-deck-store'
+import { StubAnimation } from '@campfire/test-utils/stub-animation'
 
 /**
  * Resets the deck store to a clean initial state.
@@ -95,22 +96,6 @@ describe('Deck', () => {
   })
 
   it('applies slide transition type and duration', async () => {
-    class StubAnimation {
-      finished: Promise<void>
-      private resolve!: () => void
-      constructor() {
-        this.finished = new Promise<void>(res => {
-          this.resolve = res
-        })
-        setTimeout(() => this.finish(), 0)
-      }
-      cancel() {
-        this.resolve()
-      }
-      finish() {
-        this.resolve()
-      }
-    }
     const calls: Array<{
       keyframes: Keyframe[]
       options: KeyframeAnimationOptions
@@ -146,22 +131,6 @@ describe('Deck', () => {
   })
 
   it('runs enter animation when slide changes', async () => {
-    class StubAnimation {
-      finished: Promise<void>
-      private resolve!: () => void
-      constructor() {
-        this.finished = new Promise<void>(res => {
-          this.resolve = res
-        })
-        setTimeout(() => this.finish(), 0)
-      }
-      cancel() {
-        this.resolve()
-      }
-      finish() {
-        this.resolve()
-      }
-    }
     const calls: Array<{ keyframes: Keyframe[] }> = []
     const animateMock: typeof HTMLElement.prototype.animate = (
       k: Keyframe[] | PropertyIndexedKeyframes,

--- a/apps/campfire/src/components/Slide/__tests__/Slide.test.tsx
+++ b/apps/campfire/src/components/Slide/__tests__/Slide.test.tsx
@@ -4,6 +4,7 @@ import { Deck } from '@campfire/components/Deck/Deck'
 import { Slide, type SlideProps } from '@campfire/components/Slide/Slide'
 import { useDeckStore } from '@campfire/use-deck-store'
 import type { VNode } from 'preact'
+import { StubAnimation } from '@campfire/test-utils/stub-animation'
 
 /**
  * Resets the deck store to a clean initial state.
@@ -27,22 +28,6 @@ class StubResizeObserver {
 beforeEach(() => {
   // @ts-expect-error override for tests
   globalThis.ResizeObserver = StubResizeObserver
-  class StubAnimation {
-    finished: Promise<void>
-    private resolve!: () => void
-    constructor() {
-      this.finished = new Promise<void>(res => {
-        this.resolve = res
-      })
-      setTimeout(() => this.finish(), 0)
-    }
-    cancel() {
-      this.resolve()
-    }
-    finish() {
-      this.resolve()
-    }
-  }
   // @ts-expect-error override animate
   HTMLElement.prototype.animate = () => new StubAnimation()
   resetStore()

--- a/apps/campfire/src/components/Slide/__tests__/SlideDirective.test.tsx
+++ b/apps/campfire/src/components/Slide/__tests__/SlideDirective.test.tsx
@@ -4,6 +4,7 @@ import { Deck, Slide, TriggerButton } from '@campfire/components'
 import { useDeckStore } from '@campfire/use-deck-store'
 import { useGameStore } from '@campfire/use-game-store'
 import { resetStores } from '@campfire/test-utils/helpers'
+import { StubAnimation } from '@campfire/test-utils/stub-animation'
 import { unified } from 'unified'
 import remarkParse from 'remark-parse'
 import remarkDirective from 'remark-directive'
@@ -39,22 +40,6 @@ class StubResizeObserver {
 beforeEach(() => {
   globalThis.ResizeObserver =
     StubResizeObserver as unknown as typeof ResizeObserver
-  class StubAnimation {
-    finished: Promise<void>
-    private resolve!: () => void
-    constructor() {
-      this.finished = new Promise<void>(res => {
-        this.resolve = res
-      })
-      setTimeout(() => this.finish(), 0)
-    }
-    cancel() {
-      this.resolve()
-    }
-    finish() {
-      this.resolve()
-    }
-  }
   // @ts-expect-error override animate
   HTMLElement.prototype.animate = () => new StubAnimation()
   resetDeckStore()

--- a/apps/campfire/src/test-utils/stub-animation.ts
+++ b/apps/campfire/src/test-utils/stub-animation.ts
@@ -1,0 +1,25 @@
+/**
+ * Stub Animation class that resolves immediately.
+ * Useful for replacing Web Animations in tests.
+ */
+export class StubAnimation {
+  finished: Promise<void>
+  private resolve!: () => void
+
+  constructor() {
+    this.finished = new Promise<void>(res => {
+      this.resolve = res
+    })
+    setTimeout(() => this.finish(), 0)
+  }
+
+  /** Cancels the animation and resolves the finished promise. */
+  cancel = () => {
+    this.resolve()
+  }
+
+  /** Finishes the animation and resolves the finished promise. */
+  finish = () => {
+    this.resolve()
+  }
+}


### PR DESCRIPTION
## Summary
- add StubAnimation helper for tests
- replace duplicated stub animation classes in Appear, Slide, SlideDirective, and Deck tests

## Testing
- `bun tsc && echo 'tsc succeeded'`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_689f4eab5e3083209b3fb7364dadbcd7