### PR TITLE
feat(campfire): add appear directive handler

### DIFF
--- a/apps/campfire/src/hooks/__tests__/appearDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/appearDirective.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach } from 'bun:test'
+import { render } from '@testing-library/preact'
+import { Fragment } from 'preact/jsx-runtime'
+import type { ComponentChild } from 'preact'
+import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
+import { renderDirectiveMarkdown } from '@campfire/components/Deck/Slide/renderDirectiveMarkdown'
+
+let output: ComponentChild | null = null
+
+/**
+ * Component used in tests to render markdown with directive handlers.
+ *
+ * @param markdown - Markdown string that may include directive containers.
+ * @returns Nothing; sets `output` with rendered content.
+ */
+const MarkdownRunner = ({ markdown }: { markdown: string }) => {
+  const handlers = useDirectiveHandlers()
+  output = renderDirectiveMarkdown(markdown, handlers)
+  return null
+}
+
+beforeEach(() => {
+  output = null
+  document.body.innerHTML = ''
+})
+
+describe('appear directive', () => {
+  it('renders an appear element with props', () => {
+    const md =
+      ':::appear{at=1 exitAt=3 enter="slide" exit="fade" interruptBehavior="cancel" data-test="ok"}\nHello\n:::'
+    render(<MarkdownRunner markdown={md} />)
+    const getAppear = (node: any): any => {
+      if (Array.isArray(node)) return getAppear(node[0])
+      if (node?.type === Fragment) return getAppear(node.props.children)
+      return node
+    }
+    const appear = getAppear(output)
+    expect(appear.type).toBe('appear')
+    expect(appear.props.at).toBe(1)
+    expect(appear.props.exitAt).toBe(3)
+    expect(appear.props.enter).toBe('slide')
+    expect(appear.props.exit).toBe('fade')
+    expect(appear.props.interruptBehavior).toBe('cancel')
+    expect(appear.props['data-test']).toBe('ok')
+  })
+})


### PR DESCRIPTION
## Summary
- support :::appear blocks by parsing timing and animation props
- forward unknown attributes to the resulting <Appear> element
- test appear directive handling

## Testing
- `bun x prettier --write apps/campfire/src/hooks/useDirectiveHandlers.ts apps/campfire/src/hooks/__tests__/appearDirective.test.tsx`
- `bun tsc`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_689fa5f6fe588320b8684d32f6c6b364