### PR TITLE
feat: add cached expression evaluator

### DIFF
--- a/apps/campfire/src/helpers.ts
+++ b/apps/campfire/src/helpers.ts
@@ -1,4 +1,4 @@
-import { compile } from 'expression-eval'
+import { evalExpression } from '@campfire/utils/evalExpression'
 import { unified } from 'unified'
 import remarkParse from 'remark-parse'
 import remarkGfm from 'remark-gfm'
@@ -9,8 +9,6 @@ import type { DirectiveNode } from '@campfire/remark-campfire/helpers'
 import { ensureKey, removeNode } from '@campfire/remark-campfire/helpers'
 
 const QUOTE_PATTERN = /^(['"`])(.*)\1$/
-const expressionCache = new Map<string, Function>()
-
 /**
  * Parses a raw string into a typed value. Supports quoted strings, booleans,
  * numbers, object literals and expression evaluation against provided data.
@@ -46,12 +44,7 @@ export const parseTypedValue = (
   const num = Number(trimmed)
   if (!Number.isNaN(num)) return num
   try {
-    let fn = expressionCache.get(trimmed)
-    if (!fn) {
-      fn = compile(trimmed)
-      expressionCache.set(trimmed, fn)
-    }
-    return fn(data)
+    return evalExpression(trimmed, data)
   } catch {
     return (data as Record<string, unknown>)[trimmed]
   }

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef } from 'preact/hooks'
 import i18next from 'i18next'
 import { SKIP } from 'unist-util-visit'
-import { compile } from 'expression-eval'
+import { evalExpression } from '@campfire/utils/evalExpression'
 import { toString } from 'mdast-util-to-string'
 import { unified } from 'unified'
 import remarkParse from 'remark-parse'
@@ -1236,8 +1236,7 @@ export const useDirectiveHandlers = () => {
       if (raw == null) continue
       if (typeof raw === 'string') {
         try {
-          const fn = compile(raw) as (scope: Record<string, unknown>) => unknown
-          const value = fn(gameData)
+          const value = evalExpression(raw, gameData)
           vars[name] = value ?? raw
         } catch (error) {
           const msg = `Failed to evaluate t directive var: ${raw}`

--- a/apps/campfire/src/hooks/useSerializedDirectiveRunner.ts
+++ b/apps/campfire/src/hooks/useSerializedDirectiveRunner.ts
@@ -6,7 +6,7 @@ import remarkCampfire, {
 import type { RootContent, Root } from 'mdast'
 import type { ContainerDirective } from 'mdast-util-directive'
 import rfdc from 'rfdc'
-import { compile } from 'expression-eval'
+import { evalExpression } from '@campfire/utils/evalExpression'
 import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
 import { useGameStore } from '@campfire/state/useGameStore'
 import { getLabel, stripLabel } from '@campfire/remark-campfire/helpers'
@@ -36,8 +36,7 @@ export const useSerializedDirectiveRunner = (content: string) => {
         const test = getLabel(container) || ''
         let condition = false
         try {
-          const fn = compile(test)
-          condition = !!fn(data)
+          condition = !!evalExpression(test, data)
         } catch {
           condition = false
         }

--- a/apps/campfire/src/remark-campfire/helpers.ts
+++ b/apps/campfire/src/remark-campfire/helpers.ts
@@ -1,5 +1,5 @@
 import { toString } from 'mdast-util-to-string'
-import { compile } from 'expression-eval'
+import { evalExpression } from '@campfire/utils/evalExpression'
 import type { Parent, Paragraph, RootContent } from 'mdast'
 import type {
   ContainerDirective,
@@ -294,8 +294,7 @@ export const extractAttributes = <S extends AttributeSchema>(
    */
   const evalExpr = (expr: string): unknown => {
     try {
-      const fn = compile(expr) as (scope: Record<string, unknown>) => unknown
-      return fn(state)
+      return evalExpression(expr, state)
     } catch {
       return undefined
     }

--- a/apps/campfire/src/utils/__tests__/evalExpression.test.ts
+++ b/apps/campfire/src/utils/__tests__/evalExpression.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'bun:test'
+import {
+  evalExpression,
+  clearExpressionCache,
+  getCompiledExpression
+} from '@campfire/utils/evalExpression'
+
+describe('evalExpression', () => {
+  it('caches compiled expressions', () => {
+    clearExpressionCache()
+    const expr = 'a + b'
+    const result1 = evalExpression(expr, { a: 1, b: 2 })
+    expect(result1).toBe(3)
+    const fn1 = getCompiledExpression(expr)!
+    const result2 = evalExpression(expr, { a: 2, b: 2 })
+    expect(result2).toBe(4)
+    const fn2 = getCompiledExpression(expr)!
+    expect(fn1).toBe(fn2)
+  })
+})

--- a/apps/campfire/src/utils/evalExpression.ts
+++ b/apps/campfire/src/utils/evalExpression.ts
@@ -1,0 +1,40 @@
+import { compile } from 'expression-eval'
+
+/** Cache of compiled expressions keyed by their source string. */
+const cache = new Map<string, (scope: Record<string, unknown>) => unknown>()
+
+/**
+ * Compiles and evaluates an expression with caching.
+ *
+ * @param expr - Expression to compile and evaluate.
+ * @param scope - Scope object providing variables for evaluation.
+ * @returns Result of the evaluated expression.
+ */
+export const evalExpression = (
+  expr: string,
+  scope: Record<string, unknown> = {}
+): unknown => {
+  let fn = cache.get(expr)
+  if (!fn) {
+    fn = compile(expr) as (scope: Record<string, unknown>) => unknown
+    cache.set(expr, fn)
+  }
+  return fn(scope)
+}
+
+/**
+ * Retrieves a cached compiled function for an expression, if available.
+ *
+ * @param expr - Expression whose compiled function is requested.
+ * @returns The cached function or undefined when not cached.
+ */
+export const getCompiledExpression = (
+  expr: string
+): ((scope: Record<string, unknown>) => unknown) | undefined => cache.get(expr)
+
+/**
+ * Clears all cached compiled expressions. Primarily used for testing.
+ */
+export const clearExpressionCache = (): void => {
+  cache.clear()
+}


### PR DESCRIPTION
## Summary
- add utility to cache and evaluate expressions
- use cached evaluator across helpers and directive handlers
- test evaluation caching

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_68a548b0933483209b4e5df3e3cd3136