### PR TITLE
fix(deck): prevent double click skipping appears

### DIFF
--- a/apps/campfire/src/components/Deck/Deck.tsx
+++ b/apps/campfire/src/components/Deck/Deck.tsx
@@ -211,7 +211,9 @@ export const Deck = ({
           transformOrigin: 'center center'
         }}
         className='absolute left-1/2 top-1/2'
-        onClick={next}
+        onClick={e => {
+          if (e.detail <= 1) next()
+        }}
       >
         {prevVNode}
         {currentVNode}


### PR DESCRIPTION
## Summary
- ignore multi-click mouse events in Deck to avoid skipping Appear steps

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_68a1ffbd86808320a6c37c0a55876c82