### PR TITLE
Fix shape directive to render SlideShape

### DIFF
--- a/apps/campfire/src/components/DebugWindow/index.tsx
+++ b/apps/campfire/src/components/DebugWindow/index.tsx
@@ -7,7 +7,7 @@ import remarkCampfire from '@campfire/remark-campfire'
 import remarkRehype from 'remark-rehype'
 import rehypeCampfire from '@campfire/rehype-campfire'
 import rehypeStringify from 'rehype-stringify'
-import rehypeDeckText from '@campfire/utils/rehypeDeckText'
+import rehypeSlideText from '@campfire/utils/rehypeSlideText'
 import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
 import { remarkHeadingStyles } from '@campfire/utils/remarkHeadingStyles'
 import { remarkParagraphStyles } from '@campfire/utils/remarkParagraphStyles'
@@ -124,7 +124,7 @@ export const DebugWindow = () => {
         .use(remarkHeadingStyles)
         .use(remarkRehype)
         .use(rehypeCampfire)
-        .use(rehypeDeckText)
+        .use(rehypeSlideText)
         .use(rehypeStringify),
     [handlers]
   )

--- a/apps/campfire/src/components/Deck/Deck.tsx
+++ b/apps/campfire/src/components/Deck/Deck.tsx
@@ -134,12 +134,17 @@ export const Deck = ({
     return { slides: cloned, slideSteps: steps }
   }, [children])
   const currentSlide = useDeckStore(state => state.currentSlide)
+  const currentStep = useDeckStore(state => state.currentStep)
+  const maxSteps = useDeckStore(state => state.maxSteps)
   const next = useDeckStore(state => state.next)
   const prev = useDeckStore(state => state.prev)
   const goTo = useDeckStore(state => state.goTo)
   const setSlidesCount = useDeckStore(state => state.setSlidesCount)
   const setStepsForSlide = useDeckStore(state => state.setStepsForSlide)
   const reset = useDeckStore(state => state.reset)
