### PR TITLE
fix: prevent deck from splitting slides on whitespace

### DIFF
--- a/apps/campfire/src/hooks/__tests__/deckDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/deckDirective.test.tsx
@@ -131,4 +131,35 @@ describe('deck directive', () => {
     const text = getText(output)
     expect(text).not.toContain(':::')
   })
+
+  it('does not create extra slides from whitespace', () => {
+    const md = `:::deck{size=800x600}
+  :::slide{transition=fade}
+    :::appear{at=0}
+      :::text{x=80 y=80 as="h2"}Hello:::
+    :::
+    :::appear{at=1}
+      :::text{x=100 y=100 as="h2"}World:::
+    :::
+  :::
+:::`
+    render(<MarkdownRunner markdown={md} />)
+    const getDeck = (node: any): any => {
+      if (Array.isArray(node)) return getDeck(node[0])
+      if (node?.type === Fragment) return getDeck(node.props.children)
+      return node
+    }
+    const deck = getDeck(output)
+    const slides = Array.isArray(deck.props.children)
+      ? deck.props.children
+      : [deck.props.children]
+    expect(slides.length).toBe(1)
+    const slide = slides[0]
+    const slideChildren = Array.isArray(slide.props.children)
+      ? slide.props.children
+      : [slide.props.children]
+    expect(slideChildren.length).toBe(2)
+    expect(slideChildren[0].type).toBe(Appear)
+    expect(slideChildren[1].type).toBe(Appear)
+  })
 })


### PR DESCRIPTION
## Summary
- ignore whitespace-only nodes when committing deck slides
- add regression test for whitespace after appear directives

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_68a0b7e9e4ec83208f3cdee4e7db4c24