### PR TITLE
refactor: centralize value parsing and helpers

### DIFF
--- a/apps/campfire/src/__tests__/helpers.test.ts
+++ b/apps/campfire/src/__tests__/helpers.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'bun:test'
+import type { DirectiveNode } from '@campfire/remark-campfire/helpers'
+import type { Parent } from 'mdast'
+import {
+  parseTypedValue,
+  extractKeyValue,
+  applyKeyValue
+} from '@campfire/helpers'
+
+describe('parseTypedValue', () => {
+  it('parses numbers and booleans', () => {
+    expect(parseTypedValue('42')).toBe(42)
+    expect(parseTypedValue('true')).toBe(true)
+    expect(parseTypedValue('"hi"')).toBe('hi')
+  })
+
+  it('evaluates expressions with caching', () => {
+    const data: Record<string, unknown> = { x: 2 }
+    expect(parseTypedValue('x + 1', data)).toBe(3)
+    data.x = 3
+    expect(parseTypedValue('x + 1', data)).toBe(4)
+  })
+
+  it('parses object literals', () => {
+    const obj = parseTypedValue('{a:1,b:"two"}') as Record<string, unknown>
+    expect(obj.a).toBe(1)
+    expect(obj.b).toBe('two')
+  })
+})
+
+describe('extractKeyValue and applyKeyValue', () => {
+  it('extracts and applies key/value pairs', () => {
+    const directive = {
+      type: 'leafDirective',
+      name: 'set',
+      label: 'score=1+1',
+      attributes: {},
+      children: []
+    } as unknown as DirectiveNode
+    const parent: Parent = { type: 'root', children: [directive] }
+    let stored: any
+    applyKeyValue(directive, parent, 0, {
+      parse: raw => parseTypedValue(raw, {}),
+      setValue: (k, v) => {
+        stored = { k, v }
+      },
+      onError: () => {}
+    })
+    expect(stored).toEqual({ k: 'score', v: 2 })
+    expect(parent.children.length).toBe(0)
+  })
+})

--- a/apps/campfire/src/components/Deck/index.tsx
+++ b/apps/campfire/src/components/Deck/index.tsx
@@ -15,6 +15,7 @@ import {
 } from 'preact/hooks'
 import { useDeckStore } from '@campfire/state/useDeckStory'
 import { useScale, type DeckSize } from '@campfire/hooks/useScale'