+
+  const atStart = currentSlide === 0 && currentStep === 0
+  const atEnd = currentSlide === slides.length - 1 && currentStep === maxSteps
 
   const labels: A11yLabels = useMemo(
     () => ({
@@ -354,6 +359,7 @@ export const Deck = ({
           aria-label={labels.prev}
           onClick={prev}
           data-testid='deck-prev'
+          disabled={atStart}
         >
           ◀
         </button>
@@ -363,6 +369,7 @@ export const Deck = ({
           aria-label={labels.next}
           onClick={next}
           data-testid='deck-next'
+          disabled={atEnd}
         >
           ▶
         </button>

--- a/apps/campfire/src/components/Deck/Slide/renderDirectiveMarkdown.ts
+++ b/apps/campfire/src/components/Deck/Slide/renderDirectiveMarkdown.ts
@@ -34,7 +34,7 @@ export const renderDirectiveMarkdown = (
     deck: Deck,
     slide: Slide,
     appear: Appear,
-    deckText: SlideText,
+    slideText: SlideText,
     slideImage: SlideImage,
     slideShape: SlideShape
   })

--- a/apps/campfire/src/components/Deck/__tests__/Deck.test.tsx
+++ b/apps/campfire/src/components/Deck/__tests__/Deck.test.tsx
@@ -92,6 +92,24 @@ describe('Deck', () => {
     expect(useDeckStore.getState().currentSlide).toBe(0)
   })
 
+  it('disables navigation buttons at deck bounds', () => {
+    render(
+      <Deck>
+        <div>Slide 1</div>
+        <div>Slide 2</div>
+      </Deck>
+    )
+    const prevBtn = screen.getByTestId('deck-prev') as HTMLButtonElement
+    const nextBtn = screen.getByTestId('deck-next') as HTMLButtonElement
+    expect(prevBtn).toBeDisabled()
+    expect(nextBtn).not.toBeDisabled()
+    act(() => {
+      fireEvent.click(nextBtn)
+    })
+    expect(prevBtn).not.toBeDisabled()
+    expect(nextBtn).toBeDisabled()
+  })
+
   it('jumps to start or end using Home and End keys', () => {
     render(
       <Deck>

--- a/apps/campfire/src/components/Passage/If.tsx
+++ b/apps/campfire/src/components/Passage/If.tsx
@@ -14,9 +14,13 @@ import { LinkButton } from '@campfire/components/Passage/LinkButton'
 import { TriggerButton } from '@campfire/components/Passage/TriggerButton'
 import { Show } from '@campfire/components/Passage/Show'
 import { OnExit } from '@campfire/components/Passage/OnExit'
-import { Appear } from '@campfire/components/Deck/Slide'
-import { SlideText } from '@campfire/components/Deck/Slide'
-import { rehypeDeckText } from '@campfire/utils/rehypeDeckText'
+import {
+  Appear,
+  SlideText,
+  SlideImage,
+  SlideShape
+} from '@campfire/components/Deck/Slide'
+import { rehypeSlideText } from '@campfire/utils/rehypeSlideText'
 
 interface IfProps {
   test: string
@@ -37,7 +41,7 @@ export const If = ({ test, content, fallback }: IfProps) => {
       .use(remarkCampfire, { handlers })
       .use(remarkRehype)
       .use(rehypeCampfire)
-      .use(rehypeDeckText)
+      .use(rehypeSlideText)
       .use(rehypeReact, {
         Fragment,
         jsx,
@@ -49,7 +53,9 @@ export const If = ({ test, content, fallback }: IfProps) => {
           show: Show,
           onExit: OnExit,
           appear: Appear,
-          deckText: SlideText
+          slideText: SlideText,
+          slideImage: SlideImage,
+          slideShape: SlideShape
         }
       })
     proc.parser = (_doc: unknown, file: Root) => ({

--- a/apps/campfire/src/components/Passage/Passage.tsx
+++ b/apps/campfire/src/components/Passage/Passage.tsx
@@ -19,7 +19,13 @@ import { If } from '@campfire/components/Passage/If'
 import { Show } from '@campfire/components/Passage/Show'
 import { OnExit } from '@campfire/components/Passage/OnExit'
 import { Deck } from '@campfire/components/Deck'
-import { Slide, Appear, SlideText } from '@campfire/components/Deck/Slide'
+import {
+  Slide,
+  Appear,
+  SlideText,
+  SlideImage,
+  SlideShape
+} from '@campfire/components/Deck/Slide'
 
 const DIRECTIVE_MARKER_PATTERN = '(:::[^\\n]*|:[^\\n]*|<<)'
 
@@ -116,7 +122,9 @@ export const Passage = () => {
           deck: Deck,
           slide: Slide,
           appear: Appear,
-          deckText: SlideText
+          slideText: SlideText,
+          slideImage: SlideImage,
+          slideShape: SlideShape
         },
         [remarkParagraphStyles, remarkHeadingStyles]
       ),

--- a/apps/campfire/src/components/Passage/__tests__/Passage.shapeDirective.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Passage.shapeDirective.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, beforeEach, expect } from 'bun:test'
+import { render, screen } from '@testing-library/preact'
+import i18next from 'i18next'
+import { initReactI18next } from 'react-i18next'
+import type { Element } from 'hast'
+import { Passage } from '@campfire/components/Passage/Passage'
+import { useStoryDataStore } from '@campfire/state/useStoryDataStore'
+import { resetStores } from '@campfire/test-utils/helpers'
+
+/**
+ * Tests rendering of the shape directive within a Passage.
+ */
+describe('Passage shape directive', () => {
+  beforeEach(async () => {
+    document.body.innerHTML = ''
+    resetStores()
+    ;(HTMLElement.prototype as any).animate = () => ({
+      finished: Promise.resolve(),
+      cancel() {}
+    })
+    if (!i18next.isInitialized) {
+      await i18next.use(initReactI18next).init({ lng: 'en-US', resources: {} })
+    } else {
+      await i18next.changeLanguage('en-US')
+      i18next.services.resourceStore.data = {}
+    }
+  })
+
+  it('renders SlideShape components without stray markers', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value:
+            ':::deck{size=800x600}\n:::slide\n:::shape{x=10 y=20 w=100 h=50 type="rect" data-test="ok"}\n:::\n:::\n:::\n'
+        }
+      ]
+    }
+    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+    render(<Passage />)
+    const el = await screen.findByTestId('slideShape')
+    expect(el).toBeTruthy()
+    expect(el.style.left).toBe('10px')
+    expect(el.style.top).toBe('20px')
+    expect(el.style.width).toBe('100px')
+    expect(el.style.height).toBe('50px')
+    expect(el.getAttribute('data-test')).toBe('ok')
+    expect(document.body.innerHTML).not.toContain('<SlideShape')
+    expect(document.body.textContent).not.toContain(':::')
+  })
+})

--- a/apps/campfire/src/components/Passage/__tests__/Passage.shapeDirective.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Passage.shapeDirective.test.tsx
@@ -14,9 +14,12 @@ describe('Passage shape directive', () => {
   beforeEach(async () => {
     document.body.innerHTML = ''
     resetStores()
-    ;(HTMLElement.prototype as any).animate = () => ({
-      finished: Promise.resolve(),
+    const animation: Partial<Animation> = {
+      finished: Promise.resolve<Animation>({} as Animation),
       cancel() {}
+    }
+    Object.defineProperty(HTMLElement.prototype, 'animate', {
+      value: () => animation as Animation
     })
     if (!i18next.isInitialized) {
       await i18next.use(initReactI18next).init({ lng: 'en-US', resources: {} })

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -1867,7 +1867,7 @@ export const useDirectiveHandlers = () => {
       const classes = ['text-base', 'font-normal']
       if (classAttr) classes.unshift(classAttr)
       props.className = classes.join(' ')
-      props['data-component'] = 'deckText'
+      props['data-component'] = 'slideText'
       props['data-as'] = tagName
       applyAdditionalAttributes(raw, props, [
         'x',

--- a/apps/campfire/src/utils/createMarkdownProcessor.ts
+++ b/apps/campfire/src/utils/createMarkdownProcessor.ts
@@ -5,7 +5,7 @@ import remarkDirective from 'remark-directive'
 import remarkCampfire from '@campfire/remark-campfire'
 import remarkRehype from 'remark-rehype'
 import rehypeCampfire from '@campfire/rehype-campfire'
-import rehypeDeckText from '@campfire/utils/rehypeDeckText'
+import rehypeSlideText from '@campfire/utils/rehypeSlideText'
 import rehypeReact from 'rehype-react'
 import { Fragment, jsx, jsxs } from 'preact/jsx-runtime'
 import type { ComponentType } from 'preact'
@@ -34,5 +34,5 @@ export const createMarkdownProcessor = (
     .use(remarkPlugins)
     .use(remarkRehype)
     .use(rehypeCampfire)
-    .use(rehypeDeckText)
+    .use(rehypeSlideText)
     .use(rehypeReact, { Fragment, jsx, jsxs, components })

--- a/apps/campfire/src/utils/rehypeSlideText.ts
+++ b/apps/campfire/src/utils/rehypeSlideText.ts
@@ -2,24 +2,24 @@ import { visit } from 'unist-util-visit'
 import type { Root } from 'hast'
 
 /**
- * Rewrites elements marked with `data-component="deckText"` into
- * `<deckText>` nodes for component rendering and passes along the
+ * Rewrites elements marked with `data-component="slideText"` into
+ * `<slideText>` nodes for component rendering and passes along the
  * original tag via the `as` prop.
  *
  * @returns A rehype plugin that mutates the tree in place.
  */
-export const rehypeDeckText =
+export const rehypeSlideText =
   () =>
   (tree: Root): void => {
     visit(tree, 'element', node => {
       const props = node.properties as Record<string, unknown>
-      if (props['data-component'] !== 'deckText') return
+      if (props['data-component'] !== 'slideText') return
       const as = props['data-as'] as string | undefined
-      node.tagName = 'deckText'
+      node.tagName = 'slideText'
       if (as) props.as = as
       delete props['data-component']
       delete props['data-as']
     })
   }
 
-export default rehypeDeckText
+export default rehypeSlideText

--- a/apps/storybook/src/Deck.stories.tsx
+++ b/apps/storybook/src/Deck.stories.tsx
@@ -153,3 +153,26 @@ export const WithSlideCounter: StoryObj<typeof Deck> = {
     </Deck>
   )
 }
+
+/**
+ * Demonstrates that navigation controls are disabled at the start and end of
+ * the deck.
+ *
+ * @returns The rendered Deck element showcasing disabled navigation buttons.
+ */
+export const WithDisabledControls: StoryObj<typeof Deck> = {
+  render: () => (
+    <Deck className='w-[800px] h-[600px]'>
+      <Slide>
+        <SlideText as='h2' x={200} y={200} size={36}>
+          Start
+        </SlideText>
+      </Slide>
+      <Slide>
+        <SlideText as='h2' x={200} y={200} size={36}>
+          End
+        </SlideText>
+      </Slide>
+    </Deck>
+  )
+}


### PR DESCRIPTION
## Summary
- ensure Passage's Markdown processor can render SlideShape and SlideImage directives
- test shape directive rendering within a passage
- disable deck navigation controls at bounds
- add Storybook example demonstrating disabled navigation buttons
- replace deprecated deckText directive with slideText and handle slideImage/slideShape in conditional blocks

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_68a3850522408320aebe3d39f3121694