### PR TITLE
fix: ease scale down on narrow widths

### DIFF
--- a/apps/campfire/src/hooks/__tests__/useScale.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/useScale.test.tsx
@@ -42,7 +42,7 @@ describe('useScale', () => {
     Object.defineProperty(el, 'clientWidth', { value: 50, configurable: true })
     Object.defineProperty(el, 'clientHeight', { value: 40, configurable: true })
     act(() => trigger())
-    expect(currentScale).toBe(0.4)
+    expect(currentScale).toBeCloseTo(Math.sqrt(0.4))
 
     Object.defineProperty(el, 'clientWidth', { value: 200, configurable: true })
     Object.defineProperty(el, 'clientHeight', {
@@ -69,8 +69,8 @@ describe('useScale', () => {
     const { container } = render(<TestComponent />)
     const el = container.firstElementChild as HTMLDivElement
 
-    Object.defineProperty(el, 'clientWidth', { value: 1, configurable: true })
-    Object.defineProperty(el, 'clientHeight', { value: 1, configurable: true })
+    Object.defineProperty(el, 'clientWidth', { value: 0, configurable: true })
+    Object.defineProperty(el, 'clientHeight', { value: 0, configurable: true })
     act(() => trigger())
     expect(currentScale).toBe(MIN_SCALE)
   })

--- a/apps/campfire/src/hooks/useScale.ts
+++ b/apps/campfire/src/hooks/useScale.ts
@@ -15,8 +15,10 @@ export interface DeckSize {
 
 /**
  * Observes the container size and computes a scale factor that keeps the
- * content within the provided dimensions. Returns a ref to attach to the
- * container element and the current scale value.
+ * content within the provided dimensions. When the container is smaller than
+ * the content, the scale factor is eased using a square root to avoid
+ * aggressively shrinking text. Returns a ref to attach to the container element
+ * and the current scale value.
  *
  * @param size - The natural width and height of the content.
  * @returns An object containing the `ref` and computed `scale` value.
@@ -33,7 +35,8 @@ export const useScale = (size: DeckSize) => {
       const { clientWidth: cw, clientHeight: ch } = el
       const sx = cw / size.width
       const sy = ch / size.height
-      const s = Math.max(MIN_SCALE, Math.min(sx, sy))
+      const sRaw = Math.min(sx, sy)
+      const s = Math.max(MIN_SCALE, sRaw < 1 ? Math.sqrt(sRaw) : sRaw)
       setScale(s)
     })
 


### PR DESCRIPTION
## Summary
- ease deck scaling when container width/height is smaller than content
- add tests covering eased scale and minimum clamping

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_689fb4b8f5808320a3ef1f4acd284db9