### PR TITLE
fix: retain nested directives inside slides

### DIFF
--- a/apps/campfire/src/hooks/__tests__/deckDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/deckDirective.test.tsx
@@ -5,6 +5,7 @@ import type { ComponentChild } from 'preact'
 import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
 import { Deck } from '@campfire/components/Deck'
 import { Slide } from '@campfire/components/Deck/Slide'
+import { Appear } from '@campfire/components/Deck/Slide/Appear'
 import { DEFAULT_DECK_HEIGHT, DEFAULT_DECK_WIDTH } from '@campfire/constants'
 import { renderDirectiveMarkdown } from '@campfire/components/Deck/Slide/renderDirectiveMarkdown'
 
@@ -76,6 +77,50 @@ describe('deck directive', () => {
   it('does not render stray colons when slide contains directives', () => {
     const md = `:::deck\n:::slide\n:::if{true}\nHi\n:::\n:::\n:::\n`
     render(<MarkdownRunner markdown={md} />)
+    const getText = (node: any): string => {
+      if (!node) return ''
+      if (typeof node === 'string') return node
+      if (Array.isArray(node)) return node.map(getText).join('')
+      if (node.props?.children) return getText(node.props.children)
+      return ''
+    }
+    const text = getText(output)
+    expect(text).not.toContain(':::')
+  })
+
+  it('keeps nested appear directives within a slide', () => {
+    const md = `:::deck{size=800x600}
+  :::slide{transition=fade}
+    :::appear{at=0}
+      :::text{x=80 y=80 as="h2"}
+      Hello
+      :::
+    :::
+    :::appear{at=1}
+      :::text{x=100 y=100 as="h2"}
+      World
+      :::
+    :::
+  :::
+:::`
+    render(<MarkdownRunner markdown={md} />)
+    const getDeck = (node: any): any => {
+      if (Array.isArray(node)) return getDeck(node[0])
+      if (node?.type === Fragment) return getDeck(node.props.children)
+      return node
+    }
+    const deck = getDeck(output)
+    const slides = Array.isArray(deck.props.children)
+      ? deck.props.children
+      : [deck.props.children]
+    expect(slides.length).toBe(1)
+    const slide = slides[0]
+    const slideChildren = Array.isArray(slide.props.children)
+      ? slide.props.children
+      : [slide.props.children]
+    expect(slideChildren.length).toBe(2)
+    expect(slideChildren[0].type).toBe(Appear)
+    expect(slideChildren[1].type).toBe(Appear)
     const getText = (node: any): string => {
       if (!node) return ''
       if (typeof node === 'string') return node


### PR DESCRIPTION
## Summary
- ensure deck handler keeps nested directives within slides
- strip slide markers before committing slide content
- add regression test for nested appear directives

## Testing
- `bun tsc`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_68a0a303bab883209f9ea7397c8a42ae