### PR TITLE
fix: enforce container and leaf directive usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,7 +581,7 @@ Control the flow between passages or how they appear.
   # One
 
   :::
-  :::slide{}
+  :::slide
 
   ## Two
 
@@ -589,8 +589,8 @@ Control the flow between passages or how they appear.
   :::
   ```
 
-  Each `:slide` or `:::slide` starts a new slide. Plain Markdown inside the deck
-  becomes its own slide if not preceded by a slide directive.
+  Each `:::slide` starts a new slide. Plain Markdown inside the deck becomes
+  its own slide if not preceded by a slide directive.
 
   | Input      | Description                                                                |
   | ---------- | -------------------------------------------------------------------------- |
@@ -598,19 +598,64 @@ Control the flow between passages or how they appear.
   | transition | Default transition applied between slides                                  |
   | theme      | Optional JSON object or string of CSS properties applied to the deck theme |
 
-- `text`: Position typographic content within a slide.
+- `appear`: Reveal slide content step-by-step.
 
   ```md
   :::deck
   :::slide
-  :::text{x=100 y=50 align=center size=32}
-  Hello
+  :::appear{at=0}
+  :text[First]{x=80 y=80}
+  :::
+  :::appear{at=1}
+  :text[Second]{x=80 y=120}
   :::
   :::
   :::
   ```
 
+  | Input             | Description                          |
+  | ----------------- | ------------------------------------ |
+  | at                | Deck step when content appears       |
+  | exitAt            | Deck step when content hides         |
+  | enter             | Enter animation key                  |
+  | exit              | Exit animation key                   |
+  | interruptBehavior | How to handle interrupted animations |
+
+- `text`: Position typographic content within a slide.
+
+  ```md
+  :::deck
+  :::slide
+  :text[Hello]{x=100 y=50 align=center size=32}
+  :::
+  :::
+  ```
+
   Accepts the same attributes as the `Text` component.
+
+- `image`: Position an image within a slide.
+
+  ```md
+  :::deck
+  :::slide
+  :image{src='https://example.com/cat.png' x=10 y=20}
+  :::
+  :::
+  ```
+
+  Accepts the same attributes as the `SlideImage` component.
+
+- `shape`: Draw basic shapes within a slide.
+
+  ```md
+  :::deck
+  :::slide
+  :shape{type='rect' x=10 y=20 w=100 h=50}
+  :::
+  :::
+  ```
+
+  Accepts the same attributes as the `SlideShape` component.
 
 ### Persistence
 

--- a/apps/campfire/src/components/Passage/__tests__/Passage.shapeDirective.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Passage.shapeDirective.test.tsx
@@ -38,7 +38,7 @@ describe('Passage shape directive', () => {
         {
           type: 'text',
           value:
-            ':::deck{size=800x600}\n:::slide\n:::shape{x=10 y=20 w=100 h=50 type="rect" data-test="ok"}\n:::\n:::\n:::\n'
+            ':::deck{size=800x600}\n:::slide\n:shape{x=10 y=20 w=100 h=50 type="rect" data-test="ok"}\n:::\n:::\n'
         }
       ]
     }

--- a/apps/campfire/src/components/Passage/__tests__/Passage.textDirective.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Passage.textDirective.test.tsx
@@ -5,7 +5,6 @@ import { initReactI18next } from 'react-i18next'
 import type { Element } from 'hast'
 import { Passage } from '@campfire/components/Passage/Passage'
 import { useStoryDataStore } from '@campfire/state/useStoryDataStore'
-import { useGameStore } from '@campfire/state/useGameStore'
 import { resetStores } from '@campfire/test-utils/helpers'
 
 describe('Passage text directive', () => {
@@ -33,7 +32,7 @@ describe('Passage text directive', () => {
         {
           type: 'text',
           value:
-            ':::deck{size=800x600}\n:::slide\n:::text{x=80 y=80 as="h2"}\nHello\n:::\n:::\n:::\n'
+            ':::deck{size=800x600}\n:::slide\n:text[Hello]{x=80 y=80 as="h2"}\n:::\n:::\n'
         }
       ]
     }
@@ -43,46 +42,5 @@ describe('Passage text directive', () => {
     expect(el).toBeTruthy()
     expect(document.body.innerHTML).not.toContain('<SlideText')
     expect(document.body.textContent).not.toContain(':::')
-  })
-
-  it('renders show directive inside text container', async () => {
-    useGameStore.setState({ gameData: { hp: 5 } })
-    const passage: Element = {
-      type: 'element',
-      tagName: 'tw-passagedata',
-      properties: { pid: '1', name: 'Start' },
-      children: [
-        {
-          type: 'text',
-          value:
-            ':::deck{size=800x600}\n:::slide\n:::text{x=80 y=80}\nHP: :show[hp]\n:::\n:::\n:::\n'
-        }
-      ]
-    }
-    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
-    render(<Passage />)
-    const el = await screen.findByTestId('slideText')
-    const text = el.textContent?.replace(/\s+/g, ' ').trim()
-    expect(text).toBe('HP: 5')
-  })
-
-  it('renders t directive inside text container', async () => {
-    i18next.addResource('en-US', 'translation', 'hello', 'Hello')
-    const passage: Element = {
-      type: 'element',
-      tagName: 'tw-passagedata',
-      properties: { pid: '1', name: 'Start' },
-      children: [
-        {
-          type: 'text',
-          value:
-            ':::deck{size=800x600}\n:::slide\n:::text{x=80 y=80}\n:t[hello]\n:::\n:::\n:::\n'
-        }
-      ]
-    }
-    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
-    render(<Passage />)
-    const el = await screen.findByText('Hello')
-    expect(el).toBeInTheDocument()
   })
 })

--- a/apps/campfire/src/hooks/__tests__/deckDirective.leadingNewline.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/deckDirective.leadingNewline.test.tsx
@@ -22,14 +22,10 @@ describe('deck directive', () => {
     const md = `\n:::deck{size='800x600'}
   :::slide{transition='fade'}
     :::appear{at=0}
