### PR TITLE
fix(directives): forward positioning props in text directive and add deck example test

### DIFF
--- a/apps/campfire/src/hooks/__tests__/deckDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/deckDirective.test.tsx
@@ -6,6 +6,7 @@ import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
 import { Deck } from '@campfire/components/Deck'
 import { Slide } from '@campfire/components/Deck/Slide'
 import { Appear } from '@campfire/components/Deck/Slide'
+import { DeckText } from '@campfire/components/Deck/Slide'
 import { DEFAULT_DECK_HEIGHT, DEFAULT_DECK_WIDTH } from '@campfire/constants'
 import { renderDirectiveMarkdown } from '@campfire/components/Deck/Slide'
 
@@ -161,5 +162,66 @@ describe('deck directive', () => {
     expect(slideChildren.length).toBe(2)
     expect(slideChildren[0].type).toBe(Appear)
     expect(slideChildren[1].type).toBe(Appear)
+  })
+
+  it('matches the Storybook deck example', () => {
+    const md = `:::deck{size=800x600}
+  :::slide{transition=fade}
+    :::appear{at=0}
+      :::text{x=80 y=80 as="h2"}
+      Hello
+      :::
+    :::
+    :::appear{at=1}
+      :::text{x=100 y=100 as="h2"}
+      World
+      :::
+    :::
+  :::
+:::`
+    render(<MarkdownRunner markdown={md} />)
+    const getDeck = (node: any): any => {
+      if (Array.isArray(node)) return getDeck(node[0])
+      if (node?.type === Fragment) return getDeck(node.props.children)
+      return node
+    }
+    const deck = getDeck(output)
+    expect(deck).toMatchObject({
+      type: Deck,
+      props: { size: { width: 800, height: 600 } }
+    })
+    const slides = Array.isArray(deck.props.children)
+      ? deck.props.children
+      : [deck.props.children]
+    expect(slides).toHaveLength(1)
+    const [slide] = slides
+    expect(slide).toMatchObject({
+      type: Slide,
+      props: { transition: { type: 'fade' } }
+    })
+    const appearChildren = Array.isArray(slide.props.children)
+      ? slide.props.children
+      : [slide.props.children]
+    expect(appearChildren).toHaveLength(2)
+    expect(appearChildren[0]).toMatchObject({
+      type: Appear,
+      props: {
+        at: 0,
+        children: {
+          type: DeckText,
+          props: { as: 'h2', x: 80, y: 80, children: 'Hello' }
+        }
+      }
+    })
+    expect(appearChildren[1]).toMatchObject({
+      type: Appear,
+      props: {
+        at: 1,
+        children: {
+          type: DeckText,
+          props: { as: 'h2', x: 100, y: 100, children: 'World' }
+        }
+      }
+    })
   })
 })

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -1751,16 +1751,28 @@ export const useDirectiveHandlers = () => {
       const tagName = attrs.as ? String(attrs.as) : 'p'
       const style: string[] = []
       style.push('position:absolute')
-      if (typeof attrs.x === 'number') style.push(`left:${attrs.x}px`)
-      if (typeof attrs.y === 'number') style.push(`top:${attrs.y}px`)
-      if (typeof attrs.w === 'number') style.push(`width:${attrs.w}px`)
-      if (typeof attrs.h === 'number') style.push(`height:${attrs.h}px`)
-      if (typeof attrs.z === 'number') style.push(`z-index:${attrs.z}`)
+      if (typeof attrs.x === 'number') {
+        style.push(`left:${attrs.x}px`)
+      }
+      if (typeof attrs.y === 'number') {
+        style.push(`top:${attrs.y}px`)
+      }
+      if (typeof attrs.w === 'number') {
+        style.push(`width:${attrs.w}px`)
+      }
+      if (typeof attrs.h === 'number') {
+        style.push(`height:${attrs.h}px`)
+      }
+      if (typeof attrs.z === 'number') {
+        style.push(`z-index:${attrs.z}`)
+      }
       const transforms: string[] = []
-      if (typeof attrs.rotate === 'number')
+      if (typeof attrs.rotate === 'number') {
         transforms.push(`rotate(${attrs.rotate}deg)`)
-      if (typeof attrs.scale === 'number')
+      }
+      if (typeof attrs.scale === 'number') {
         transforms.push(`scale(${attrs.scale})`)
+      }
       if (transforms.length) style.push(`transform:${transforms.join(' ')}`)
       if (attrs.anchor && attrs.anchor !== 'top-left') {
         const originMap: Record<string, string> = {
@@ -1786,6 +1798,14 @@ export const useDirectiveHandlers = () => {
         style.push(`line-height:${attrs.lineHeight}`)
       if (attrs.color) style.push(`color:${attrs.color}`)
       const props: Record<string, unknown> = {}
+      if (typeof attrs.x === 'number') props.x = attrs.x
+      if (typeof attrs.y === 'number') props.y = attrs.y
+      if (typeof attrs.w === 'number') props.w = attrs.w
+      if (typeof attrs.h === 'number') props.h = attrs.h
+      if (typeof attrs.z === 'number') props.z = attrs.z
+      if (typeof attrs.rotate === 'number') props.rotate = attrs.rotate
+      if (typeof attrs.scale === 'number') props.scale = attrs.scale
+      if (attrs.anchor) props.anchor = attrs.anchor
       if (style.length) props.style = style.join(';')
       const classAttr =
         typeof raw.class === 'string'


### PR DESCRIPTION
## Summary
- add regression test mirroring Campfire/Directives/Deck story
- ensure text directive forwards positioning props to DeckText

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_68a13383cca083209c9a1093d9ee8d25