+import { DEFAULT_DECK_HEIGHT, DEFAULT_DECK_WIDTH } from '@campfire/constants'
 import {
   defaultTransition,
   prefersReducedMotion,
@@ -38,7 +39,7 @@ export interface DeckProps {
  * @returns A deck element that renders the current slide.
  */
 export const Deck = ({
-  size = { width: 1920, height: 1080 },
+  size = { width: DEFAULT_DECK_WIDTH, height: DEFAULT_DECK_HEIGHT },
   theme,
   children,
   className

--- a/apps/campfire/src/constants.ts
+++ b/apps/campfire/src/constants.ts
@@ -1,0 +1,9 @@
+/**
+ * Default width for deck slides in pixels.
+ */
+export const DEFAULT_DECK_WIDTH = 1920
+
+/**
+ * Default height for deck slides in pixels.
+ */
+export const DEFAULT_DECK_HEIGHT = 1080

--- a/apps/campfire/src/helpers.ts
+++ b/apps/campfire/src/helpers.ts
@@ -1,0 +1,184 @@
+import { compile } from 'expression-eval'
+import { unified } from 'unified'
+import remarkParse from 'remark-parse'
+import remarkGfm from 'remark-gfm'
+import remarkDirective from 'remark-directive'
+import { toString } from 'mdast-util-to-string'
+import type { Parent, Root, RootContent } from 'mdast'
+import type { DirectiveNode } from '@campfire/remark-campfire/helpers'
+import { ensureKey, removeNode } from '@campfire/remark-campfire/helpers'
+
+const QUOTE_PATTERN = /^(['"`])(.*)\1$/
+const expressionCache = new Map<string, Function>()
+
+/**
+ * Parses a raw string into a typed value. Supports quoted strings, booleans,
+ * numbers, object literals and expression evaluation against provided data.
+ *
+ * @param raw - Raw value string to parse.
+ * @param data - Optional context for expression evaluation.
+ * @returns Parsed value or undefined when empty.
+ */
+export const parseTypedValue = (
+  raw: string,
+  data: Record<string, unknown> = {}
+): unknown => {
+  const trimmed = raw.trim()
+  if (!trimmed) return undefined
+  const quoted = trimmed.match(QUOTE_PATTERN)
+  if (quoted) return quoted[2]
+  if (trimmed === 'true') return true
+  if (trimmed === 'false') return false
+  if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
+    const inner = trimmed.slice(1, -1)
+    const obj: Record<string, unknown> = {}
+    for (const part of inner.split(',')) {
+      const colon = part.indexOf(':')
+      if (colon === -1) continue
+      const key = part.slice(0, colon).trim()
+      if (!key) continue
+      const value = part.slice(colon + 1)
+      const parsed = parseTypedValue(value, data)
+      if (typeof parsed !== 'undefined') obj[key] = parsed
+    }
+    return obj
+  }
+  const num = Number(trimmed)
+  if (!Number.isNaN(num)) return num
+  try {
+    let fn = expressionCache.get(trimmed)
+    if (!fn) {
+      fn = compile(trimmed)
+      expressionCache.set(trimmed, fn)
+    }
+    return fn(data)
+  } catch {
+    return (data as Record<string, unknown>)[trimmed]
+  }
+}
+
+/**
+ * Extracts a `key=value` pair from a directive node.
+ *
+ * @param directive - Directive being processed.
+ * @param parent - Parent node containing the directive.
+ * @param index - Index of the directive within the parent.
+ * @param onError - Callback for reporting errors.
+ * @returns The extracted key and raw value, or undefined on failure.
+ */
+export const extractKeyValue = (
+  directive: DirectiveNode,
+  parent: Parent | undefined,
+  index: number | undefined,
+  onError: (msg: string) => void
+): { key: string; valueRaw: string } | undefined => {
+  const label = (
+    (directive as { label?: string }).label ?? toString(directive)
+  ).trim()
+  const eq = label.indexOf('=')
+  if (eq === -1) {
+    const name = (directive as { name?: string }).name ?? 'unknown'
+    const msg = `Malformed ${name} directive: ${label}`
+    console.error(msg)
+    onError(msg)
+    return undefined
+  }
+  const keyRaw = label.slice(0, eq).trim()
+  const key = ensureKey(keyRaw, parent, index)
+  if (!key) return undefined
+  const valueRaw = label.slice(eq + 1).trim()
+  return { key, valueRaw }
+}
+
+/**
+ * Replaces a directive with new nodes while preserving its indentation.
+ *
+ * @param directive - Directive being replaced.
+ * @param parent - Parent of the directive.
+ * @param index - Index of the directive within the parent.
+ * @param nodes - Nodes to insert.
+ * @returns Index of the first inserted node.
+ */
+export const replaceWithIndentation = (
+  directive: DirectiveNode,
+  parent: Parent,
+  index: number,
+  nodes: RootContent[]
+): number => {
+  const indent = (directive.data as { indentation?: string } | undefined)
+    ?.indentation
+  const insert = indent
+    ? ([{ type: 'text', value: indent }, ...nodes] as RootContent[])
+    : nodes
+  parent.children.splice(index, 1, ...insert)
+  return index + (indent ? 1 : 0)
+}
+
+/**
+ * Recursively expands indented code blocks into markdown nodes.
+ *
+ * @param nodes - Nodes to expand.
+ * @param depth - Current recursion depth.
+ * @param maxDepth - Maximum allowed depth to prevent infinite recursion.
+ * @returns Expanded nodes.
+ */
+export const expandIndentedCode = (
+  nodes: RootContent[],
+  depth = 0,
+  maxDepth = 20
+): RootContent[] => {
+  if (depth >= maxDepth) return nodes
+  return nodes.flatMap(node => {
+    if (node.type === 'code' && !node.lang) {
+      const root = unified()
+        .use(remarkParse)
+        .use(remarkGfm)
+        .use(remarkDirective)
+        .parse((node as any).value) as Root
+      return expandIndentedCode(
+        root.children as RootContent[],
+        depth + 1,
+        maxDepth
+      )
+    }
+    if ('children' in node && Array.isArray((node as Parent).children)) {
+      ;(node as Parent).children = expandIndentedCode(
+        (node as Parent).children as RootContent[],
+        depth + 1,
+        maxDepth
+      )
+    }
+    return [node]
+  })
+}
+
+/**
+ * Applies a key/value directive by parsing the value and assigning it using the
+ * provided setter.
+ *
+ * @param directive - Directive node to process.
+ * @param parent - Parent node.
+ * @param index - Index of directive within parent.
+ * @param opts - Options controlling parsing and assignment.
+ * @returns The index of the removed node, if applicable.
+ */
+export const applyKeyValue = <T>(
+  directive: DirectiveNode,
+  parent: Parent | undefined,
+  index: number | undefined,
+  opts: {
+    parse: (raw: string, key: string) => T
+    setValue: (key: string, value: T, options?: any) => void
+    onError: (msg: string) => void
+    lock?: boolean
+  }
+) => {
+  const parsed = extractKeyValue(directive, parent, index, opts.onError)
+  if (!parsed) return index
+  const { key, valueRaw } = parsed
+  const value = opts.parse(valueRaw, key)
+  opts.setValue(key, value, { lock: opts.lock })
+  const removed = removeNode(parent, index)
+  if (typeof removed === 'number') return removed
+  return index
+}

--- a/apps/campfire/src/helpers.ts
+++ b/apps/campfire/src/helpers.ts
@@ -4,7 +4,7 @@ import remarkParse from 'remark-parse'
 import remarkGfm from 'remark-gfm'
 import remarkDirective from 'remark-directive'
 import { toString } from 'mdast-util-to-string'
-import type { Parent, Root, RootContent } from 'mdast'
+import type { Parent, Root, RootContent, Code } from 'mdast'
 import type { DirectiveNode } from '@campfire/remark-campfire/helpers'
 import { ensureKey, removeNode } from '@campfire/remark-campfire/helpers'
 
@@ -134,7 +134,7 @@ export const expandIndentedCode = (
         .use(remarkParse)
         .use(remarkGfm)
         .use(remarkDirective)
-        .parse((node as any).value) as Root
+        .parse((node as Code).value) as Root
       return expandIndentedCode(
         root.children as RootContent[],
         depth + 1,

--- a/apps/campfire/src/hooks/__tests__/deckDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/deckDirective.test.tsx
@@ -5,6 +5,7 @@ import type { ComponentChild } from 'preact'
 import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
 import { Deck } from '@campfire/components/Deck'
 import { Slide } from '@campfire/components/Deck/Slide'
+import { DEFAULT_DECK_HEIGHT, DEFAULT_DECK_WIDTH } from '@campfire/constants'
 import { renderDirectiveMarkdown } from '@campfire/components/Deck/Slide/renderDirectiveMarkdown'
 
 let output: ComponentChild | null = null
@@ -44,8 +45,8 @@ describe('deck directive', () => {
     }
     const deck = getDeck(output)
     expect(deck.type).toBe(Deck)
-    expect(deck.props.size.width).toBe(1920)
-    expect(deck.props.size.height).toBe(1080)
+    expect(deck.props.size.width).toBe(DEFAULT_DECK_WIDTH)
+    expect(deck.props.size.height).toBe(DEFAULT_DECK_HEIGHT)
     const slides = Array.isArray(deck.props.children)
       ? deck.props.children
       : [deck.props.children]


### PR DESCRIPTION
## Summary
- add shared typed value parser with expression caching
- extract indentation utilities and key/value directive helpers
- consolidate deck size defaults into constants

## Testing
- `bun tsc`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_689f9fc855e08320854573085cf05694