-      :::text{x=80 y=80 as="h2"}
-      Hello
-      :::
+      :text[Hello]{x=80 y=80 as="h2"}
     :::
     :::appear{at=1}
-      :::text{x=100 y=100 as="h2"}
-      World
-      :::
+      :text[World]{x=100 y=100 as="h2"}
     :::
   :::
 :::

--- a/apps/campfire/src/hooks/__tests__/deckDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/deckDirective.test.tsx
@@ -49,7 +49,7 @@ describe('deck directive', () => {
 :::slide{transition='fade'}
 # One
 :::
-::slide{}
+:::slide
 ## Two
 :::
 :::`
@@ -117,14 +117,10 @@ describe('deck directive', () => {
     const md = `:::deck{size='800x600'}
   :::slide{transition='fade'}
     :::appear{at=0}
-      :::text{x=80 y=80 as="h2"}
-      Hello
-      :::
+      :text[Hello]{x=80 y=80 as="h2"}
     :::
     :::appear{at=1}
-      :::text{x=100 y=100 as="h2"}
-      World
-      :::
+      :text[World]{x=100 y=100 as="h2"}
     :::
   :::
 :::`
@@ -154,10 +150,10 @@ describe('deck directive', () => {
     const md = `:::deck{size='800x600'}
   :::slide{transition='fade'}
     :::appear{at=0}
-      :::text{x=80 y=80 as="h2"}Hello:::
+      :text[Hello]{x=80 y=80 as="h2"}
     :::
     :::appear{at=1}
-      :::text{x=100 y=100 as="h2"}World:::
+      :text[World]{x=100 y=100 as="h2"}
     :::
   :::
 :::`
@@ -185,11 +181,11 @@ describe('deck directive', () => {
     const md = `:::deck{size='800x600'}
   :::slide{transition='fade'}
     :::appear{at=0}
-      :::text{x=80 y=80 as="h2"}Hello:::
+      :text[Hello]{x=80 y=80 as="h2"}
     :::
   :::
   :::appear{at=1}
-    :::text{x=100 y=100 as="h2"}World:::
+    :text[World]{x=100 y=100 as="h2"}
   :::
 :::`
     render(<MarkdownRunner markdown={md} />)
@@ -216,14 +212,10 @@ describe('deck directive', () => {
     const md = `:::deck{size='800x600'}
   :::slide{transition='fade'}
     :::appear{at=0}
-      :::text{x=80 y=80 as="h2"}
-      Hello
-      :::
+      :text[Hello]{x=80 y=80 as="h2"}
     :::
     :::appear{at=1}
-      :::text{x=100 y=100 as="h2"}
-      World
-      :::
+      :text[World]{x=100 y=100 as="h2"}
     :::
   :::
 :::`
@@ -251,26 +243,11 @@ describe('deck directive', () => {
       ? slide.props.children
       : [slide.props.children]
     expect(appearChildren).toHaveLength(2)
-    expect(appearChildren[0]).toMatchObject({
-      type: Appear,
-      props: {
-        at: 0,
-        children: {
-          type: SlideText,
-          props: { as: 'h2', x: 80, y: 80, children: 'Hello' }
-        }
-      }
-    })
-    expect(appearChildren[1]).toMatchObject({
-      type: Appear,
-      props: {
-        at: 1,
-        children: {
-          type: SlideText,
-          props: { as: 'h2', x: 100, y: 100, children: 'World' }
-        }
-      }
-    })
+    const [first, second] = appearChildren
+    expect(first).toMatchObject({ type: Appear, props: { at: 0 } })
+    expect(getText(first)).toBe('Hello')
+    expect(second).toMatchObject({ type: Appear, props: { at: 1 } })
+    expect(getText(second)).toBe('World')
     const text = getText(output)
     expect(text).toBe('HelloWorld')
   })

--- a/apps/campfire/src/hooks/__tests__/shapeDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/shapeDirective.test.tsx
@@ -31,7 +31,7 @@ beforeEach(() => {
 describe('shape directive', () => {
   it('renders a SlideShape component with props', () => {
     const md =
-      ':::appear\n:::shape{x=10 y=20 w=100 h=50 type="rect" stroke="red" fill="blue" radius=5 shadow=true class="rounded" data-test="ok"}\n:::\n:::\n'
+      ':::appear\n:shape{x=10 y=20 w=100 h=50 type="rect" stroke="red" fill="blue" radius=5 shadow=true class="rounded" data-test="ok"}\n:::\n'
     render(<MarkdownRunner markdown={md} />)
     const el = document.querySelector(
       '[data-testid="slideShape"]'
@@ -52,7 +52,7 @@ describe('shape directive', () => {
   })
 
   it('does not render stray colons after shape blocks', () => {
-    const md = ':::shape{type="rect"}\n:::\n:::if{true}\nHi\n:::\n'
+    const md = ':shape{type="rect"}\n:::if{true}\nHi\n:::\n'
     render(<MarkdownRunner markdown={md} />)
     const text = document.body.textContent || ''
     expect(text).not.toContain(':::')

--- a/apps/campfire/src/hooks/__tests__/textDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/textDirective.test.tsx
@@ -28,7 +28,7 @@ beforeEach(() => {
 describe('text directive', () => {
   it('renders a SlideText component with styles', () => {
     const md =
-      ':::text{x=10 y=20 w=100 h=50 z=5 rotate=45 scale=1.5 anchor=center as="h2" align=center size=24 weight=700 lineHeight=1.2 color="red" class="underline" data-test="ok"}\nHello\n:::'
+      ':text[Hello]{x=10 y=20 w=100 h=50 z=5 rotate=45 scale=1.5 anchor=center as="h2" align=center size=24 weight=700 lineHeight=1.2 color="red" class="underline" data-test="ok"}'
     render(<MarkdownRunner markdown={md} />)
     const el = document.querySelector(
       '[data-testid="slideText"]'
@@ -65,19 +65,5 @@ describe('text directive', () => {
     )
     expect(el.getAttribute('data-test')).toBe('ok')
     expect(inner.textContent).toBe('Hello')
-  })
-
-  it('does not render stray colons when text contains directives', () => {
-    const md = ':::text\n:::if{true}\nHi\n:::\n:::\n'
-    render(<MarkdownRunner markdown={md} />)
-    const getTextContent = (node: any): string => {
-      if (!node) return ''
-      if (typeof node === 'string') return node
-      if (Array.isArray(node)) return node.map(getTextContent).join('')
-      if (node.props?.children) return getTextContent(node.props.children)
-      return ''
-    }
-    const text = getTextContent(output)
-    expect(text).not.toContain(':::')
   })
 })

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -1641,6 +1641,12 @@ export const useDirectiveHandlers = () => {
     ): DirectiveHandler =>
     (directive, parent, index) => {
       if (!parent || typeof index !== 'number') return
+      if (directive.type !== 'containerDirective') {
+        const msg = `${directive.name} can only be used as a container directive`
+        console.error(msg)
+        addError(msg)
+        return removeNode(parent, index)
+      }
       const container = directive as ContainerDirective
       const { attrs } = extractAttributes<S>(directive, parent, index, schema)
       const rawAttrs = (directive.attributes || {}) as Record<string, unknown>
@@ -1786,129 +1792,120 @@ export const useDirectiveHandlers = () => {
   )
 
   /**
-   * Converts a `:::text` directive into a SlideText element.
+   * Converts a `:text` directive into a SlideText element.
    *
    * @param directive - The text directive node.
    * @param parent - Parent node containing the directive.
    * @param index - Index of the directive within its parent.
-   * @returns Visitor instructions after replacement.
+   * @returns The index of the inserted node.
    */
-  const handleText = createContainerHandler(
-    attrs => (attrs.as ? String(attrs.as) : 'p'),
-    textSchema,
-    (attrs, raw) => {
-      const tagName = attrs.as ? String(attrs.as) : 'p'
-      const style: string[] = []
-      style.push('position:absolute')
-      if (typeof attrs.x === 'number') {
-        style.push(`left:${attrs.x}px`)
-      }
-      if (typeof attrs.y === 'number') {
-        style.push(`top:${attrs.y}px`)
-      }
-      if (typeof attrs.w === 'number') {
-        style.push(`width:${attrs.w}px`)
-      }
-      if (typeof attrs.h === 'number') {
-        style.push(`height:${attrs.h}px`)
-      }
-      if (typeof attrs.z === 'number') {
-        style.push(`z-index:${attrs.z}`)
-      }
-      const transforms: string[] = []
-      if (typeof attrs.rotate === 'number') {
-        transforms.push(`rotate(${attrs.rotate}deg)`)
-      }
-      if (typeof attrs.scale === 'number') {
-        transforms.push(`scale(${attrs.scale})`)
-      }
-      if (transforms.length) style.push(`transform:${transforms.join(' ')}`)
-      if (attrs.anchor && attrs.anchor !== 'top-left') {
-        const originMap: Record<string, string> = {
-          'top-left': '0% 0%',
-          top: '50% 0%',
-          'top-right': '100% 0%',
-          left: '0% 50%',
-          center: '50% 50%',
-          right: '100% 50%',
-          'bottom-left': '0% 100%',
-          bottom: '50% 100%',
-          'bottom-right': '100% 100%'
-        }
-        const origin = originMap[attrs.anchor]
-        if (origin) style.push(`transform-origin:${origin}`)
-      }
-      if (attrs.align) style.push(`text-align:${attrs.align}`)
-      if (typeof attrs.size === 'number')
-        style.push(`font-size:${attrs.size}px`)
-      if (typeof attrs.weight === 'number')
-        style.push(`font-weight:${attrs.weight}`)
-      if (typeof attrs.lineHeight === 'number')
-        style.push(`line-height:${attrs.lineHeight}`)
-      if (attrs.color) style.push(`color:${attrs.color}`)
-      const props: Record<string, unknown> = {}
-      if (typeof attrs.x === 'number') props.x = attrs.x
-      if (typeof attrs.y === 'number') props.y = attrs.y
-      if (typeof attrs.w === 'number') props.w = attrs.w
-      if (typeof attrs.h === 'number') props.h = attrs.h
-      if (typeof attrs.z === 'number') props.z = attrs.z
-      if (typeof attrs.rotate === 'number') props.rotate = attrs.rotate
-      if (typeof attrs.scale === 'number') props.scale = attrs.scale
-      if (attrs.anchor) props.anchor = attrs.anchor
-      if (style.length) props.style = style.join(';')
-      const classAttr =
-        typeof raw.class === 'string'
-          ? raw.class
-          : typeof raw.className === 'string'
-            ? raw.className
-            : typeof raw.classes === 'string'
-              ? raw.classes
-              : undefined
-      const classes = ['text-base', 'font-normal']
-      if (classAttr) classes.unshift(classAttr)
-      props.className = classes.join(' ')
-      props['data-component'] = 'slideText'
-      props['data-as'] = tagName
-      applyAdditionalAttributes(raw, props, [
-        'x',
-        'y',
-        'w',
-        'h',
-        'z',
-        'rotate',
-        'scale',
-        'anchor',
-        'as',
-        'content',
-        'align',
-        'size',
-        'weight',
-        'lineHeight',
-        'color',
-        'class',
-        'className',
-        'classes'
-      ])
-      return props
-    },
-    (processed, attrs) => {
-      if (attrs.content) {
-        return [{ type: 'text', value: attrs.content } as RootContent]
-      }
-      if (processed.length === 1 && processed[0].type === 'paragraph') {
-        return (processed[0] as Parent).children as RootContent[]
-      }
-      return processed
-    },
-    (parent, markerIndex) => {
-      if (
-        parent.children[markerIndex]?.type === 'text' &&
-        /^\s*$/.test((parent.children[markerIndex] as MdText).value)
-      ) {
-        parent.children.splice(markerIndex, 1)
-      }
+  const handleText: DirectiveHandler = (directive, parent, index) => {
+    if (!parent || typeof index !== 'number') return
+    if (directive.type !== 'textDirective') {
+      const msg = 'text can only be used as a leaf directive'
+      console.error(msg)
+      addError(msg)
+      return removeNode(parent, index)
     }
-  )
+    const { attrs } = extractAttributes<TextSchema>(
+      directive,
+      parent,
+      index,
+      textSchema
+    )
+    const raw = (directive.attributes || {}) as Record<string, unknown>
+    const tagName = attrs.as ? String(attrs.as) : 'p'
+    const style: string[] = []
+    style.push('position:absolute')
+    if (typeof attrs.x === 'number') style.push(`left:${attrs.x}px`)
+    if (typeof attrs.y === 'number') style.push(`top:${attrs.y}px`)
+    if (typeof attrs.w === 'number') style.push(`width:${attrs.w}px`)
+    if (typeof attrs.h === 'number') style.push(`height:${attrs.h}px`)
+    if (typeof attrs.z === 'number') style.push(`z-index:${attrs.z}`)
+    const transforms: string[] = []
+    if (typeof attrs.rotate === 'number')
+      transforms.push(`rotate(${attrs.rotate}deg)`)
+    if (typeof attrs.scale === 'number')
+      transforms.push(`scale(${attrs.scale})`)
+    if (transforms.length) style.push(`transform:${transforms.join(' ')}`)
+    if (attrs.anchor && attrs.anchor !== 'top-left') {
+      const originMap: Record<string, string> = {
+        'top-left': '0% 0%',
+        top: '50% 0%',
+        'top-right': '100% 0%',
+        left: '0% 50%',
+        center: '50% 50%',
+        right: '100% 50%',
+        'bottom-left': '0% 100%',
+        bottom: '50% 100%',
+        'bottom-right': '100% 100%'
+      }
+      const origin = originMap[attrs.anchor]
+      if (origin) style.push(`transform-origin:${origin}`)
+    }
+    if (attrs.align) style.push(`text-align:${attrs.align}`)
+    if (typeof attrs.size === 'number') style.push(`font-size:${attrs.size}px`)
+    if (typeof attrs.weight === 'number')
+      style.push(`font-weight:${attrs.weight}`)
+    if (typeof attrs.lineHeight === 'number')
+      style.push(`line-height:${attrs.lineHeight}`)
+    if (attrs.color) style.push(`color:${attrs.color}`)
+    const props: Record<string, unknown> = {}
+    if (typeof attrs.x === 'number') props.x = attrs.x
+    if (typeof attrs.y === 'number') props.y = attrs.y
+    if (typeof attrs.w === 'number') props.w = attrs.w
+    if (typeof attrs.h === 'number') props.h = attrs.h
+    if (typeof attrs.z === 'number') props.z = attrs.z
+    if (typeof attrs.rotate === 'number') props.rotate = attrs.rotate
+    if (typeof attrs.scale === 'number') props.scale = attrs.scale
+    if (attrs.anchor) props.anchor = attrs.anchor
+    if (style.length) props.style = style.join(';')
+    const classAttr =
+      typeof raw.class === 'string'
+        ? raw.class
+        : typeof raw.className === 'string'
+          ? raw.className
+          : typeof raw.classes === 'string'
+            ? raw.classes
+            : undefined
+    const classes = ['text-base', 'font-normal']
+    if (classAttr) classes.unshift(classAttr)
+    props.className = classes.join(' ')
+    props['data-component'] = 'slideText'
+    props['data-as'] = tagName
+    applyAdditionalAttributes(raw, props, [
+      'x',
+      'y',
+      'w',
+      'h',
+      'z',
+      'rotate',
+      'scale',
+      'anchor',
+      'as',
+      'content',
+      'align',
+      'size',
+      'weight',
+      'lineHeight',
+      'color',
+      'class',
+      'className',
+      'classes'
+    ])
+    const content =
+      typeof attrs.content === 'string'
+        ? attrs.content
+        : toString(directive).trim()
+    const node: Parent = {
+      type: 'paragraph',
+      children: [{ type: 'text', value: content } as RootContent],
+      data: { hName: tagName, hProperties: props as Properties }
+    }
+    return replaceWithIndentation(directive, parent, index, [
+      node as RootContent
+    ])
+  }
 
   /**
    * Converts a `:image` directive into a SlideImage element.
@@ -1920,6 +1917,12 @@ export const useDirectiveHandlers = () => {
    */
   const handleImage: DirectiveHandler = (directive, parent, index) => {
     if (!parent || typeof index !== 'number') return
+    if (directive.type !== 'textDirective') {
+      const msg = 'image can only be used as a leaf directive'
+      console.error(msg)
+      addError(msg)
+      return removeNode(parent, index)
+    }
     const { attrs } = extractAttributes<ImageSchema>(
       directive,
       parent,
@@ -1974,76 +1977,92 @@ export const useDirectiveHandlers = () => {
   }
 
   /**
-   * Converts a `:::shape` directive into a SlideShape element.
+   * Converts a `:shape` directive into a SlideShape element.
    *
    * @param directive - The shape directive node.
    * @param parent - Parent node containing the directive.
    * @param index - Index of the directive within its parent.
-   * @returns Visitor instructions after replacement.
+   * @returns The index of the inserted node.
    */
-  const handleShape = createContainerHandler(
-    'slideShape',
-    shapeSchema,
-    (attrs, raw) => {
-      const props: Record<string, unknown> = { type: attrs.type }
-      if (typeof attrs.x === 'number') props.x = attrs.x
-      if (typeof attrs.y === 'number') props.y = attrs.y
-      if (typeof attrs.w === 'number') props.w = attrs.w
-      if (typeof attrs.h === 'number') props.h = attrs.h
-      if (typeof attrs.z === 'number') props.z = attrs.z
-      if (typeof attrs.rotate === 'number') props.rotate = attrs.rotate
-      if (typeof attrs.scale === 'number') props.scale = attrs.scale
-      if (attrs.anchor) props.anchor = attrs.anchor
-      if (attrs.points) props.points = attrs.points
-      if (typeof attrs.x1 === 'number') props.x1 = attrs.x1
-      if (typeof attrs.y1 === 'number') props.y1 = attrs.y1
-      if (typeof attrs.x2 === 'number') props.x2 = attrs.x2
-      if (typeof attrs.y2 === 'number') props.y2 = attrs.y2
-      if (attrs.stroke) props.stroke = attrs.stroke
-      if (typeof attrs.strokeWidth === 'number')
-        props.strokeWidth = attrs.strokeWidth
-      if (attrs.fill) props.fill = attrs.fill
-      if (typeof attrs.radius === 'number') props.radius = attrs.radius
-      if (typeof attrs.shadow === 'boolean') props.shadow = attrs.shadow
-      if (attrs.style) props.style = attrs.style
-      const classAttr =
-        typeof raw.class === 'string'
-          ? raw.class
-          : typeof raw.className === 'string'
-            ? raw.className
-            : typeof raw.classes === 'string'
-              ? raw.classes
-              : undefined
-      if (classAttr) props.className = classAttr
-      applyAdditionalAttributes(raw, props, [
-        'x',
-        'y',
-        'w',
-        'h',
-        'z',
-        'rotate',
-        'scale',
-        'anchor',
-        'type',
-        'points',
-        'x1',
-        'y1',
-        'x2',
-        'y2',
-        'stroke',
-        'strokeWidth',
-        'fill',
-        'radius',
-        'shadow',
-        'style',
-        'class',
-        'className',
-        'classes'
-      ])
-      return props
-    },
-    () => []
-  )
+  const handleShape: DirectiveHandler = (directive, parent, index) => {
+    if (!parent || typeof index !== 'number') return
+    if (directive.type !== 'textDirective') {
+      const msg = 'shape can only be used as a leaf directive'
+      console.error(msg)
+      addError(msg)
+      return removeNode(parent, index)
+    }
+    const { attrs } = extractAttributes<ShapeSchema>(
+      directive,
+      parent,
+      index,
+      shapeSchema
+    )
+    const raw = (directive.attributes || {}) as Record<string, unknown>
+    const props: Record<string, unknown> = { type: attrs.type }
+    if (typeof attrs.x === 'number') props.x = attrs.x
+    if (typeof attrs.y === 'number') props.y = attrs.y
+    if (typeof attrs.w === 'number') props.w = attrs.w
+    if (typeof attrs.h === 'number') props.h = attrs.h
+    if (typeof attrs.z === 'number') props.z = attrs.z
+    if (typeof attrs.rotate === 'number') props.rotate = attrs.rotate
+    if (typeof attrs.scale === 'number') props.scale = attrs.scale
+    if (attrs.anchor) props.anchor = attrs.anchor
+    if (attrs.points) props.points = attrs.points
+    if (typeof attrs.x1 === 'number') props.x1 = attrs.x1
+    if (typeof attrs.y1 === 'number') props.y1 = attrs.y1
+    if (typeof attrs.x2 === 'number') props.x2 = attrs.x2
+    if (typeof attrs.y2 === 'number') props.y2 = attrs.y2
+    if (attrs.stroke) props.stroke = attrs.stroke
+    if (typeof attrs.strokeWidth === 'number')
+      props.strokeWidth = attrs.strokeWidth
+    if (attrs.fill) props.fill = attrs.fill
+    if (typeof attrs.radius === 'number') props.radius = attrs.radius
+    if (typeof attrs.shadow === 'boolean') props.shadow = attrs.shadow
+    if (attrs.style) props.style = attrs.style
+    const classAttr =
+      typeof raw.class === 'string'
+        ? raw.class
+        : typeof raw.className === 'string'
+          ? raw.className
+          : typeof raw.classes === 'string'
+            ? raw.classes
+            : undefined
+    if (classAttr) props.className = classAttr
+    applyAdditionalAttributes(raw, props, [
+      'x',
+      'y',
+      'w',
+      'h',
+      'z',
+      'rotate',
+      'scale',
+      'anchor',
+      'type',
+      'points',
+      'x1',
+      'y1',
+      'x2',
+      'y2',
+      'stroke',
+      'strokeWidth',
+      'fill',
+      'radius',
+      'shadow',
+      'style',
+      'class',
+      'className',
+      'classes'
+    ])
+    const node: Parent = {
+      type: 'paragraph',
+      children: [],
+      data: { hName: 'slideShape', hProperties: props as Properties }
+    }
+    return replaceWithIndentation(directive, parent, index, [
+      node as RootContent
+    ])
+  }
 
   /**
    * Builds a props object for the Slide component from extracted attributes.
@@ -2081,6 +2100,12 @@ export const useDirectiveHandlers = () => {
    */
   const handleDeck: DirectiveHandler = (directive, parent, index) => {
     if (!parent || typeof index !== 'number') return
+    if (directive.type !== 'containerDirective') {
+      const msg = 'deck can only be used as a container directive'
+      console.error(msg)
+      addError(msg)
+      return removeNode(parent, index)
+    }
     const container = directive as ContainerDirective
 
     const { attrs: deckAttrs } = extractAttributes(
@@ -2139,7 +2164,6 @@ export const useDirectiveHandlers = () => {
     )
     let pendingAttrs: Record<string, unknown> = {}
     let pendingNodes: RootContent[] = []
-    let pendingLeaf = false
 
     /**
      * Finalizes the currently buffered slide content and adds it to the deck.
@@ -2167,7 +2191,7 @@ export const useDirectiveHandlers = () => {
       const processed = runBlock(pendingNodes)
       const content = stripLabel(processed)
       const attrsEmpty = Object.keys(pendingAttrs).length === 0
-      if (slides.length > 0 && attrsEmpty && !pendingLeaf) {
+      if (slides.length > 0 && attrsEmpty) {
         const lastSlide = slides[slides.length - 1]
         ;(lastSlide.children as RootContent[]).push(...content)
       } else {
@@ -2195,7 +2219,6 @@ export const useDirectiveHandlers = () => {
       }
       pendingAttrs = {}
       pendingNodes = []
-      pendingLeaf = false
     }
 
     children.forEach((child, i) => {
@@ -2227,14 +2250,9 @@ export const useDirectiveHandlers = () => {
         (child as DirectiveNode).name === 'slide'
       ) {
         commitPending()
-        const { attrs: parsed } = extractAttributes<SlideSchema>(
-          child as DirectiveNode,
-          container,
-          i,
-          slideSchema
-        )
-        pendingAttrs = parsed
-        pendingLeaf = true
+        const msg = 'slide can only be used as a container directive'
+        console.error(msg)
+        addError(msg)
       } else {
         pendingNodes.push(child)
       }

--- a/apps/storybook/src/Campfire.stories.tsx
+++ b/apps/storybook/src/Campfire.stories.tsx
@@ -56,16 +56,11 @@ export const Deck: StoryObj = {
 :::deck{size='800x600'}
   :::slide{transition='fade'}
     :::appear{at=0}
-      :::text{x=80 y=80 as="h2"}
-      Hello
-      :::
+      :text[Hello]{x=80 y=80 as="h2"}
     :::
-    :::shape{x=150 y=150 w=100 h=50 type='rect' stroke='blue' fill='#ddf' radius=8 shadow=true}
-    :::
+    :shape{x=150 y=150 w=100 h=50 type='rect' stroke='blue' fill='#ddf' radius=8 shadow=true}
     :::appear{at=1}
-      :::text{x=100 y=100 as="h2"}
-      World
-      :::
+      :text[World]{x=100 y=100 as="h2"}
     :::
   :::
 :::


### PR DESCRIPTION
## Summary
- restrict deck, slide, and appear directives to container blocks
- limit text, image, and shape directives to leaf form
- document directive usage and examples

## Testing
- `bun tsc`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_68a3eb1a1994832098c98a9bd7de6fb2