### PR TITLE
feat: add preset directive and from attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,6 +597,7 @@ Control the flow between passages or how they appear.
   | size       | Slide size as `WIDTHxHEIGHT` in pixels or aspect ratio like `16x9`         |
   | transition | Default transition applied between slides                                  |
   | theme      | Optional JSON object or string of CSS properties applied to the deck theme |
+  | from       | Name of a deck preset to apply before other attributes                     |
 
 - `appear`: Reveal slide content step-by-step.
 
@@ -620,6 +621,7 @@ Control the flow between passages or how they appear.
   | enter             | Enter animation key                  |
   | exit              | Exit animation key                   |
   | interruptBehavior | How to handle interrupted animations |
+  | from              | Name of an appear preset to apply    |
 
 - `text`: Position typographic content within a slide.
 
@@ -631,7 +633,7 @@ Control the flow between passages or how they appear.
   :::
   ```
 
-  Accepts the same attributes as the `Text` component.
+  Accepts the same attributes as the `Text` component and supports a `from` attribute to apply presets.
 
 - `image`: Position an image within a slide.
 
@@ -643,7 +645,7 @@ Control the flow between passages or how they appear.
   :::
   ```
 
-  Accepts the same attributes as the `SlideImage` component.
+  Accepts the same attributes as the `SlideImage` component and supports a `from` attribute to apply presets.
 
 - `shape`: Draw basic shapes within a slide.
 
