### PR TITLE
fix: render Text component via directive

### DIFF
--- a/apps/campfire/src/components/Deck/Slide/Text/__tests__/Text.test.tsx
+++ b/apps/campfire/src/components/Deck/Slide/Text/__tests__/Text.test.tsx
@@ -4,13 +4,17 @@ import { Text } from '@campfire/components/Deck/Slide/Text'
 
 describe('Text', () => {
   it('renders the specified HTML tag', () => {
-    render(<Text as='h2' content='Hello' />)
+    render(<Text as='h2'>Hello</Text>)
     const el = screen.getByText('Hello') as HTMLElement
     expect(el.tagName).toBe('H2')
   })
 
   it('forwards positioning props to Layer', () => {
-    render(<Text x={10} y={20} w={100} h={50} content='Positioned' />)
+    render(
+      <Text x={10} y={20} w={100} h={50}>
+        Positioned
+      </Text>
+    )
     const wrapper = screen.getByText('Positioned').parentElement as HTMLElement
     expect(wrapper.style.left).toBe('10px')
     expect(wrapper.style.top).toBe('20px')
@@ -20,14 +24,9 @@ describe('Text', () => {
 
   it('applies custom typography styles', () => {
     render(
-      <Text
-        size={24}
-        weight={700}
-        align='center'
-        color='red'
-        lineHeight={1.5}
-        content='Styled'
-      />
+      <Text size={24} weight={700} align='center' color='red' lineHeight={1.5}>
+        Styled
+      </Text>
     )
     const el = screen.getByText('Styled') as HTMLElement
     expect(el.style.fontSize).toBe('24px')
@@ -35,11 +34,5 @@ describe('Text', () => {
     expect(el.style.textAlign).toBe('center')
     expect(el.style.color).toBe('red')
     expect(el.style.lineHeight).toBe('1.5')
-  })
-
-  it('prefers children over content', () => {
-    render(<Text content='Fallback'>Child</Text>)
-    expect(screen.getByText('Child')).toBeTruthy()
-    expect(screen.queryByText('Fallback')).toBeNull()
   })
 })

--- a/apps/campfire/src/components/Deck/Slide/Text/index.tsx
+++ b/apps/campfire/src/components/Deck/Slide/Text/index.tsx
@@ -4,8 +4,6 @@ import { Layer, type LayerProps } from '@campfire/components/Deck/Slide/Layer'
 export interface TextProps extends Omit<LayerProps, 'children'> {
   /** The HTML tag to render. Defaults to 'p'. */
   as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'li' | 'span'
-  /** Plain-text content. If provided, children should be omitted. */
-  content?: string
   /** Horizontal alignment. Defaults to 'left'. */
   align?: 'left' | 'center' | 'right' | 'justify'
   /** Font size in pixels. Falls back to theme variables or Tailwind utilities if omitted. */
@@ -16,7 +14,7 @@ export interface TextProps extends Omit<LayerProps, 'children'> {
   lineHeight?: number
   /** Text color. Use Tailwind classes or inline CSS variables (e.g., 'var(--accent)'). */
   color?: string
-  /** Children (rich nodes) override the content prop. */
+  /** Text or rich node children to render inside the element. */
   children?: ComponentChildren
 }
 
@@ -28,7 +26,6 @@ export interface TextProps extends Omit<LayerProps, 'children'> {
  */
 export const Text = ({
   as = 'p',
-  content,
   align = 'left',
   size,
   weight,
@@ -48,7 +45,7 @@ export const Text = ({
   return (
     <Layer {...layerProps}>
       <Tag style={style} className='text-base font-normal'>
-        {children ?? content}
+        {children}
       </Tag>
     </Layer>
   )

--- a/apps/campfire/src/components/Deck/Slide/renderDirectiveMarkdown.ts
+++ b/apps/campfire/src/components/Deck/Slide/renderDirectiveMarkdown.ts
@@ -51,7 +51,7 @@ export const renderDirectiveMarkdown = (
         deck: Deck,
         slide: Slide,
         appear: Appear,
-        text: Text
+        Text
       }
     })
 

--- a/apps/campfire/src/hooks/__tests__/textDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/textDirective.test.tsx
@@ -8,6 +8,12 @@ import { Text } from '@campfire/components/Deck/Slide/Text'
 
 let output: ComponentChild | null = null
 
+/**
+ * Component used in tests to render markdown with directive handlers.
+ *
+ * @param markdown - Markdown string that may include directive containers.
+ * @returns Nothing; sets `output` with rendered content.
+ */
 const MarkdownRunner = ({ markdown }: { markdown: string }) => {
   const handlers = useDirectiveHandlers()
   output = renderDirectiveMarkdown(markdown, handlers)
@@ -20,9 +26,9 @@ beforeEach(() => {
 })
 
 describe('text directive', () => {
-  it('renders a Text component with props', () => {
+  it('renders a Text component with attributes', () => {
     const md =
-      ':::text{x=10 y=20 w=100 h=50 as="h2" align=center size=24 weight=700 lineHeight=1.2 color="red"}\nHello\n:::'
+      ':::text{x=10 y=20 w=100 h=50 z=5 rotate=45 scale=1.5 anchor=center as="h2" align=center size=24 weight=700 lineHeight=1.2 color="red" class="underline" data-test="ok"}\nHello\n:::'
     render(<MarkdownRunner markdown={md} />)
     const getText = (node: any): any => {
       if (Array.isArray(node)) return getText(node[0])
@@ -35,12 +41,18 @@ describe('text directive', () => {
     expect(text.props.y).toBe(20)
     expect(text.props.w).toBe(100)
     expect(text.props.h).toBe(50)
+    expect(text.props.z).toBe(5)
+    expect(text.props.rotate).toBe(45)
+    expect(text.props.scale).toBe(1.5)
+    expect(text.props.anchor).toBe('center')
     expect(text.props.as).toBe('h2')
     expect(text.props.align).toBe('center')
     expect(text.props.size).toBe(24)
     expect(text.props.weight).toBe(700)
     expect(text.props.lineHeight).toBe(1.2)
     expect(text.props.color).toBe('red')
+    expect(text.props.className).toBe('underline')
+    expect(text.props['data-test']).toBe('ok')
     expect(text.props.children).toBe('Hello')
   })
 

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -1750,7 +1750,7 @@ export const useDirectiveHandlers = () => {
     const textNode: Parent = {
       type: 'paragraph',
       children: content,
-      data: { hName: 'text', hProperties: props as Properties }
+      data: { hName: 'Text', hProperties: props as Properties }
     }
 
     const newIndex = replaceWithIndentation(directive, parent, index, [

--- a/apps/storybook/src/Appear.stories.tsx
+++ b/apps/storybook/src/Appear.stories.tsx
@@ -19,34 +19,20 @@ const render: StoryObj<typeof Appear>['render'] = () => (
   <Deck className='w-[800px] h-[600px]'>
     <Slide>
       <Appear at={0}>
-        <Text
-          as='h2'
-          x={80}
-          y={80}
-          size={36}
-          color='var(--color-gray-50)'
-          content='First'
-        />
+        <Text as='h2' x={80} y={80} size={36} color='var(--color-gray-50)'>
+          First
+        </Text>
       </Appear>
       <Appear at={1}>
-        <Text
-          x={500}
-          y={400}
-          size={24}
-          color='var(--color-gray-50)'
-          content='Second'
-        />
+        <Text x={500} y={400} size={24} color='var(--color-gray-50)'>
+          Second
+        </Text>
       </Appear>
     </Slide>
     <Slide>
-      <Text
-        as='h2'
-        x={80}
-        y={80}
-        size={36}
-        color='var(--color-gray-50)'
-        content='Next Slide'
-      />
+      <Text as='h2' x={80} y={80} size={36} color='var(--color-gray-50)'>
+        Next Slide
+      </Text>
     </Slide>
   </Deck>
 )

--- a/apps/storybook/src/Deck.stories.tsx
+++ b/apps/storybook/src/Deck.stories.tsx
@@ -26,32 +26,19 @@ const render: StoryObj<typeof Deck>['render'] = () => (
       }}
     >
       <Appear at={0}>
-        <Text
-          as='h2'
-          x={80}
-          y={80}
-          size={36}
-          color='var(--color-gray-50)'
-          content='Fade Slide'
-        />
+        <Text as='h2' x={80} y={80} size={36} color='var(--color-gray-50)'>
+          Fade Slide
+        </Text>
       </Appear>
       <Appear at={1}>
-        <Text
-          x={500}
-          y={400}
-          size={24}
-          color='var(--color-gray-50)'
-          content='Second step'
-        />
+        <Text x={500} y={400} size={24} color='var(--color-gray-50)'>
+          Second step
+        </Text>
       </Appear>
       <Appear at={2}>
-        <Text
-          x={500}
-          y={500}
-          size={24}
-          color='var(--color-gray-50)'
-          content='Third step'
-        />
+        <Text x={500} y={500} size={24} color='var(--color-gray-50)'>
+          Third step
+        </Text>
       </Appear>
     </Slide>
     <Slide
@@ -61,23 +48,14 @@ const render: StoryObj<typeof Deck>['render'] = () => (
       }}
     >
       <Appear at={0}>
-        <Text
-          as='h2'
-          x={80}
-          y={80}
-          size={36}
-          color='var(--color-gray-50)'
-          content='Slide Transition'
-        />
+        <Text as='h2' x={80} y={80} size={36} color='var(--color-gray-50)'>
+          Slide Transition
+        </Text>
       </Appear>
       <Appear at={1}>
-        <Text
-          x={500}
-          y={400}
-          size={24}
-          color='var(--color-gray-50)'
-          content='Second step'
-        />
+        <Text x={500} y={400} size={24} color='var(--color-gray-50)'>
+          Second step
+        </Text>
       </Appear>
     </Slide>
     <Slide
@@ -87,23 +65,14 @@ const render: StoryObj<typeof Deck>['render'] = () => (
       }}
     >
       <Appear at={0}>
-        <Text
-          as='h2'
-          x={80}
-          y={80}
-          size={36}
-          color='var(--color-gray-50)'
-          content='Zoom Slide'
-        />
+        <Text as='h2' x={80} y={80} size={36} color='var(--color-gray-50)'>
+          Zoom Slide
+        </Text>
       </Appear>
       <Appear at={1}>
-        <Text
-          x={500}
-          y={400}
-          size={24}
-          color='var(--color-gray-50)'
-          content='Second step'
-        />
+        <Text x={500} y={400} size={24} color='var(--color-gray-50)'>
+          Second step
+        </Text>
       </Appear>
     </Slide>
   </Deck>


### PR DESCRIPTION
## Summary
- ensure :::text directive renders Text component
- have Text component use children instead of a content prop
- update storybook examples and tests
- add test verifying :::text directive renders Text component with attributes

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_68a06950e90c8320af6baf0e0a92165e