### PR TITLE
feat: add SlideShape component

### DIFF
--- a/apps/campfire/src/components/Deck/Slide/SlideShape/__tests__/SlideShape.test.tsx
+++ b/apps/campfire/src/components/Deck/Slide/SlideShape/__tests__/SlideShape.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'bun:test'
+import { render, screen } from '@testing-library/preact'
+import { SlideShape } from '@campfire/components/Deck/Slide'
+
+describe('SlideShape', () => {
+  it('renders a rectangle with styling options', () => {
+    render(
+      <SlideShape
+        type='rect'
+        x={10}
+        y={20}
+        w={100}
+        h={50}
+        stroke='red'
+        fill='blue'
+        radius={5}
+        shadow
+      />
+    )
+    const wrapper = screen.getByTestId('slideShape') as HTMLElement
+    const rect = wrapper.querySelector('rect') as SVGRectElement
+    const svg = wrapper.querySelector('svg') as SVGSVGElement
+    expect(rect.getAttribute('rx')).toBe('5')
+    expect(rect.getAttribute('fill')).toBe('blue')
+    expect(rect.getAttribute('stroke')).toBe('red')
+    expect(svg.style.filter).toContain('drop-shadow')
+    expect(wrapper.style.left).toBe('10px')
+    expect(wrapper.style.top).toBe('20px')
+    expect(wrapper.style.width).toBe('100px')
+    expect(wrapper.style.height).toBe('50px')
+  })
+
+  it('renders a line', () => {
+    render(
+      <SlideShape
+        type='line'
+        x={0}
+        y={0}
+        w={100}
+        h={100}
+        x1={0}
+        y1={50}
+        x2={100}
+        y2={50}
+        stroke='black'
+      />
+    )
+    const line = screen
+      .getByTestId('slideShape')
+      .querySelector('line') as SVGLineElement
+    expect(line.getAttribute('x1')).toBe('0')
+    expect(line.getAttribute('x2')).toBe('100')
+  })
+})

--- a/apps/campfire/src/components/Deck/Slide/SlideShape/index.tsx
+++ b/apps/campfire/src/components/Deck/Slide/SlideShape/index.tsx
@@ -1,0 +1,96 @@
+import { type JSX } from 'preact'
+import { Layer, type LayerProps } from '@campfire/components/Deck/Slide'
+import parseInlineStyle from '@campfire/utils/parseInlineStyle'
+
+export interface SlideShapeProps extends Omit<LayerProps, 'children'> {
+  /** Shape type to render. */
+  type: 'rect' | 'ellipse' | 'line' | 'polygon'
+  /** SVG path points used for polygon shapes. */
+  points?: string
+  /** Starting x-coordinate for line shapes. */
+  x1?: number
+  /** Starting y-coordinate for line shapes. */
+  y1?: number
+  /** Ending x-coordinate for line shapes. */
+  x2?: number
+  /** Ending y-coordinate for line shapes. */
+  y2?: number
+  /** Stroke color of the shape. */
+  stroke?: string
+  /** Stroke width of the shape. Defaults to 1. */
+  strokeWidth?: number
+  /** Fill color of the shape. Defaults to 'none'. */
+  fill?: string
+  /** Corner radius for rectangles. */
+  radius?: number
+  /** Adds a drop shadow when true. */
+  shadow?: boolean
+  /** Additional CSS class names for the svg element. */
+  className?: string
+  /** Additional CSS properties for the svg element. */
+  style?: JSX.CSSProperties | string
+}
+
+/**
+ * Renders basic SVG shapes within an absolutely positioned layer.
+ *
+ * @param props - Configuration options for the shape element.
+ * @returns The rendered shape layer.
+ */
+export const SlideShape = ({
+  type,
+  points,
+  x1,
+  y1,
+  x2,
+  y2,
+  stroke,
+  strokeWidth = 1,
+  fill = 'none',
+  radius,
+  shadow,
+  className,
+  style: styleProp,
+  ...layerProps
+}: SlideShapeProps): JSX.Element => {
+  const style: JSX.CSSProperties = parseInlineStyle(styleProp ?? {})
+  if (shadow) {
+    const drop = 'drop-shadow(0 1px 2px rgba(0,0,0,0.25))'
+    style.filter = style.filter ? `${style.filter} ${drop}` : drop
+  }
+  const shapeProps = { stroke, strokeWidth, fill }
+  let shape: JSX.Element | null = null
+  switch (type) {
+    case 'rect':
+      shape = (
+        <rect
+          width='100%'
+          height='100%'
+          rx={radius}
+          ry={radius}
+          {...shapeProps}
+        />
+      )
+      break
+    case 'ellipse':
+      shape = <ellipse cx='50%' cy='50%' rx='50%' ry='50%' {...shapeProps} />
+      break
+    case 'line':
+      shape = <line x1={x1} y1={y1} x2={x2} y2={y2} {...shapeProps} />
+      break
+    case 'polygon':
+      shape = <polygon points={points} {...shapeProps} />
+      break
+    default:
+      shape = null
+  }
+  return (
+    <Layer data-testid='slideShape' {...layerProps}>
+      <svg width='100%' height='100%' className={className} style={style}>
+        {shape}
+      </svg>
+    </Layer>
+  )
+}
+
+export default SlideShape

--- a/apps/campfire/src/components/Deck/Slide/index.tsx
+++ b/apps/campfire/src/components/Deck/Slide/index.tsx
@@ -157,6 +157,7 @@ export default Slide
 export { Appear } from './Appear'
 export { SlideText } from './SlideText'
 export { SlideImage } from './SlideImage'
+export { SlideShape } from './SlideShape'
 export { Layer } from './Layer'
 export type { LayerProps } from './Layer'
 export { renderDirectiveMarkdown } from './renderDirectiveMarkdown'

--- a/apps/campfire/src/components/index.ts
+++ b/apps/campfire/src/components/index.ts
@@ -15,5 +15,6 @@ export {
   Appear,
   Layer,
   SlideText,
-  SlideImage
+  SlideImage,
+  SlideShape
 } from '@campfire/components/Deck/Slide'

--- a/apps/storybook/src/SlideShape.stories.tsx
+++ b/apps/storybook/src/SlideShape.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/preact'
+import { h } from 'preact'
+import { Deck, Slide, SlideShape } from '@campfire/components'
+
+const meta: Meta<typeof SlideShape> = {
+  component: SlideShape,
+  title: 'Campfire/SlideShape'
+}
+
+export default meta
+
+/**
+ * Demonstrates drawing basic shapes on a slide using SlideShape.
+ *
+ * @returns Deck with several shapes.
+ */
+export const Basic: StoryObj<typeof SlideShape> = {
+  render: () => (
+    <Deck className='w-[800px] h-[600px]'>
+      <Slide>
+        <SlideShape
+          type='rect'
+          x={50}
+          y={50}
+          w={150}
+          h={100}
+          fill='#93c5fd'
+          stroke='#1e3a8a'
+          radius={8}
+          shadow
+        />
+        <SlideShape
+          type='line'
+          x={300}
+          y={100}
+          w={200}
+          h={50}
+          x1={0}
+          y1={25}
+          x2={200}
+          y2={25}
+          stroke='#000'
+        />
+      </Slide>
+    </Deck>
+  )
+}


### PR DESCRIPTION
## Summary
- add SlideShape component for basic SVG shapes
- export component and add Storybook example
- cover SlideShape with unit tests
- remove arrow shape type for now

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_68a348664d508320b634c8911fc58e56