@@ -655,7 +657,22 @@ Control the flow between passages or how they appear.
   :::
   ```
 
-  Accepts the same attributes as the `SlideShape` component.
+  Accepts the same attributes as the `SlideShape` component and supports a `from` attribute to apply presets.
+
+- `preset`: Define reusable attribute sets that can be applied via the `from` attribute on `deck`, `appear`, `image`, `shape`, and `text` directives.
+
+  ```md
+  :preset{type="deck" name="wide" size="16x9"}
+  :preset{type="text" name="title" x=100 y=50 size=32 color="#333"}
+
+  :::deck{from="wide"}
+  :::slide
+  :text[Welcome]{from="title"}
+  :::
+  :::
+  ```
+
+  Presets allow authors to reuse common configurations across multiple directives.
 
 ### Persistence
 

--- a/apps/campfire/src/hooks/__tests__/appearDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/appearDirective.test.tsx
@@ -45,6 +45,20 @@ describe('appear directive', () => {
     expect(appear.props['data-test']).toBe('ok')
   })
 
+  it('applies appear presets with overrides', () => {
+    const md =
+      ':preset{type="appear" name="fade" at=2}\n:::appear{from="fade" exitAt=3}\nHi\n:::'
+    render(<MarkdownRunner markdown={md} />)
+    const getAppear = (node: any): any => {
+      if (Array.isArray(node)) return getAppear(node[0])
+      if (node?.type === Fragment) return getAppear(node.props.children)
+      return node
+    }
+    const appear = getAppear(output)
+    expect(appear.props.at).toBe(2)
+    expect(appear.props.exitAt).toBe(3)
+  })
+
   it('does not render stray colons when appear contains directives', () => {
     const md = `:::appear\n:::if{true}\nHi\n:::\n:::\n`
     render(<MarkdownRunner markdown={md} />)

--- a/apps/campfire/src/hooks/__tests__/deckDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/deckDirective.test.tsx
@@ -251,4 +251,18 @@ describe('deck directive', () => {
     const text = getText(output)
     expect(text).toBe('HelloWorld')
   })
+
+  it('applies deck presets with overrides', () => {
+    const md =
+      ':preset{type="deck" name="wide" theme="dark" transition="fade"}\n:::deck{from="wide" transition="slide"}\n:::'
+    render(<MarkdownRunner markdown={md} />)
+    const getDeck = (node: any): any => {
+      if (Array.isArray(node)) return getDeck(node[0])
+      if (node?.type === Fragment) return getDeck(node.props.children)
+      return node
+    }
+    const deck = getDeck(output)
+    expect(deck.props.transition).toBe('slide')
+    expect(deck.props.theme.theme).toBe('dark')
+  })
 })

--- a/apps/campfire/src/hooks/__tests__/imageDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/imageDirective.test.tsx
@@ -46,4 +46,17 @@ describe('image directive', () => {
     expect(img.className).toBe('rounded')
     expect(img.style.border).toBe('1px solid red')
   })
+
+  it('applies image presets with overrides', () => {
+    const md =
+      ':preset{type="image" name="cat" x=5 y=5 src="https://example.com/cat.png"}\n:::appear\n:image{from="cat" y=10}\n:::\n'
+    render(<MarkdownRunner markdown={md} />)
+    const el = document.querySelector(
+      '[data-testid="slideImage"]'
+    ) as HTMLElement
+    expect(el.style.left).toBe('5px')
+    expect(el.style.top).toBe('10px')
+    const img = el.querySelector('img') as HTMLImageElement
+    expect(img.getAttribute('src')).toBe('https://example.com/cat.png')
+  })
 })

--- a/apps/campfire/src/hooks/__tests__/shapeDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/shapeDirective.test.tsx
@@ -51,6 +51,20 @@ describe('shape directive', () => {
     expect(svg.style.filter).toContain('drop-shadow')
   })
 
+  it('applies shape presets with overrides', () => {
+    const md =
+      ':preset{type="shape" name="box" x=5 y=5 w=10 h=10 fill="red"}\n:::appear\n:shape{from="box" y=20 type="rect"}\n:::\n'
+    render(<MarkdownRunner markdown={md} />)
+    const el = document.querySelector(
+      '[data-testid="slideShape"]'
+    ) as HTMLElement
+    expect(el.style.left).toBe('5px')
+    expect(el.style.top).toBe('20px')
+    const svg = el.querySelector('svg') as SVGSVGElement
+    const rect = svg.querySelector('rect') as SVGRectElement
+    expect(rect.getAttribute('fill')).toBe('red')
+  })
+
   it('does not render stray colons after shape blocks', () => {
     const md = ':shape{type="rect"}\n:::if{true}\nHi\n:::\n'
     render(<MarkdownRunner markdown={md} />)

--- a/apps/campfire/src/hooks/__tests__/textDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/textDirective.test.tsx
@@ -66,4 +66,19 @@ describe('text directive', () => {
     expect(el.getAttribute('data-test')).toBe('ok')
     expect(inner.textContent).toBe('Hello')
   })
+
+  it('applies text presets with overrides', () => {
+    const md =
+      ':preset{type="text" name="title" x=10 y=20 size=24 color="red"}\n:text[Hi]{from="title" size=32}'
+    render(<MarkdownRunner markdown={md} />)
+    const el = document.querySelector(
+      '[data-testid="slideText"]'
+    ) as HTMLElement
+    const inner = el.firstElementChild as HTMLElement
+    const style = inner.getAttribute('style') || ''
+    expect(style).toContain('left: 10px')
+    expect(style).toContain('top: 20px')
+    expect(style).toContain('font-size: 32px')
+    expect(style).toContain('color: red')
+  })
 })

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -119,6 +119,9 @@ export const useDirectiveHandlers = () => {
   const getPassageById = useStoryDataStore(state => state.getPassageById)
   const getPassageByName = useStoryDataStore(state => state.getPassageByName)
   const handlersRef = useRef<Record<string, DirectiveHandler>>({})
+  const presetsRef = useRef<
+    Record<string, Record<string, Record<string, unknown>>>
+  >({})
   const checkpointIdRef = useRef<string | null>(null)
   const checkpointErrorRef = useRef(false)
   const onExitSeenRef = useRef(false)
@@ -1613,6 +1616,49 @@ export const useDirectiveHandlers = () => {
   }
 
   /**
+   * Stores attribute presets for reuse by other directives.
+   *
+   * @param directive - The preset directive node.
+   * @param parent - Parent node containing the directive.
+   * @param index - Index of the directive within the parent.
+   * @returns The index of the removed node.
+   */
+  const handlePreset: DirectiveHandler = (directive, parent, index) => {
+    if (!parent || typeof index !== 'number') return
+    const { attrs: presetAttrs } = extractAttributes(
+      directive,
+      parent,
+      index,
+      {
+        type: { type: 'string', required: true },
+        name: { type: 'string', required: true }
+      },
+      { label: false }
+    )
+    const target = String(presetAttrs.type)
+    const name = String(presetAttrs.name)
+    const rawAttrs = {
+      ...(directive.attributes || {})
+    } as Record<string, unknown>
+    delete rawAttrs.type
+    delete rawAttrs.name
+    for (const key of Object.keys(rawAttrs)) {
+      const val = rawAttrs[key]
+      if (
+        typeof val === 'number' ||
+        (typeof val === 'string' && NUMERIC_PATTERN.test(val))
+      ) {
+        const num = parseNumericValue(val)
+        rawAttrs[key] = num
+      }
+    }
+    if (!presetsRef.current[target]) presetsRef.current[target] = {}
+    presetsRef.current[target][name] = rawAttrs
+    parent.children.splice(index, 1)
+    return index
+  }
+
+  /**
    * Creates a handler for container directives that converts directive blocks
    * into corresponding hast nodes.
    *
@@ -1677,7 +1723,8 @@ export const useDirectiveHandlers = () => {
     exitAt: { type: 'number' },
     enter: { type: 'string' },
     exit: { type: 'string' },
-    interruptBehavior: { type: 'string' }
+    interruptBehavior: { type: 'string' },
+    from: { type: 'string', expression: false }
   } as const
 
   type AppearSchema = typeof appearSchema
@@ -1688,7 +1735,8 @@ export const useDirectiveHandlers = () => {
     transition: { type: 'string' },
     steps: { type: 'number' },
     onEnter: { type: 'string' },
-    onExit: { type: 'string' }
+    onExit: { type: 'string' },
+    from: { type: 'string', expression: false }
   } as const
 
   type SlideSchema = typeof slideSchema
@@ -1710,7 +1758,8 @@ export const useDirectiveHandlers = () => {
     size: { type: 'number' },
     weight: { type: 'number' },
     lineHeight: { type: 'number' },
-    color: { type: 'string' }
+    color: { type: 'string' },
+    from: { type: 'string', expression: false }
   } as const
 
   type TextSchema = typeof textSchema
@@ -1728,7 +1777,8 @@ export const useDirectiveHandlers = () => {
     anchor: { type: 'string' },
     src: { type: 'string', required: true },
     alt: { type: 'string' },
-    style: { type: 'string' }
+    style: { type: 'string' },
+    from: { type: 'string', expression: false }
   } as const
 
   type ImageSchema = typeof imageSchema
@@ -1755,7 +1805,8 @@ export const useDirectiveHandlers = () => {
     fill: { type: 'string' },
     radius: { type: 'number' },
     shadow: { type: 'boolean' },
-    style: { type: 'string' }
+    style: { type: 'string' },
+    from: { type: 'string', expression: false }
   } as const
 
   type ShapeSchema = typeof shapeSchema
@@ -1774,18 +1825,40 @@ export const useDirectiveHandlers = () => {
     appearSchema,
     (attrs, raw) => {
       const props: Record<string, unknown> = {}
+      const preset = attrs.from
+        ? presetsRef.current['appear']?.[String(attrs.from)]
+        : undefined
+      if (preset) {
+        const atPreset = parseNumericValue(preset.at)
+        if (typeof atPreset === 'number') props.at = atPreset
+        const exitAtPreset = parseNumericValue(preset.exitAt)
+        if (typeof exitAtPreset === 'number') props.exitAt = exitAtPreset
+        if (preset.enter) props.enter = preset.enter
+        if (preset.exit) props.exit = preset.exit
+        if (preset.interruptBehavior)
+          props.interruptBehavior = preset.interruptBehavior
+        applyAdditionalAttributes(preset, props, [
+          'at',
+          'exitAt',
+          'enter',
+          'exit',
+          'interruptBehavior'
+        ])
+      }
       if (typeof attrs.at === 'number') props.at = attrs.at
       if (typeof attrs.exitAt === 'number') props.exitAt = attrs.exitAt
       if (attrs.enter) props.enter = attrs.enter
       if (attrs.exit) props.exit = attrs.exit
       if (attrs.interruptBehavior)
         props.interruptBehavior = attrs.interruptBehavior
-      applyAdditionalAttributes(raw, props, [
+      const mergedRaw = { ...(preset || {}), ...raw }
+      applyAdditionalAttributes(mergedRaw, props, [
         'at',
         'exitAt',
         'enter',
         'exit',
-        'interruptBehavior'
+        'interruptBehavior',
+        'from'
       ])
       return props
     }
@@ -1814,21 +1887,30 @@ export const useDirectiveHandlers = () => {
       textSchema
     )
     const raw = (directive.attributes || {}) as Record<string, unknown>
-    const tagName = attrs.as ? String(attrs.as) : 'p'
+    const preset = attrs.from
+      ? presetsRef.current['text']?.[String(attrs.from)]
+      : undefined
+    const mergedRaw = { ...(preset || {}), ...raw }
+    const mergedAttrs = { ...(preset || {}), ...attrs } as TextAttrs &
+      Record<string, unknown>
+    const tagName = mergedAttrs.as ? String(mergedAttrs.as) : 'p'
     const style: string[] = []
     style.push('position:absolute')
-    if (typeof attrs.x === 'number') style.push(`left:${attrs.x}px`)
-    if (typeof attrs.y === 'number') style.push(`top:${attrs.y}px`)
-    if (typeof attrs.w === 'number') style.push(`width:${attrs.w}px`)
-    if (typeof attrs.h === 'number') style.push(`height:${attrs.h}px`)
-    if (typeof attrs.z === 'number') style.push(`z-index:${attrs.z}`)
+    if (typeof mergedAttrs.x === 'number') style.push(`left:${mergedAttrs.x}px`)
+    if (typeof mergedAttrs.y === 'number') style.push(`top:${mergedAttrs.y}px`)
+    if (typeof mergedAttrs.w === 'number')
+      style.push(`width:${mergedAttrs.w}px`)
+    if (typeof mergedAttrs.h === 'number')
+      style.push(`height:${mergedAttrs.h}px`)
+    if (typeof mergedAttrs.z === 'number')
+      style.push(`z-index:${mergedAttrs.z}`)
     const transforms: string[] = []
-    if (typeof attrs.rotate === 'number')
-      transforms.push(`rotate(${attrs.rotate}deg)`)
-    if (typeof attrs.scale === 'number')
-      transforms.push(`scale(${attrs.scale})`)
+    if (typeof mergedAttrs.rotate === 'number')
+      transforms.push(`rotate(${mergedAttrs.rotate}deg)`)
+    if (typeof mergedAttrs.scale === 'number')
+      transforms.push(`scale(${mergedAttrs.scale})`)
     if (transforms.length) style.push(`transform:${transforms.join(' ')}`)
-    if (attrs.anchor && attrs.anchor !== 'top-left') {
+    if (mergedAttrs.anchor && mergedAttrs.anchor !== 'top-left') {
       const originMap: Record<string, string> = {
         'top-left': '0% 0%',
         top: '50% 0%',
@@ -1840,40 +1922,42 @@ export const useDirectiveHandlers = () => {
         bottom: '50% 100%',
         'bottom-right': '100% 100%'
       }
-      const origin = originMap[attrs.anchor]
+      const origin = originMap[mergedAttrs.anchor]
       if (origin) style.push(`transform-origin:${origin}`)
     }
-    if (attrs.align) style.push(`text-align:${attrs.align}`)
-    if (typeof attrs.size === 'number') style.push(`font-size:${attrs.size}px`)
-    if (typeof attrs.weight === 'number')
-      style.push(`font-weight:${attrs.weight}`)
-    if (typeof attrs.lineHeight === 'number')
-      style.push(`line-height:${attrs.lineHeight}`)
-    if (attrs.color) style.push(`color:${attrs.color}`)
+    if (mergedAttrs.align) style.push(`text-align:${mergedAttrs.align}`)
+    if (typeof mergedAttrs.size === 'number')
+      style.push(`font-size:${mergedAttrs.size}px`)
+    if (typeof mergedAttrs.weight === 'number')
+      style.push(`font-weight:${mergedAttrs.weight}`)
+    if (typeof mergedAttrs.lineHeight === 'number')
+      style.push(`line-height:${mergedAttrs.lineHeight}`)
+    if (mergedAttrs.color) style.push(`color:${mergedAttrs.color}`)
     const props: Record<string, unknown> = {}
-    if (typeof attrs.x === 'number') props.x = attrs.x
-    if (typeof attrs.y === 'number') props.y = attrs.y
-    if (typeof attrs.w === 'number') props.w = attrs.w
-    if (typeof attrs.h === 'number') props.h = attrs.h
-    if (typeof attrs.z === 'number') props.z = attrs.z
-    if (typeof attrs.rotate === 'number') props.rotate = attrs.rotate
-    if (typeof attrs.scale === 'number') props.scale = attrs.scale
-    if (attrs.anchor) props.anchor = attrs.anchor
+    if (typeof mergedAttrs.x === 'number') props.x = mergedAttrs.x
+    if (typeof mergedAttrs.y === 'number') props.y = mergedAttrs.y
+    if (typeof mergedAttrs.w === 'number') props.w = mergedAttrs.w
+    if (typeof mergedAttrs.h === 'number') props.h = mergedAttrs.h
+    if (typeof mergedAttrs.z === 'number') props.z = mergedAttrs.z
+    if (typeof mergedAttrs.rotate === 'number')
+      props.rotate = mergedAttrs.rotate
+    if (typeof mergedAttrs.scale === 'number') props.scale = mergedAttrs.scale
+    if (mergedAttrs.anchor) props.anchor = mergedAttrs.anchor
     if (style.length) props.style = style.join(';')
     const classAttr =
-      typeof raw.class === 'string'
-        ? raw.class
-        : typeof raw.className === 'string'
-          ? raw.className
-          : typeof raw.classes === 'string'
-            ? raw.classes
+      typeof mergedRaw.class === 'string'
+        ? mergedRaw.class
+        : typeof mergedRaw.className === 'string'
+          ? mergedRaw.className
+          : typeof mergedRaw.classes === 'string'
+            ? mergedRaw.classes
             : undefined
     const classes = ['text-base', 'font-normal']
     if (classAttr) classes.unshift(classAttr)
     props.className = classes.join(' ')
     props['data-component'] = 'slideText'
     props['data-as'] = tagName
-    applyAdditionalAttributes(raw, props, [
+    applyAdditionalAttributes(mergedRaw, props, [
       'x',
       'y',
       'w',
@@ -1891,11 +1975,12 @@ export const useDirectiveHandlers = () => {
       'color',
       'class',
       'className',
-      'classes'
+      'classes',
+      'from'
     ])
     const content =
-      typeof attrs.content === 'string'
-        ? attrs.content
+      typeof mergedAttrs.content === 'string'
+        ? mergedAttrs.content
         : toString(directive).trim()
     const node: Parent = {
       type: 'paragraph',
@@ -1930,27 +2015,40 @@ export const useDirectiveHandlers = () => {
       imageSchema
     )
     const raw = (directive.attributes || {}) as Record<string, unknown>
-    const props: Record<string, unknown> = { src: attrs.src }
-    if (typeof attrs.x === 'number') props.x = attrs.x
-    if (typeof attrs.y === 'number') props.y = attrs.y
-    if (typeof attrs.w === 'number') props.w = attrs.w
-    if (typeof attrs.h === 'number') props.h = attrs.h
-    if (typeof attrs.z === 'number') props.z = attrs.z
-    if (typeof attrs.rotate === 'number') props.rotate = attrs.rotate
-    if (typeof attrs.scale === 'number') props.scale = attrs.scale
-    if (attrs.anchor) props.anchor = attrs.anchor
-    if (attrs.alt) props.alt = attrs.alt
-    if (attrs.style) props.style = attrs.style
+    const preset = attrs.from
+      ? presetsRef.current['image']?.[String(attrs.from)]
+      : undefined
+    const mergedRaw = { ...(preset || {}), ...raw }
+    const mergedAttrs = { ...(preset || {}), ...attrs } as ImageAttrs &
+      Record<string, unknown>
+    const props: Record<string, unknown> = { src: mergedAttrs.src }
+    const x = parseNumericValue(mergedAttrs.x)
+    if (typeof x === 'number') props.x = x
+    const y = parseNumericValue(mergedAttrs.y)
+    if (typeof y === 'number') props.y = y
+    const w = parseNumericValue(mergedAttrs.w)
+    if (typeof w === 'number') props.w = w
+    const h = parseNumericValue(mergedAttrs.h)
+    if (typeof h === 'number') props.h = h
+    const z = parseNumericValue(mergedAttrs.z)
+    if (typeof z === 'number') props.z = z
+    const rotate = parseNumericValue(mergedAttrs.rotate)
+    if (typeof rotate === 'number') props.rotate = rotate
+    const scale = parseNumericValue(mergedAttrs.scale)
+    if (typeof scale === 'number') props.scale = scale
+    if (mergedAttrs.anchor) props.anchor = mergedAttrs.anchor
+    if (mergedAttrs.alt) props.alt = mergedAttrs.alt
+    if (mergedAttrs.style) props.style = mergedAttrs.style
     const classAttr =
-      typeof raw.class === 'string'
-        ? raw.class
-        : typeof raw.className === 'string'
-          ? raw.className
-          : typeof raw.classes === 'string'
-            ? raw.classes
+      typeof mergedRaw.class === 'string'
+        ? mergedRaw.class
+        : typeof mergedRaw.className === 'string'
+          ? mergedRaw.className
+          : typeof mergedRaw.classes === 'string'
+            ? mergedRaw.classes
             : undefined
     if (classAttr) props.className = classAttr
-    applyAdditionalAttributes(raw, props, [
+    applyAdditionalAttributes(mergedRaw, props, [
       'x',
       'y',
       'w',
@@ -1964,7 +2062,8 @@ export const useDirectiveHandlers = () => {
       'style',
       'class',
       'className',
-      'classes'
+      'classes',
+      'from'
     ])
     const node: Parent = {
       type: 'paragraph',
@@ -1999,37 +2098,56 @@ export const useDirectiveHandlers = () => {
       shapeSchema
     )
     const raw = (directive.attributes || {}) as Record<string, unknown>
-    const props: Record<string, unknown> = { type: attrs.type }
-    if (typeof attrs.x === 'number') props.x = attrs.x
-    if (typeof attrs.y === 'number') props.y = attrs.y
-    if (typeof attrs.w === 'number') props.w = attrs.w
-    if (typeof attrs.h === 'number') props.h = attrs.h
-    if (typeof attrs.z === 'number') props.z = attrs.z
-    if (typeof attrs.rotate === 'number') props.rotate = attrs.rotate
-    if (typeof attrs.scale === 'number') props.scale = attrs.scale
-    if (attrs.anchor) props.anchor = attrs.anchor
-    if (attrs.points) props.points = attrs.points
-    if (typeof attrs.x1 === 'number') props.x1 = attrs.x1
-    if (typeof attrs.y1 === 'number') props.y1 = attrs.y1
-    if (typeof attrs.x2 === 'number') props.x2 = attrs.x2
-    if (typeof attrs.y2 === 'number') props.y2 = attrs.y2
-    if (attrs.stroke) props.stroke = attrs.stroke
-    if (typeof attrs.strokeWidth === 'number')
-      props.strokeWidth = attrs.strokeWidth
-    if (attrs.fill) props.fill = attrs.fill
-    if (typeof attrs.radius === 'number') props.radius = attrs.radius
-    if (typeof attrs.shadow === 'boolean') props.shadow = attrs.shadow
-    if (attrs.style) props.style = attrs.style
+    const preset = attrs.from
+      ? presetsRef.current['shape']?.[String(attrs.from)]
+      : undefined
+    const mergedRaw = { ...(preset || {}), ...raw }
+    const mergedAttrs = { ...(preset || {}), ...attrs } as ShapeAttrs &
+      Record<string, unknown>
+    const props: Record<string, unknown> = { type: mergedAttrs.type }
+    const x = parseNumericValue(mergedAttrs.x)
+    if (typeof x === 'number') props.x = x
+    const y = parseNumericValue(mergedAttrs.y)
+    if (typeof y === 'number') props.y = y
+    const w = parseNumericValue(mergedAttrs.w)
+    if (typeof w === 'number') props.w = w
+    const h = parseNumericValue(mergedAttrs.h)
+    if (typeof h === 'number') props.h = h
+    const z = parseNumericValue(mergedAttrs.z)
+    if (typeof z === 'number') props.z = z
+    const rotate = parseNumericValue(mergedAttrs.rotate)
+    if (typeof rotate === 'number') props.rotate = rotate
+    const scale = parseNumericValue(mergedAttrs.scale)
+    if (typeof scale === 'number') props.scale = scale
+    if (mergedAttrs.anchor) props.anchor = mergedAttrs.anchor
+    if (mergedAttrs.points) props.points = mergedAttrs.points
+    const x1 = parseNumericValue(mergedAttrs.x1)
+    if (typeof x1 === 'number') props.x1 = x1
+    const y1 = parseNumericValue(mergedAttrs.y1)
+    if (typeof y1 === 'number') props.y1 = y1
+    const x2 = parseNumericValue(mergedAttrs.x2)
+    if (typeof x2 === 'number') props.x2 = x2
+    const y2 = parseNumericValue(mergedAttrs.y2)
+    if (typeof y2 === 'number') props.y2 = y2
+    if (mergedAttrs.stroke) props.stroke = mergedAttrs.stroke
+    const strokeWidth = parseNumericValue(mergedAttrs.strokeWidth)
+    if (typeof strokeWidth === 'number') props.strokeWidth = strokeWidth
+    if (mergedAttrs.fill) props.fill = mergedAttrs.fill
+    const radius = parseNumericValue(mergedAttrs.radius)
+    if (typeof radius === 'number') props.radius = radius
+    if (typeof mergedAttrs.shadow === 'boolean')
+      props.shadow = mergedAttrs.shadow
+    if (mergedAttrs.style) props.style = mergedAttrs.style
     const classAttr =
-      typeof raw.class === 'string'
-        ? raw.class
-        : typeof raw.className === 'string'
-          ? raw.className
-          : typeof raw.classes === 'string'
-            ? raw.classes
+      typeof mergedRaw.class === 'string'
+        ? mergedRaw.class
+        : typeof mergedRaw.className === 'string'
+          ? mergedRaw.className
+          : typeof mergedRaw.classes === 'string'
+            ? mergedRaw.classes
             : undefined
     if (classAttr) props.className = classAttr
-    applyAdditionalAttributes(raw, props, [
+    applyAdditionalAttributes(mergedRaw, props, [
       'x',
       'y',
       'w',
@@ -2052,7 +2170,8 @@ export const useDirectiveHandlers = () => {
       'style',
       'class',
       'className',
-      'classes'
+      'classes',
+      'from'
     ])
     const node: Parent = {
       type: 'paragraph',
@@ -2072,6 +2191,26 @@ export const useDirectiveHandlers = () => {
    */
   const buildSlideProps = (attrs: SlideAttrs): Record<string, unknown> => {
     const props: Record<string, unknown> = {}
+    if (attrs.from) {
+      const preset = presetsRef.current['slide']?.[String(attrs.from)]
+      if (preset) {
+        if (preset.transition) {
+          props.transition =
+            typeof preset.transition === 'string'
+              ? { type: preset.transition as string }
+              : preset.transition
+        }
+        if (typeof preset.steps === 'number') props.steps = preset.steps
+        if (preset.onEnter) props.onEnter = preset.onEnter
+        if (preset.onExit) props.onExit = preset.onExit
+        applyAdditionalAttributes(preset, props, [
+          'transition',
+          'steps',
+          'onEnter',
+          'onExit'
+        ])
+      }
+    }
     if (attrs.transition) {
       props.transition =
         typeof attrs.transition === 'string'
@@ -2085,7 +2224,8 @@ export const useDirectiveHandlers = () => {
       'transition',
       'steps',
       'onEnter',
-      'onExit'
+      'onExit',
+      'from'
     ])
     return props
   }
@@ -2115,12 +2255,30 @@ export const useDirectiveHandlers = () => {
       {
         size: { type: 'string' },
         transition: { type: 'string' },
-        theme: { type: 'string' }
+        theme: { type: 'string' },
+        from: { type: 'string', expression: false }
       },
       { label: false }
     )
 
     const deckProps: Record<string, unknown> = {}
+    if (deckAttrs.from) {
+      const preset = presetsRef.current['deck']?.[String(deckAttrs.from)]
+      if (preset) {
+        if (typeof preset.size === 'string')
+          deckProps.size = parseDeckSize(preset.size as string)
+        if (preset.transition) deckProps.transition = preset.transition
+        if (typeof preset.theme !== 'undefined') {
+          const t = parseThemeValue(preset.theme)
+          if (t) deckProps.theme = t
+        }
+        applyAdditionalAttributes(preset, deckProps, [
+          'size',
+          'transition',
+          'theme'
+        ])
+      }
+    }
     if (typeof deckAttrs.size === 'string') {
       deckProps.size = parseDeckSize(deckAttrs.size)
     }
@@ -2133,7 +2291,8 @@ export const useDirectiveHandlers = () => {
     applyAdditionalAttributes(rawDeckAttrs, deckProps, [
       'size',
       'transition',
-      'theme'
+      'theme',
+      'from'
     ])
 
     const slides: Parent[] = []
@@ -2396,6 +2555,7 @@ export const useDirectiveHandlers = () => {
       text: handleText,
       image: handleImage,
       shape: handleShape,
+      preset: handlePreset,
       deck: handleDeck,
       lang: handleLang,
       include: handleInclude,


### PR DESCRIPTION
## Summary
- add `preset` directive and `from` attribute for reusing directive options
- document preset usage and `from` support across directives

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_68a4a9d9ffb483208f4b43cd91cb5551