### PR TITLE
fix: keep deck closing markers intact

### DIFF
--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -1893,7 +1893,9 @@ export const useDirectiveHandlers = () => {
       following.push(node as RootContent)
       markerPos++
     }
-    parent.children.splice(index + 1, markerPos - index)
+    if (markerPos > index + 1) {
+      parent.children.splice(index + 1, markerPos - index - 1)
+    }
 
     const children = stripLabel([
       ...(container.children as RootContent[]),

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -1894,7 +1894,7 @@ export const useDirectiveHandlers = () => {
       markerPos++
     }
     if (markerPos > index + 1) {
-      parent.children.splice(index + 1, markerPos - index - 1)
+      parent.children.splice(index + 1, markerPos - (index + 1))
     }
 
     const children = stripLabel([


### PR DESCRIPTION
## Summary
- avoid removing deck closing markers when splitting slides

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_68a09afc11fc8320aeb7425e70485da1