### PR TITLE
fix: render Appear component for appear directive

### DIFF
--- a/apps/campfire/src/components/Deck/Slide/renderDirectiveMarkdown.ts
+++ b/apps/campfire/src/components/Deck/Slide/renderDirectiveMarkdown.ts
@@ -16,6 +16,7 @@ import { Show } from '@campfire/components/Passage/Show'
 import { OnExit } from '@campfire/components/Passage/OnExit'
 import { Deck } from '@campfire/components/Deck'
 import { Slide } from './'
+import { Appear } from '@campfire/components/Deck/Slide/Appear'
 
 /**
  * Converts Markdown containing Campfire directives into Preact elements.
@@ -47,7 +48,8 @@ export const renderDirectiveMarkdown = (
         show: Show,
         onExit: OnExit,
         deck: Deck,
-        slide: Slide
+        slide: Slide,
+        appear: Appear
       }
     })
 

--- a/apps/campfire/src/components/Passage/If.tsx
+++ b/apps/campfire/src/components/Passage/If.tsx
@@ -14,6 +14,7 @@ import { LinkButton } from '@campfire/components/Passage/LinkButton'
 import { TriggerButton } from '@campfire/components/Passage/TriggerButton'
 import { Show } from '@campfire/components/Passage/Show'
 import { OnExit } from '@campfire/components/Passage/OnExit'
+import { Appear } from '@campfire/components/Deck/Slide/Appear'
 
 interface IfProps {
   test: string
@@ -43,7 +44,8 @@ export const If = ({ test, content, fallback }: IfProps) => {
           trigger: TriggerButton,
           if: If,
           show: Show,
-          onExit: OnExit
+          onExit: OnExit,
+          appear: Appear
         }
       })
     proc.parser = (_doc: unknown, file: Root) => ({

--- a/apps/campfire/src/components/Passage/Passage.tsx
+++ b/apps/campfire/src/components/Passage/Passage.tsx
@@ -28,6 +28,7 @@ import { Show } from '@campfire/components/Passage/Show'
 import { OnExit } from '@campfire/components/Passage/OnExit'
 import { Deck } from '@campfire/components/Deck'
 import { Slide } from '@campfire/components/Deck/Slide'
+import { Appear } from '@campfire/components/Deck/Slide/Appear'
 
 const DIRECTIVE_MARKER_PATTERN = '(:::[^\\n]*|:[^\\n]*|<<)'
 
@@ -133,7 +134,8 @@ export const Passage = () => {
             show: Show,
             onExit: OnExit,
             deck: Deck,
-            slide: Slide
+            slide: Slide,
+            appear: Appear
           }
         }),
     [handlers]

--- a/apps/campfire/src/hooks/__tests__/appearDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/appearDirective.test.tsx
@@ -4,6 +4,7 @@ import { Fragment } from 'preact/jsx-runtime'
 import type { ComponentChild } from 'preact'
 import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
 import { renderDirectiveMarkdown } from '@campfire/components/Deck/Slide/renderDirectiveMarkdown'
+import { Appear } from '@campfire/components/Deck/Slide/Appear'
 
 let output: ComponentChild | null = null
 
@@ -25,7 +26,7 @@ beforeEach(() => {
 })
 
 describe('appear directive', () => {
-  it('renders an appear element with props', () => {
+  it('renders an Appear component with props', () => {
     const md =
       ':::appear{at=1 exitAt=3 enter="slide" exit="fade" interruptBehavior="cancel" data-test="ok"}\nHello\n:::'
     render(<MarkdownRunner markdown={md} />)
@@ -35,7 +36,7 @@ describe('appear directive', () => {
       return node
     }
     const appear = getAppear(output)
-    expect(appear.type).toBe('appear')
+    expect(appear.type).toBe(Appear)
     expect(appear.props.at).toBe(1)
     expect(appear.props.exitAt).toBe(3)
     expect(appear.props.enter).toBe('slide')


### PR DESCRIPTION
## Summary
- ensure :::appear uses Appear component when rendering markdown
- wire Appear into passage and conditional markdown processors
- verify appear directive renders Appear component

## Testing
- `bun tsc`
- `bun test`
- `bun test apps/campfire/src/hooks/__tests__/appearDirective.test.tsx`


------
https://chatgpt.com/codex/tasks/task_b_689fff30410c832096042c9f6181a900