### PR TITLE
fix(Appear): prevent unseen elements from animating on slide change

### DIFF
--- a/apps/campfire/src/components/Appear/Appear.tsx
+++ b/apps/campfire/src/components/Appear/Appear.tsx
@@ -45,10 +45,9 @@ export const Appear = ({
 
   const prevStepRef = useRef(currentStep)
   const prevSlideRef = useRef(currentSlide)
-  const jumped =
-    Math.abs(prevSlideRef.current - currentSlide) > 1 ||
-    (prevSlideRef.current === currentSlide &&
-      Math.abs(prevStepRef.current - currentStep) > 1)
+  const slideChanged = prevSlideRef.current !== currentSlide
+  const stepJumped =
+    !slideChanged && Math.abs(prevStepRef.current - currentStep) > 1
   useEffect(() => {
     prevStepRef.current = currentStep
     prevSlideRef.current = currentSlide
@@ -80,7 +79,25 @@ export const Appear = ({
 
     clearAnimation()
 
-    if (jumped || reduceMotion) {
+    if (slideChanged) {
+      if (present) {
+        if (!reduceMotion && el) {
+          const anim = runAnimation(el, exit ?? defaultTransition, 'out')
+          animationRef.current = anim
+          anim.finished.then(() => {
+            if (animationRef.current === anim) {
+              setPresent(false)
+              animationRef.current = null
+            }
+          })
+        } else {
+          setPresent(false)
+        }
+      }
+      return clearAnimation
+    }
+
+    if (stepJumped || reduceMotion) {
       if (visible) {
         if (!present) {
           setPresent(true)
@@ -133,7 +150,8 @@ export const Appear = ({
     enter,
     exit,
     interruptBehavior,
-    jumped,
+    slideChanged,
+    stepJumped,
     reduceMotion
   ])
 

--- a/apps/campfire/src/components/Appear/__tests__/Appear.test.tsx
+++ b/apps/campfire/src/components/Appear/__tests__/Appear.test.tsx
@@ -93,4 +93,38 @@ describe('Appear', () => {
     })
     expect(screen.getByText('Skip')).toBeTruthy()
   })
+
+  it('unmounts visible elements and does not mount unseen ones on slide change', async () => {
+    // @ts-expect-error override animate
+    HTMLElement.prototype.animate = () => new StubAnimation()
+
+    render(
+      <Deck>
+        <Slide>
+          <Appear at={0}>First</Appear>
+          <Appear at={1}>Second</Appear>
+        </Slide>
+        <Slide>
+          <Appear at={0}>Next</Appear>
+        </Slide>
+      </Deck>
+    )
+
+    expect(screen.getByText('First')).toBeTruthy()
+    expect(screen.queryByText('Second')).toBeNull()
+
+    act(() => {
+      useDeckStore.getState().goTo(1, 0)
+    })
+
+    expect(screen.queryByText('Second')).toBeNull()
+    expect(screen.getByText('First')).toBeTruthy()
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 0))
+    })
+
+    expect(screen.queryByText('First')).toBeNull()
+    expect(screen.queryByText('Second')).toBeNull()
+  })
 })

--- a/apps/storybook/src/Appear.stories.tsx
+++ b/apps/storybook/src/Appear.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from '@storybook/preact'
+import { h } from 'preact'
+import { Deck, Slide, Text, Appear } from '@campfire/components'
+
+const meta: Meta<typeof Appear> = {
+  component: Appear,
+  title: 'Campfire/Appear'
+}
+
+export default meta
+
+/**
+ * Renders a deck demonstrating sequential Appear elements and their
+ * behavior when switching slides.
+ *
+ * @returns The rendered deck.
+ */
+const render: StoryObj<typeof Appear>['render'] = () => (
+  <Deck className='w-[800px] h-[600px]'>
+    <Slide>
+      <Appear at={0}>
+        <Text
+          as='h2'
+          x={80}
+          y={80}
+          size={36}
+          color='var(--color-gray-50)'
+          content='First'
+        />
+      </Appear>
+      <Appear at={1}>
+        <Text
+          x={500}
+          y={400}
+          size={24}
+          color='var(--color-gray-50)'
+          content='Second'
+        />
+      </Appear>
+    </Slide>
+    <Slide>
+      <Text
+        as='h2'
+        x={80}
+        y={80}
+        size={36}
+        color='var(--color-gray-50)'
+        content='Next Slide'
+      />
+    </Slide>
+  </Deck>
+)
+
+export const Basic: StoryObj<typeof Appear> = { render }


### PR DESCRIPTION
## Summary
- stop unseen Appear elements from mounting when leaving a slide
- run exit transitions for visible Appear elements on slide change
- add Appear story and tests for slide-change behavior

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_689f560dc5b083209a5918bf66745eb0