### PR TITLE
fix: merge stray appear directives into previous slide

### DIFF
--- a/apps/campfire/src/hooks/__tests__/deckDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/deckDirective.test.tsx
@@ -164,6 +164,37 @@ describe('deck directive', () => {
     expect(slideChildren[1].type).toBe(Appear)
   })
 
+  it('merges stray appear directives into the previous slide', () => {
+    const md = `:::deck{size=800x600}
+  :::slide{transition=fade}
+    :::appear{at=0}
+      :::text{x=80 y=80 as="h2"}Hello:::
+    :::
+  :::
+  :::appear{at=1}
+    :::text{x=100 y=100 as="h2"}World:::
+  :::
+:::`
+    render(<MarkdownRunner markdown={md} />)
+    const getDeck = (node: any): any => {
+      if (Array.isArray(node)) return getDeck(node[0])
+      if (node?.type === Fragment) return getDeck(node.props.children)
+      return node
+    }
+    const deck = getDeck(output)
+    const slides = Array.isArray(deck.props.children)
+      ? deck.props.children
+      : [deck.props.children]
+    expect(slides.length).toBe(1)
+    const slide = slides[0]
+    const slideChildren = Array.isArray(slide.props.children)
+      ? slide.props.children
+      : [slide.props.children]
+    expect(slideChildren.length).toBe(2)
+    expect(slideChildren[0].type).toBe(Appear)
+    expect(slideChildren[1].type).toBe(Appear)
+  })
+
   it('matches the Storybook deck example', () => {
     const md = `:::deck{size=800x600}
   :::slide{transition=fade}


### PR DESCRIPTION
## Summary
- prevent deck handler from generating empty slides by merging stray directives into prior slide
- add regression test covering stray `appear` directives outside a slide

## Testing
- `bun tsc`
- `bun test`
- `bun test apps/campfire/src/hooks/__tests__/deckDirective.test.tsx`

------
https://chatgpt.com/codex/tasks/task_b_68a15d9d1b7c8320a5c7587bddad761b