### PR TITLE
feat(utils): add appendClassNames helper

### DIFF
--- a/apps/campfire/src/utils/__tests__/remarkHelpers.test.ts
+++ b/apps/campfire/src/utils/__tests__/remarkHelpers.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'bun:test'
+import { appendClassNames } from '@campfire/utils/remarkHelpers'
+
+describe('appendClassNames', () => {
+  it('creates className array when none exists', () => {
+    const node: any = {}
+    appendClassNames(node, ['foo', 'bar'])
+    expect(node.data?.hProperties?.className).toEqual(['foo', 'bar'])
+  })
+
+  it('merges with existing class names array', () => {
+    const node: any = { data: { hProperties: { className: ['one', 2] } } }
+    appendClassNames(node, ['two'])
+    expect(node.data?.hProperties?.className).toEqual(['one', 'two'])
+  })
+
+  it('converts existing string className to array', () => {
+    const node: any = { data: { hProperties: { className: 'one' } } }
+    appendClassNames(node, ['two'])
+    expect(node.data?.hProperties?.className).toEqual(['one', 'two'])
+  })
+})

--- a/apps/campfire/src/utils/__tests__/remarkStyles.test.ts
+++ b/apps/campfire/src/utils/__tests__/remarkStyles.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'bun:test'
+import type { Root } from 'mdast'
+import { remarkHeadingStyles } from '@campfire/utils/remarkHeadingStyles'
+import { remarkParagraphStyles } from '@campfire/utils/remarkParagraphStyles'
+
+describe('remarkHeadingStyles', () => {
+  it('appends default classes', () => {
+    const tree: Root = {
+      type: 'root',
+      children: [
+        {
+          type: 'heading',
+          depth: 2,
+          data: { hProperties: { className: 'existing' } },
+          children: []
+        } as any
+      ]
+    }
+
+    remarkHeadingStyles()(tree)
+    expect(tree.children[0].data?.hProperties?.className).toEqual([
+      'existing',
+      'font-libertinus text-3xl font-semibold'
+    ])
+  })
+})
+
+describe('remarkParagraphStyles', () => {
+  it('appends default classes', () => {
+    const tree: Root = {
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          data: { hProperties: { className: 'existing' } },
+          children: []
+        } as any
+      ]
+    }
+
+    remarkParagraphStyles()(tree)
+    expect(tree.children[0].data?.hProperties?.className).toEqual([
+      'existing',
+      'font-libertinus',
+      'text-base'
+    ])
+  })
+})

--- a/apps/campfire/src/utils/remarkHeadingStyles.ts
+++ b/apps/campfire/src/utils/remarkHeadingStyles.ts
@@ -1,5 +1,6 @@
 import { visit } from 'unist-util-visit'
 import type { Root } from 'mdast'
+import { appendClassNames } from '@campfire/utils/remarkHelpers'
 
 /**
  * Applies default Tailwind font family, size, and weight classes to Markdown heading nodes.
@@ -18,15 +19,6 @@ export const remarkHeadingStyles = () => (tree: Root) => {
     }
     const cls = mapping[node.depth]
     if (!cls) return
-    if (!node.data) node.data = {}
-    if (!node.data.hProperties) node.data.hProperties = {}
-    const existing = node.data.hProperties.className
-    const classes: string[] = Array.isArray(existing)
-      ? existing.filter((c): c is string => typeof c === 'string')
-      : typeof existing === 'string'
-        ? [existing]
-        : []
-    classes.push(cls)
-    node.data.hProperties.className = classes
+    appendClassNames(node, [cls])
   })
 }

--- a/apps/campfire/src/utils/remarkHelpers.ts
+++ b/apps/campfire/src/utils/remarkHelpers.ts
@@ -27,5 +27,3 @@ export const appendClassNames = (
   classes.push(...classNames)
   props.className = classes
 }
-
-export default appendClassNames

--- a/apps/campfire/src/utils/remarkHelpers.ts
+++ b/apps/campfire/src/utils/remarkHelpers.ts
@@ -1,0 +1,31 @@
+import type { Data } from 'unist'
+import type { Properties } from 'hast'
+
+/**
+ * Appends one or more class names to a node's `hProperties.className`,
+ * preserving any existing classes.
+ *
+ * @param node - Target MDAST node.
+ * @param classNames - Class names to append.
+ */
+export const appendClassNames = (
+  node: { data?: Data & { hProperties?: Properties } },
+  classNames: string[]
+): void => {
+  const data = (node.data ?? (node.data = {})) as Data & {
+    hProperties?: Properties
+  }
+  const props = (data.hProperties ?? (data.hProperties = {})) as Properties & {
+    className?: string | string[]
+  }
+  const existing = props.className
+  const classes = Array.isArray(existing)
+    ? existing.filter((c): c is string => typeof c === 'string')
+    : typeof existing === 'string'
+      ? [existing]
+      : []
+  classes.push(...classNames)
+  props.className = classes
+}
+
+export default appendClassNames

--- a/apps/campfire/src/utils/remarkParagraphStyles.ts
+++ b/apps/campfire/src/utils/remarkParagraphStyles.ts
@@ -2,6 +2,7 @@ import { visit } from 'unist-util-visit'
 import type { Root, Paragraph } from 'mdast'
 import type { Data } from 'unist'
 import type { Properties } from 'hast'
+import { appendClassNames } from '@campfire/utils/remarkHelpers'
 
 /**
  * Applies default Tailwind font family and size classes to Markdown paragraph nodes.
@@ -17,14 +18,6 @@ export const remarkParagraphStyles = () => (tree: Root) => {
   visit(tree, 'paragraph', (node: Paragraph) => {
     const data = (node.data ?? (node.data = {})) as NodeData
     if (data.hName) return
-    const props = (data.hProperties ?? (data.hProperties = {})) as Properties
-    const existing = props.className
-    const classes: string[] = Array.isArray(existing)
-      ? existing.filter((c): c is string => typeof c === 'string')
-      : typeof existing === 'string'
-        ? [existing]
-        : []
-    classes.push('font-libertinus', 'text-base')
-    props.className = classes
+    appendClassNames(node, ['font-libertinus', 'text-base'])
   })
 }


### PR DESCRIPTION
## Summary
- centralize class name merging logic in `appendClassNames`
- refactor heading and paragraph remark plugins to use helper
- add unit tests for helper and remark style plugins

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_68a54afea48083208839b09b47e72288