### PR TITLE
fix: remove default backgrounds from deck and slide components

### DIFF
--- a/apps/campfire/src/components/Deck/Slide/__tests__/Slide.test.tsx
+++ b/apps/campfire/src/components/Deck/Slide/__tests__/Slide.test.tsx
@@ -29,7 +29,7 @@ beforeEach(() => {
 })
 
 describe('Slide', () => {
-  it('uses default gray background when none provided', () => {
+  it('does not apply a default background when none provided', () => {
     render(
       <Deck>
         <Slide>Slide 1</Slide>
@@ -37,7 +37,7 @@ describe('Slide', () => {
       </Deck>
     )
     const el = screen.getByText('Slide 1') as HTMLElement
-    expect(el).toHaveClass('bg-gray-100', 'dark:bg-gray-900')
+    expect(el).not.toHaveClass('bg-gray-100', 'dark:bg-gray-900')
   })
 
   it('registers steps in the deck store when active', () => {

--- a/apps/campfire/src/components/Deck/Slide/index.tsx
+++ b/apps/campfire/src/components/Deck/Slide/index.tsx
@@ -94,7 +94,7 @@ export const Slide = ({
     }
   }, [])
 
-  const bgClass = typeof background === 'string' ? background : ''
+  const bgClass = background && typeof background === 'string' ? background : ''
   const bgStyle: JSX.CSSProperties =
     typeof background === 'object'
       ? {

--- a/apps/campfire/src/components/Deck/__tests__/Deck.test.tsx
+++ b/apps/campfire/src/components/Deck/__tests__/Deck.test.tsx
@@ -43,13 +43,16 @@ describe('Deck', () => {
     expect(screen.getByText('Slide 1')).toBeInTheDocument()
   })
 
-  it('uses gray backgrounds for light and dark modes', () => {
+  it('does not apply default backgrounds', () => {
     const { container } = render(
       <Deck>
         <div>Slide 1</div>
       </Deck>
     )
-    expect(container.firstChild).toHaveClass('bg-gray-100', 'dark:bg-gray-900')
+    expect(container.firstChild).not.toHaveClass(
+      'bg-gray-100',
+      'dark:bg-gray-900'
+    )
   })
 
   it('advances and reverses slides via click and keyboard', () => {

--- a/apps/storybook/src/Appear.stories.tsx
+++ b/apps/storybook/src/Appear.stories.tsx
@@ -17,7 +17,7 @@ export default meta
  */
 const render: StoryObj<typeof Appear>['render'] = () => (
   <Deck className='w-[800px] h-[600px]'>
-    <Slide>
+    <Slide background='bg-gray-100 dark:bg-gray-900'>
       <Appear at={0}>
         <DeckText
           as='h2'
@@ -44,7 +44,7 @@ const render: StoryObj<typeof Appear>['render'] = () => (
         </DeckText>
       </Appear>
     </Slide>
-    <Slide>
+    <Slide background='bg-gray-100 dark:bg-gray-900'>
       <DeckText
         as='h2'
         x={280}

--- a/apps/storybook/src/Deck.stories.tsx
+++ b/apps/storybook/src/Deck.stories.tsx
@@ -24,6 +24,7 @@ const render: StoryObj<typeof Deck>['render'] = () => (
         enter: { type: 'fade', duration: 300 },
         exit: { type: 'fade', duration: 300 }
       }}
+      background='bg-gray-100 dark:bg-gray-900'
     >
       <Appear at={0}>
         <DeckText as='h2' x={80} y={80} size={36}>
@@ -46,6 +47,7 @@ const render: StoryObj<typeof Deck>['render'] = () => (
         enter: { type: 'slide', dir: 'left', duration: 300 },
         exit: { type: 'slide', dir: 'right', duration: 300 }
       }}
+      background='bg-gray-100 dark:bg-gray-900'
     >
       <Appear at={0}>
         <DeckText as='h2' x={80} y={80} size={36}>
@@ -63,6 +65,7 @@ const render: StoryObj<typeof Deck>['render'] = () => (
         enter: { type: 'zoom', duration: 300 },
         exit: { type: 'zoom', duration: 300 }
       }}
+      background='bg-gray-100 dark:bg-gray-900'
     >
       <Appear at={0}>
         <DeckText as='h2' x={80} y={80} size={36}>


### PR DESCRIPTION
## Summary
- drop default gray backgrounds from Deck and Slide
- update related tests and stories to apply backgrounds explicitly

## Testing
- `bun x prettier --write .`
- `bun tsc --pretty false --listFiles`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_68a12f2eff00832097a484ab12fafbfb