### PR TITLE
fix: reset deck state on unmount

### DIFF
--- a/apps/campfire/src/components/Deck/Slide/Appear/__tests__/Appear.test.tsx
+++ b/apps/campfire/src/components/Deck/Slide/Appear/__tests__/Appear.test.tsx
@@ -10,13 +10,7 @@ import { StubAnimation } from '@campfire/test-utils/stub-animation'
  * Resets the deck store to a clean initial state.
  */
 const resetStore = () => {
-  useDeckStore.setState({
-    currentSlide: 0,
-    currentStep: 0,
-    maxSteps: 0,
-    slidesCount: 0,
-    stepsPerSlide: {}
-  })
+  useDeckStore.getState().reset()
 }
 
 // Minimal ResizeObserver stub for the tests

--- a/apps/campfire/src/components/Deck/Slide/__tests__/Slide.test.tsx
+++ b/apps/campfire/src/components/Deck/Slide/__tests__/Slide.test.tsx
@@ -10,13 +10,7 @@ import { StubAnimation } from '@campfire/test-utils/stub-animation'
  * Resets the deck store to a clean initial state.
  */
 const resetStore = () => {
-  useDeckStore.setState({
-    currentSlide: 0,
-    currentStep: 0,
-    maxSteps: 0,
-    slidesCount: 0,
-    stepsPerSlide: {}
-  })
+  useDeckStore.getState().reset()
 }
 
 // Minimal ResizeObserver stub for the tests

--- a/apps/campfire/src/components/Deck/Slide/__tests__/SlideDirective.test.tsx
+++ b/apps/campfire/src/components/Deck/Slide/__tests__/SlideDirective.test.tsx
@@ -21,13 +21,7 @@ const makeDirective = (md: string) =>
  * Resets deck store for each test.
  */
 const resetDeckStore = () => {
-  useDeckStore.setState({
-    currentSlide: 0,
-    currentStep: 0,
-    maxSteps: 0,
-    slidesCount: 0,
-    stepsPerSlide: {}
-  })
+  useDeckStore.getState().reset()
 }
 
 // Minimal ResizeObserver stub for the tests

--- a/apps/campfire/src/components/Deck/__tests__/Deck.test.tsx
+++ b/apps/campfire/src/components/Deck/__tests__/Deck.test.tsx
@@ -9,13 +9,7 @@ import { StubAnimation } from '@campfire/test-utils/stub-animation'
  * Resets the deck store to a clean initial state.
  */
 const resetStore = () => {
-  useDeckStore.setState({
-    currentSlide: 0,
-    currentStep: 0,
-    maxSteps: 0,
-    slidesCount: 0,
-    stepsPerSlide: {}
-  })
+  useDeckStore.getState().reset()
 }
 
 // Minimal ResizeObserver stub for the tests
@@ -93,6 +87,24 @@ describe('Deck', () => {
       window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home' }))
     })
     expect(useDeckStore.getState().currentSlide).toBe(0)
+  })
+
+  it('resets deck state when unmounted', () => {
+    const { unmount } = render(
+      <Deck>
+        <div>One</div>
+        <div>Two</div>
+      </Deck>
+    )
+    act(() => {
+      useDeckStore.getState().next()
+    })
+    expect(useDeckStore.getState().currentSlide).toBe(1)
+    act(() => {
+      unmount()
+    })
+    expect(useDeckStore.getState().currentSlide).toBe(0)
+    expect(useDeckStore.getState().slidesCount).toBe(0)
   })
 
   it('applies slide transition type and duration', async () => {

--- a/apps/campfire/src/components/Deck/index.tsx
+++ b/apps/campfire/src/components/Deck/index.tsx
@@ -65,6 +65,7 @@ export const Deck = ({
   const prev = useDeckStore(state => state.prev)
   const goTo = useDeckStore(state => state.goTo)
   const setSlidesCount = useDeckStore(state => state.setSlidesCount)
+  const reset = useDeckStore(state => state.reset)
 
   const [currentVNode, setCurrentVNode] = useState(slides[0] as VNode)
   const [prevVNode, setPrevVNode] = useState<VNode | null>(null)
@@ -188,11 +189,18 @@ export const Deck = ({
     return () => window.removeEventListener('keydown', onKey)
   }, [next, prev, goTo, slides.length])
 
+  useEffect(() => {
+    return () => {
+      reset()
+    }
+  }, [reset])
+
   return (
     <div
       ref={hostRef}
       className={`relative w-full h-full overflow-hidden bg-gray-100 dark:bg-gray-900 ${className ?? ''}`}
       style={themeStyle}
+      data-testid='deck'
     >
       <div
         ref={slideRef}

--- a/apps/campfire/src/state/useDeckStory/__tests__/index.test.ts
+++ b/apps/campfire/src/state/useDeckStory/__tests__/index.test.ts
@@ -2,13 +2,7 @@ import { describe, it, expect, beforeEach } from 'bun:test'
 import { useDeckStore } from '../index'
 
 beforeEach(() => {
-  useDeckStore.setState({
-    currentSlide: 0,
-    currentStep: 0,
-    maxSteps: 0,
-    slidesCount: 0,
-    stepsPerSlide: {}
-  })
+  useDeckStore.getState().reset()
 })
 
 describe('useDeckStore', () => {

--- a/apps/campfire/src/state/useDeckStory/index.ts
+++ b/apps/campfire/src/state/useDeckStory/index.ts
@@ -22,15 +22,22 @@ export interface DeckState {
   prev: () => void
   /** Jump to a specific slide and step */
   goTo: (slide: number, step?: number) => void
+  /** Reset the deck to its initial state */
+  reset: () => void
 }
 
-/** Zustand store for tracking slide and step navigation */
-export const useDeckStore = create<DeckState>((set, get) => ({
+/** Initial state for the deck store */
+const initialState = {
   currentSlide: 0,
   currentStep: 0,
   maxSteps: 0,
   slidesCount: 0,
-  stepsPerSlide: {},
+  stepsPerSlide: {} as Record<number, number>
+}
+
+/** Zustand store for tracking slide and step navigation */
+export const useDeckStore = create<DeckState>((set, get) => ({
+  ...initialState,
   /** Update the total slide count */
   setSlidesCount: n =>
     set(
@@ -103,5 +110,7 @@ export const useDeckStore = create<DeckState>((set, get) => ({
         state.currentStep = targetStep
         state.maxSteps = maxStepsForSlide
       })
-    )
+    ),
+  /** Reset the deck to its initial state */
+  reset: () => set(initialState)
 }))

--- a/apps/campfire/src/test-utils/helpers.ts
+++ b/apps/campfire/src/test-utils/helpers.ts
@@ -1,6 +1,7 @@
 import type { Element } from 'hast'
 import { useGameStore } from '@campfire/state/useGameStore'
 import { useStoryDataStore } from '@campfire/state/useStoryDataStore'
+import { useDeckStore } from '@campfire/state/useDeckStory'
 
 export const samplePassage: Element = {
   type: 'element',
@@ -10,9 +11,10 @@ export const samplePassage: Element = {
 }
 
 /**
- * Resets story and game stores along with related side effects.
+ * Resets deck, story and game stores along with related side effects.
  */
 export const resetStores = () => {
+  useDeckStore.getState().reset()
   useStoryDataStore.setState({
     storyData: {},
     passages: [],


### PR DESCRIPTION
## Summary
- reset deck store when Deck unmounts
- add reset helper to store and tests
- ensure test helpers clear deck state

## Testing
- `bun tsc --pretty false && echo tsc-complete`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_68a0b1c06b0c8320bb81610967711489