### PR TITLE
fix(passage): render text directive and clean markers

### DIFF
--- a/apps/campfire/src/components/Deck/Slide/renderDirectiveMarkdown.ts
+++ b/apps/campfire/src/components/Deck/Slide/renderDirectiveMarkdown.ts
@@ -51,7 +51,7 @@ export const renderDirectiveMarkdown = (
         deck: Deck,
         slide: Slide,
         appear: Appear,
-        Text
+        text: Text
       }
     })
 

--- a/apps/campfire/src/components/Passage/If.tsx
+++ b/apps/campfire/src/components/Passage/If.tsx
@@ -15,6 +15,7 @@ import { TriggerButton } from '@campfire/components/Passage/TriggerButton'
 import { Show } from '@campfire/components/Passage/Show'
 import { OnExit } from '@campfire/components/Passage/OnExit'
 import { Appear } from '@campfire/components/Deck/Slide/Appear'
+import { Text } from '@campfire/components/Deck/Slide/Text'
 
 interface IfProps {
   test: string
@@ -45,7 +46,8 @@ export const If = ({ test, content, fallback }: IfProps) => {
           if: If,
           show: Show,
           onExit: OnExit,
-          appear: Appear
+          appear: Appear,
+          text: Text
         }
       })
     proc.parser = (_doc: unknown, file: Root) => ({

--- a/apps/campfire/src/components/Passage/Passage.tsx
+++ b/apps/campfire/src/components/Passage/Passage.tsx
@@ -137,7 +137,7 @@ export const Passage = () => {
             deck: Deck,
             slide: Slide,
             appear: Appear,
-            Text
+            text: Text
           }
         }),
     [handlers]

--- a/apps/campfire/src/components/Passage/Passage.tsx
+++ b/apps/campfire/src/components/Passage/Passage.tsx
@@ -9,7 +9,7 @@ import remarkCampfire from '@campfire/remark-campfire'
 import remarkRehype from 'remark-rehype'
 import rehypeCampfire from '@campfire/rehype-campfire'
 import rehypeReact from 'rehype-react'
-import type { Text, Content } from 'hast'
+import type { Text as HastText, Content } from 'hast'
 import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
 import { remarkHeadingStyles } from '@campfire/utils/remarkHeadingStyles'
 import { remarkParagraphStyles } from '@campfire/utils/remarkParagraphStyles'
@@ -29,6 +29,7 @@ import { OnExit } from '@campfire/components/Passage/OnExit'
 import { Deck } from '@campfire/components/Deck'
 import { Slide } from '@campfire/components/Deck/Slide'
 import { Appear } from '@campfire/components/Deck/Slide/Appear'
+import { Text } from '@campfire/components/Deck/Slide/Text'
 
 const DIRECTIVE_MARKER_PATTERN = '(:::[^\\n]*|:[^\\n]*|<<)'
 
@@ -135,7 +136,8 @@ export const Passage = () => {
             onExit: OnExit,
             deck: Deck,
             slide: Slide,
-            appear: Appear
+            appear: Appear,
+            Text
           }
         }),
     [handlers]
@@ -192,7 +194,7 @@ export const Passage = () => {
       const text = passage.children
         .map((child: Content) =>
           child.type === 'text' && typeof child.value === 'string'
-            ? (child as Text).value
+            ? (child as HastText).value
             : ''
         )
         .join('')

--- a/apps/campfire/src/components/Passage/__tests__/Passage.textDirective.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Passage.textDirective.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, beforeEach, expect } from 'bun:test'
+import { render, screen } from '@testing-library/preact'
+import i18next from 'i18next'
+import { initReactI18next } from 'react-i18next'
+import type { Element } from 'hast'
+import { Passage } from '@campfire/components/Passage/Passage'
+import { useStoryDataStore } from '@campfire/state/useStoryDataStore'
+import { resetStores } from '@campfire/test-utils/helpers'
+
+describe('Passage text directive', () => {
+  beforeEach(async () => {
+    document.body.innerHTML = ''
+    resetStores()
+    ;(HTMLElement.prototype as any).animate = () => ({
+      finished: Promise.resolve(),
+      cancel() {}
+    })
+    if (!i18next.isInitialized) {
+      await i18next.use(initReactI18next).init({ lng: 'en-US', resources: {} })
+    } else {
+      await i18next.changeLanguage('en-US')
+      i18next.services.resourceStore.data = {}
+    }
+  })
+
+  it('renders Text components without stray markers', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value:
+            ':::deck{size=800x600}\n:::slide\n:::text{x=80 y=80 as="h2"}\nHello\n:::\n:::\n:::\n'
+        }
+      ]
+    }
+    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+    render(<Passage />)
+    const heading = await screen.findByRole('heading', {
+      level: 2,
+      name: 'Hello'
+    })
+    expect(heading).toBeTruthy()
+    expect(document.body.innerHTML).not.toContain('<Text')
+    expect(document.body.textContent).not.toContain(':::')
+  })
+})

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -1756,7 +1756,14 @@ export const useDirectiveHandlers = () => {
     const newIndex = replaceWithIndentation(directive, parent, index, [
       textNode as RootContent
     ])
-    removeDirectiveMarker(parent, newIndex + 1)
+    const markerIndex = newIndex + 1
+    if (
+      parent.children[markerIndex]?.type === 'text' &&
+      /^\s*$/.test((parent.children[markerIndex] as MdText).value)
+    ) {
+      parent.children.splice(markerIndex, 1)
+    }
+    removeDirectiveMarker(parent, markerIndex)
     return [SKIP, newIndex]
   }
 

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -1750,7 +1750,7 @@ export const useDirectiveHandlers = () => {
     const textNode: Parent = {
       type: 'paragraph',
       children: content,
-      data: { hName: 'Text', hProperties: props as Properties }
+      data: { hName: 'text', hProperties: props as Properties }
     }
 
     const newIndex = replaceWithIndentation(directive, parent, index, [


### PR DESCRIPTION
## Summary
- ensure Passage maps Text directive to its component
- strip whitespace and markers after text directives
- add regression test for text directive rendering

## Testing
- `bun tsc`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_68a0747c938883208d3f6350b84c1cc5