### PR TITLE
fix: avoid extra slides from stray markers

### DIFF
--- a/apps/campfire/src/hooks/__tests__/deckDirective.leadingNewline.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/deckDirective.leadingNewline.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach } from 'bun:test'
+import { render } from '@testing-library/preact'
+import { Fragment } from 'preact/jsx-runtime'
+import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
+import { Appear } from '@campfire/components/Deck/Slide'
+import { renderDirectiveMarkdown } from '@campfire/components/Deck/Slide'
+
+let output: any = null
+const MarkdownRunner = ({ markdown }: { markdown: string }) => {
+  const handlers = useDirectiveHandlers()
+  output = renderDirectiveMarkdown(markdown, handlers)
+  return null
+}
+
+describe('deck directive', () => {
+  beforeEach(() => {
+    output = null
+    document.body.innerHTML = ''
+  })
+
+  it('handles leading newline before deck', () => {
+    const md = `\n:::deck{size=800x600}
+  :::slide{transition=fade}
+    :::appear{at=0}
+      :::text{x=80 y=80 as="h2"}
+      Hello
+      :::
+    :::
+    :::appear{at=1}
+      :::text{x=100 y=100 as="h2"}
+      World
+      :::
+    :::
+  :::
+:::
+`
+    render(<MarkdownRunner markdown={md} />)
+    const getDeck = (node: any): any => {
+      if (Array.isArray(node)) return getDeck(node[0])
+      if (node?.type === Fragment) return getDeck(node.props.children)
+      return node
+    }
+    const deck = getDeck(output)
+    const slides = Array.isArray(deck.props.children)
+      ? deck.props.children
+      : [deck.props.children]
+    expect(slides.length).toBe(1)
+    const [slide] = slides
+    const slideChildren = Array.isArray(slide.props.children)
+      ? slide.props.children
+      : [slide.props.children]
+    expect(slideChildren).toHaveLength(2)
+    expect(slideChildren[0].type).toBe(Appear)
+    expect(slideChildren[1].type).toBe(Appear)
+  })
+})

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -1955,6 +1955,10 @@ export const useDirectiveHandlers = () => {
 
     const children: RootContent[] = stripLabel(
       preprocessBlock([...(container.children as RootContent[]), ...following])
+    ).filter(
+      child =>
+        !isMarkerParagraph(child as RootContent) &&
+        !isWhitespaceNode(child as RootContent)
     )
     let pendingAttrs: Record<string, unknown> = {}
     let pendingNodes: RootContent[] = []


### PR DESCRIPTION
## Summary
- filter stray marker and whitespace nodes when building deck slides
- add regression test for leading newline before deck

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_68a1527670708320b5545ee48a13dffe