### PR TITLE
fix: remove stray directive markers in decks

### DIFF
--- a/apps/campfire/src/hooks/__tests__/appearDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/appearDirective.test.tsx
@@ -43,4 +43,18 @@ describe('appear directive', () => {
     expect(appear.props.interruptBehavior).toBe('cancel')
     expect(appear.props['data-test']).toBe('ok')
   })
+
+  it('does not render stray colons when appear contains directives', () => {
+    const md = `:::appear\n:::if{true}\nHi\n:::\n:::\n`
+    render(<MarkdownRunner markdown={md} />)
+    const getText = (node: any): string => {
+      if (!node) return ''
+      if (typeof node === 'string') return node
+      if (Array.isArray(node)) return node.map(getText).join('')
+      if (node.props?.children) return getText(node.props.children)
+      return ''
+    }
+    const text = getText(output)
+    expect(text).not.toContain(':::')
+  })
 })

--- a/apps/campfire/src/hooks/__tests__/deckDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/deckDirective.test.tsx
@@ -72,4 +72,18 @@ describe('deck directive', () => {
     expect(slides.length).toBe(1)
     expect(slides[0].type).toBe(Slide)
   })
+
+  it('does not render stray colons when slide contains directives', () => {
+    const md = `:::deck\n:::slide\n:::if{true}\nHi\n:::\n:::\n:::\n`
+    render(<MarkdownRunner markdown={md} />)
+    const getText = (node: any): string => {
+      if (!node) return ''
+      if (typeof node === 'string') return node
+      if (Array.isArray(node)) return node.map(getText).join('')
+      if (node.props?.children) return getText(node.props.children)
+      return ''
+    }
+    const text = getText(output)
+    expect(text).not.toContain(':::')
+  })
 })


### PR DESCRIPTION
## Summary
- strip paragraphs that contain only directive markers when processing deck directives
- remove closing marker after appear directives
- test that nested directives inside decks and appears do not render stray `:::`

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_689ffaf5671883209a1f001392ecf00e