### PR TITLE
feat: add runDirectiveBlock utility

### DIFF
--- a/apps/campfire/src/components/Passage/TriggerButton.tsx
+++ b/apps/campfire/src/components/Passage/TriggerButton.tsx
@@ -1,10 +1,7 @@
-import { unified } from 'unified'
-import remarkCampfire, {
-  remarkCampfireIndentation
-} from '@campfire/remark-campfire'
-import type { RootContent, Root } from 'mdast'
+import type { RootContent } from 'mdast'
 import rfdc from 'rfdc'
 import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
+import { runDirectiveBlock } from '@campfire/utils/directives'
 import type { JSX } from 'preact'
 
 const clone = rfdc()
@@ -34,18 +31,6 @@ export const TriggerButton = ({
   style
 }: TriggerButtonProps) => {
   const handlers = useDirectiveHandlers()
-  /**
-   * Processes a block of AST nodes using the Campfire remark plugins.
-   *
-   * @param nodes - Nodes to process.
-   */
-  const runBlock = (nodes: RootContent[]) => {
-    const root: Root = { type: 'root', children: nodes }
-    unified()
-      .use(remarkCampfireIndentation)
-      .use(remarkCampfire, { handlers })
-      .runSync(root)
-  }
   const classes = Array.isArray(className)
     ? className
     : className
@@ -54,10 +39,13 @@ export const TriggerButton = ({
   return (
     <button
       type='button'
+      data-testid='trigger-button'
       className={['campfire-trigger', 'font-libertinus', ...classes].join(' ')}
       disabled={disabled}
       style={style}
-      onClick={() => runBlock(clone(JSON.parse(content)))}
+      onClick={() =>
+        runDirectiveBlock(clone(JSON.parse(content)) as RootContent[], handlers)
+      }
     >
       {children}
     </button>

--- a/apps/campfire/src/hooks/useSerializedDirectiveRunner.ts
+++ b/apps/campfire/src/hooks/useSerializedDirectiveRunner.ts
@@ -1,12 +1,9 @@
 import { useCallback, useMemo } from 'preact/hooks'
-import { unified } from 'unified'
-import remarkCampfire, {
-  remarkCampfireIndentation
-} from '@campfire/remark-campfire'
-import type { RootContent, Root } from 'mdast'
+import type { RootContent } from 'mdast'
 import type { ContainerDirective } from 'mdast-util-directive'
 import rfdc from 'rfdc'
 import { evalExpression } from '@campfire/utils/evalExpression'
+import { runDirectiveBlock } from '@campfire/utils/directives'
 import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
 import { useGameStore } from '@campfire/state/useGameStore'
 import { getLabel, stripLabel } from '@campfire/remark-campfire/helpers'
@@ -61,11 +58,7 @@ export const useSerializedDirectiveRunner = (content: string) => {
   const runBlock = (block: RootContent[], data: Record<string, unknown>) => {
     const processed = resolveIf(block, data)
     if (processed.length === 0) return
-    const root: Root = { type: 'root', children: processed }
-    unified()
-      .use(remarkCampfireIndentation)
-      .use(remarkCampfire, { handlers })
-      .runSync(root)
+    runDirectiveBlock(processed, handlers)
   }
 
   const gameData = useGameStore(state => state.gameData)

--- a/apps/campfire/src/utils/__tests__/directives.test.ts
+++ b/apps/campfire/src/utils/__tests__/directives.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'bun:test'
+import { unified } from 'unified'
+import remarkParse from 'remark-parse'
+import remarkDirective from 'remark-directive'
+import type { RootContent } from 'mdast'
+import { runDirectiveBlock } from '@campfire/utils/directives'
+import type { DirectiveHandler } from '@campfire/remark-campfire'
+
+describe('runDirectiveBlock', () => {
+  it('executes directive handlers', () => {
+    const nodes = unified()
+      .use(remarkParse)
+      .use(remarkDirective)
+      .parse(':test[]').children as RootContent[]
+    let called = false
+    const handler: DirectiveHandler = () => {
+      called = true
+    }
+    runDirectiveBlock(nodes, { test: handler })
+    expect(called).toBe(true)
+  })
+})

--- a/apps/campfire/src/utils/directives.ts
+++ b/apps/campfire/src/utils/directives.ts
@@ -1,0 +1,23 @@
+import { unified } from 'unified'
+import remarkCampfire, {
+  remarkCampfireIndentation,
+  type DirectiveHandler
+} from '@campfire/remark-campfire'
+import type { Root, RootContent } from 'mdast'
+
+/**
+ * Runs a block of directive AST nodes through the Campfire remark pipeline.
+ *
+ * @param nodes - Nodes to process.
+ * @param handlers - Directive handlers to apply.
+ */
+export const runDirectiveBlock = (
+  nodes: RootContent[],
+  handlers: Record<string, DirectiveHandler>
+): void => {
+  const root: Root = { type: 'root', children: nodes }
+  unified()
+    .use(remarkCampfireIndentation)
+    .use(remarkCampfire, { handlers })
+    .runSync(root)
+}


### PR DESCRIPTION
## Summary
- add `runDirectiveBlock` helper for executing directive AST nodes
- use shared directive runner in trigger buttons and serialized directive runner
- cover directive runner with tests

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_68a5508acafc8320b22affcbaa4056db