### PR TITLE
docs: document deck directives and expand story

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,6 +656,52 @@ Save and load progress or store data in the browser.
   | ----- | --------------------- |
   | id    | Storage key to remove |
 
+### Presentation decks
+
+Embed slide decks directly in passages using the `deck`, `slide`, and `appear` directives.
+
+```md
+:::deck{class="w-[800px] h-[600px]"}
+:::slide
+:::appear{at=0}
+
+# Slide One
+
+:::
+:::appear{at=1}
+This line appears second.
+:::
+:::
+:::slide
+:::appear{at=0}
+
+# Slide Two
+
+:::
+:::appear{at=1}
+This line appears second.
+:::
+:::
+:::slide
+:::appear{at=0}
+
+# Slide Three
+
+:::
+:::appear{at=1}
+This line appears second.
+:::
+:::
+```
+
+`deck` wraps multiple `slide` blocks, each defining a slide. Inside a `slide`, the `appear` directive reveals content when the deck advances steps.
+
+| Directive | Description                                                                      | Key inputs                    |
+| --------- | -------------------------------------------------------------------------------- | ----------------------------- |
+| `deck`    | Container for slides; supports options such as `size`, `class`, and `transition` | `size`, `class`, `transition` |
+| `slide`   | Defines a single slide within the deck                                           | _(none)_                      |
+| `appear`  | Reveals content at a specific step in the current slide                          | `at`                          |
+
 ### Localization & internationalization
 
 Change language and handle translations.

--- a/apps/storybook/src/Story.stories.tsx
+++ b/apps/storybook/src/Story.stories.tsx
@@ -8,20 +8,23 @@ const meta: Meta = {
 
 export default meta
 
-// A super-minimal story that renders TwineJS custom elements directly in JSX.
-// This validates our JSX and DOM typings for these tags.
-export const InDom: StoryObj = {
-  render: () => (
-    <Fragment>
-      <tw-storydata
-        name='Storybook Demo'
-        startnode='1'
-        data-demo={true}
-        tags='demo'
-        options='debug'
-      >
-        <tw-passagedata pid='1' name='Start'>
-          {`
+/**
+ * Renders TwineJS custom elements directly in JSX and demonstrates the
+ * `deck`, `slide`, and `appear` directives.
+ *
+ * @returns The rendered story elements.
+ */
+const render: StoryObj['render'] = () => (
+  <Fragment>
+    <tw-storydata
+      name='Storybook Demo'
+      startnode='1'
+      data-demo={true}
+      tags='demo'
+      options='debug'
+    >
+      <tw-passagedata pid='1' name='Start'>
+        {`
 # Hello World!
 
 :set[test=true]
@@ -33,19 +36,47 @@ export const InDom: StoryObj = {
 :::if{!test}
 [[Go to second passage->Second]]
 :::
+
+:::deck{class="w-[800px] h-[600px]"}
+:::slide
+:::appear{at=0}
+# First Slide
+:::
+:::appear{at=1}
+This line appears second.
+:::
+:::
+:::slide
+:::appear{at=0}
+# Second Slide
+:::
+:::appear{at=1}
+This line appears second.
+:::
+:::
+:::slide
+:::appear{at=0}
+# Third Slide
+:::
+:::appear{at=1}
+This line appears second.
+:::
+:::
+:::
 `}
-        </tw-passagedata>
-        <tw-passagedata pid='2' name='Second'>
-          Second passage
-        </tw-passagedata>
-      </tw-storydata>
-      <tw-story data-mounted='yes'>
-        <tw-sidebar></tw-sidebar>
-        <tw-link name='Go' type='internal' data-target='2'></tw-link>
-        <tw-hook name='content'></tw-hook>
-        <tw-enchantment></tw-enchantment>
-      </tw-story>
-      <Campfire />
-    </Fragment>
-  )
-}
+      </tw-passagedata>
+      <tw-passagedata pid='2' name='Second'>
+        Second passage
+      </tw-passagedata>
+    </tw-storydata>
+    <tw-story data-mounted='yes'>
+      <tw-sidebar></tw-sidebar>
+      <tw-link name='Go' type='internal' data-target='2'></tw-link>
+      <tw-hook name='content'></tw-hook>
+      <tw-enchantment></tw-enchantment>
+    </tw-story>
+    <Campfire />
+  </Fragment>
+)
+
+export const InDom: StoryObj = { render }


### PR DESCRIPTION
## Summary
- add three-slide deck example with appear steps to Story story
- document usage of `deck`, `slide`, and `appear` directives in README

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_689fdac08ee883209454aad7d22b000c