### PR TITLE
fix: reset deck state when slide unmounts

### DIFF
--- a/apps/campfire/src/components/Deck/Slide/__tests__/Slide.test.tsx
+++ b/apps/campfire/src/components/Deck/Slide/__tests__/Slide.test.tsx
@@ -64,4 +64,15 @@ describe('Slide', () => {
       JSON.stringify({ type: 'fade', duration: 300 })
     )
   })
+
+  it('resets deck state when the slide unmounts', () => {
+    const { rerender } = render(
+      <Deck>
+        <Slide steps={2}>Slide 1</Slide>
+      </Deck>
+    )
+    expect(useDeckStore.getState().maxSteps).toBe(2)
+    rerender(<Deck></Deck>)
+    expect(useDeckStore.getState().maxSteps).toBe(0)
+  })
 })

--- a/apps/campfire/src/components/Deck/Slide/index.tsx
+++ b/apps/campfire/src/components/Deck/Slide/index.tsx
@@ -68,6 +68,8 @@ export const Slide = ({
   const runExit = useSerializedDirectiveRunner(onExit ?? '[]')
   const runExitRef = useRef(runExit)
   const onExitRef = useRef(onExit)
+  // Preserve the slide index at mount for cleanup checks
+  const indexRef = useRef(useDeckStore.getState().currentSlide)
 
   useEffect(() => {
     if ((steps ?? 0) !== maxSteps) {
@@ -91,8 +93,11 @@ export const Slide = ({
       if (onExitRef.current) {
         runExitRef.current()
       }
+      if (useDeckStore.getState().currentSlide === indexRef.current) {
+        setMaxSteps(0)
+      }
     }
-  }, [])
+  }, [setMaxSteps])
 
   const bgClass = background && typeof background === 'string' ? background : ''
   const bgStyle: JSX.CSSProperties =


### PR DESCRIPTION
## Summary
- reset deck store state when a Slide component unmounts while still active
- add regression test to ensure deck state resets after slide removal

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_68a2036035d88320baa2eb1a9cebe605