### PR TITLE
feat: add slide layer wrapper

### DIFF
--- a/apps/campfire/src/components/Deck/Slide/SlideImage/index.tsx
+++ b/apps/campfire/src/components/Deck/Slide/SlideImage/index.tsx
@@ -1,8 +1,8 @@
 import { type JSX } from 'preact'
-import { Layer, type LayerProps } from '../Layer'
-import parseInlineStyle from '@campfire/utils/parseInlineStyle'
+import { SlideLayer, type SlideLayerProps } from '../SlideLayer'
 
-export interface SlideImageProps extends Omit<LayerProps, 'children'> {
+export interface SlideImageProps
+  extends Omit<SlideLayerProps, 'children' | 'as' | 'elementProps'> {
   /** Image source URL. */
   src: string
   /** Alternate text description for the image. */
@@ -23,16 +23,17 @@ export const SlideImage = ({
   src,
   alt,
   className,
-  style: styleProp,
+  style,
   ...layerProps
-}: SlideImageProps): JSX.Element => {
-  const style: JSX.CSSProperties = parseInlineStyle(styleProp ?? {})
-
-  return (
-    <Layer data-testid='slideImage' {...layerProps}>
-      <img src={src} alt={alt} className={className} style={style} />
-    </Layer>
-  )
-}
+}: SlideImageProps): JSX.Element => (
+  <SlideLayer
+    as='img'
+    elementProps={{ src, alt }}
+    className={className}
+    style={style}
+    testId='slideImage'
+    {...layerProps}
+  />
+)
 
 export default SlideImage

--- a/apps/campfire/src/components/Deck/Slide/SlideLayer/__tests__/SlideLayer.test.tsx
+++ b/apps/campfire/src/components/Deck/Slide/SlideLayer/__tests__/SlideLayer.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'bun:test'
+import { render, screen } from '@testing-library/preact'
+import { SlideLayer } from '@campfire/components/Deck/Slide'
+
+describe('SlideLayer', () => {
+  it('renders specified element and parses style strings', () => {
+    render(
+      <SlideLayer
+        as='p'
+        testId='layer'
+        style='color: rgb(0, 0, 255);'
+        x={5}
+        y={10}
+      >
+        Text
+      </SlideLayer>
+    )
+    const wrapper = screen.getByTestId('layer') as HTMLElement
+    const p = wrapper.querySelector('p') as HTMLElement
+    expect(p.style.color).toBe('rgb(0, 0, 255)')
+    expect(wrapper.style.left).toBe('5px')
+    expect(wrapper.style.top).toBe('10px')
+  })
+})

--- a/apps/campfire/src/components/Deck/Slide/SlideLayer/index.tsx
+++ b/apps/campfire/src/components/Deck/Slide/SlideLayer/index.tsx
@@ -1,0 +1,53 @@
+import { type ComponentChildren, type ComponentType, type JSX } from 'preact'
+import { Layer, type LayerProps } from '../Layer'
+import parseInlineStyle from '@campfire/utils/parseInlineStyle'
+
+export interface SlideLayerProps
+  extends Omit<LayerProps, 'children' | 'className'> {
+  /** Class applied to the Layer wrapper. */
+  layerClassName?: string
+  /** Element or component to render inside the Layer. */
+  as?: keyof JSX.IntrinsicElements | ComponentType<any>
+  /** Class applied to the inner element. */
+  className?: string
+  /** Style for the inner element. */
+  style?: JSX.CSSProperties | string
+  /** Transform function for the parsed style. */
+  styleTransform?: (style: JSX.CSSProperties) => JSX.CSSProperties
+  /** data-testid for the Layer wrapper. */
+  testId?: string
+  /** Props forwarded to the inner element. */
+  elementProps?: Record<string, unknown>
+  /** Child nodes to render within the inner element. */
+  children?: ComponentChildren
+}
+
+/**
+ * Wraps slide content with a Layer and applies inline styles.
+ *
+ * @param props - Configuration for the layer and inner element.
+ * @returns Positioned and styled slide content.
+ */
+export const SlideLayer = ({
+  layerClassName,
+  as: Tag = 'div',
+  className,
+  style,
+  styleTransform,
+  testId = 'slideLayer',
+  elementProps = {},
+  children,
+  ...layerProps
+}: SlideLayerProps): JSX.Element => {
+  const baseStyle = parseInlineStyle(style ?? {})
+  const finalStyle = styleTransform ? styleTransform(baseStyle) : baseStyle
+  return (
+    <Layer data-testid={testId} className={layerClassName} {...layerProps}>
+      <Tag className={className} style={finalStyle} {...elementProps}>
+        {children}
+      </Tag>
+    </Layer>
+  )
+}
+
+export default SlideLayer

--- a/apps/campfire/src/components/Deck/Slide/SlideShape/__tests__/SlideShape.test.tsx
+++ b/apps/campfire/src/components/Deck/Slide/SlideShape/__tests__/SlideShape.test.tsx
@@ -15,6 +15,7 @@ describe('SlideShape', () => {
         fill='blue'
         radius={5}
         shadow
+        style='filter: blur(2px);'
       />
     )
     const wrapper = screen.getByTestId('slideShape') as HTMLElement
@@ -23,6 +24,7 @@ describe('SlideShape', () => {
     expect(rect.getAttribute('rx')).toBe('5')
     expect(rect.getAttribute('fill')).toBe('blue')
     expect(rect.getAttribute('stroke')).toBe('red')
+    expect(svg.style.filter).toContain('blur(2px)')
     expect(svg.style.filter).toContain('drop-shadow')
     expect(wrapper.style.left).toBe('10px')
     expect(wrapper.style.top).toBe('20px')

--- a/apps/campfire/src/components/Deck/Slide/SlideShape/index.tsx
+++ b/apps/campfire/src/components/Deck/Slide/SlideShape/index.tsx
@@ -1,8 +1,8 @@
 import { type JSX } from 'preact'
-import { Layer, type LayerProps } from '../Layer'
-import parseInlineStyle from '@campfire/utils/parseInlineStyle'
+import { SlideLayer, type SlideLayerProps } from '../SlideLayer'
 
-export interface SlideShapeProps extends Omit<LayerProps, 'children'> {
+export interface SlideShapeProps
+  extends Omit<SlideLayerProps, 'children' | 'as' | 'elementProps'> {
   /** Shape type to render. */
   type: 'rect' | 'ellipse' | 'line' | 'polygon'
   /** SVG path points used for polygon shapes. */
@@ -50,14 +50,9 @@ export const SlideShape = ({
   radius,
   shadow,
   className,
-  style: styleProp,
+  style,
   ...layerProps
 }: SlideShapeProps): JSX.Element => {
-  const style: JSX.CSSProperties = parseInlineStyle(styleProp ?? {})
-  if (shadow) {
-    const drop = 'drop-shadow(0 1px 2px rgba(0,0,0,0.25))'
-    style.filter = style.filter ? `${style.filter} ${drop}` : drop
-  }
   const shapeProps = { stroke, strokeWidth, fill }
   let shape: JSX.Element | null = null
   switch (type) {
@@ -84,12 +79,25 @@ export const SlideShape = ({
     default:
       shape = null
   }
+  const styleTransform = (base: JSX.CSSProperties): JSX.CSSProperties => {
+    if (shadow) {
+      const drop = 'drop-shadow(0 1px 2px rgba(0,0,0,0.25))'
+      base.filter = base.filter ? `${base.filter} ${drop}` : drop
+    }
+    return base
+  }
   return (
-    <Layer data-testid='slideShape' {...layerProps}>
-      <svg width='100%' height='100%' className={className} style={style}>
-        {shape}
-      </svg>
-    </Layer>
+    <SlideLayer
+      as='svg'
+      elementProps={{ width: '100%', height: '100%' }}
+      className={className}
+      style={style}
+      styleTransform={styleTransform}
+      testId='slideShape'
+      {...layerProps}
+    >
+      {shape}
+    </SlideLayer>
   )
 }
 

--- a/apps/campfire/src/components/Deck/Slide/SlideText/__tests__/SlideText.test.tsx
+++ b/apps/campfire/src/components/Deck/Slide/SlideText/__tests__/SlideText.test.tsx
@@ -42,4 +42,11 @@ describe('SlideText', () => {
     expect(el.style.color).toBe('red')
     expect(el.style.lineHeight).toBe('1.5')
   })
+
+  it('parses style strings via SlideLayer', () => {
+    render(<SlideText style='color: blue; font-weight: 900;'>Text</SlideText>)
+    const el = screen.getByText('Text') as HTMLElement
+    expect(el.style.color).toBe('blue')
+    expect(el.style.fontWeight).toBe('900')
+  })
 })

--- a/apps/campfire/src/components/Deck/Slide/SlideText/index.tsx
+++ b/apps/campfire/src/components/Deck/Slide/SlideText/index.tsx
@@ -1,8 +1,8 @@
 import { type ComponentChildren, type JSX } from 'preact'
-import { Layer, type LayerProps } from '../Layer'
-import parseInlineStyle from '@campfire/utils/parseInlineStyle'
+import { SlideLayer, type SlideLayerProps } from '../SlideLayer'
 
-export interface SlideTextProps extends Omit<LayerProps, 'children'> {
+export interface SlideTextProps
+  extends Omit<SlideLayerProps, 'children' | 'as'> {
   /** The HTML tag to render. Defaults to 'p'. */
   as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'li' | 'span'
   /** Horizontal alignment. Defaults to 'left'. */
@@ -37,27 +37,32 @@ export const SlideText = ({
   lineHeight,
   color,
   className,
-  style: styleProp,
+  style,
   children,
   ...layerProps
 }: SlideTextProps): JSX.Element => {
-  const Tag = as
-  const baseStyle: JSX.CSSProperties = parseInlineStyle(styleProp ?? {})
-  const style: JSX.CSSProperties = {
-    ...baseStyle,
-    fontSize: size !== undefined ? `${size}px` : baseStyle.fontSize,
-    fontWeight: weight !== undefined ? String(weight) : baseStyle.fontWeight,
-    lineHeight: lineHeight ? String(lineHeight) : baseStyle.lineHeight,
-    color: color ?? baseStyle.color,
-    textAlign: align ?? baseStyle.textAlign
-  }
+  const styleTransform = (base: JSX.CSSProperties): JSX.CSSProperties => ({
+    ...base,
+    fontSize: size !== undefined ? `${size}px` : base.fontSize,
+    fontWeight: weight !== undefined ? String(weight) : base.fontWeight,
+    lineHeight: lineHeight ? String(lineHeight) : base.lineHeight,
+    color: color ?? base.color,
+    textAlign: align ?? base.textAlign
+  })
   const classes = ['text-base', 'font-normal']
   if (className) classes.unshift(className)
   return (
-    <Layer data-testid='slideText' {...layerProps}>
-      <Tag style={style} className={classes.join(' ')}>
-        {children}
-      </Tag>
-    </Layer>
+    <SlideLayer
+      as={as}
+      style={style}
+      styleTransform={styleTransform}
+      className={classes.join(' ')}
+      testId='slideText'
+      {...layerProps}
+    >
+      {children}
+    </SlideLayer>
   )
 }
+
+export default SlideText

--- a/apps/campfire/src/components/Deck/Slide/index.ts
+++ b/apps/campfire/src/components/Deck/Slide/index.ts
@@ -14,6 +14,8 @@ export { SlideImage } from './SlideImage'
 export { SlideShape } from './SlideShape'
 export { Layer } from './Layer'
 export type { LayerProps } from './Layer'
+export { SlideLayer } from './SlideLayer'
+export type { SlideLayerProps } from './SlideLayer'
 export { renderDirectiveMarkdown } from './renderDirectiveMarkdown'
 
 export default Slide

--- a/apps/storybook/src/SlideText.stories.tsx
+++ b/apps/storybook/src/SlideText.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/preact'
+import { h } from 'preact'
+import { Deck, Slide, SlideText } from '@campfire/components'
+
+const meta: Meta<typeof SlideText> = {
+  component: SlideText,
+  title: 'Campfire/SlideText'
+}
+
+export default meta
+
+/**
+ * Demonstrates text rendering on a slide using SlideText.
+ *
+ * @returns Deck with a single slide containing text.
+ */
+export const Basic: StoryObj<typeof SlideText> = {
+  render: () => (
+    <Deck className='w-[800px] h-[600px]'>
+      <Slide>
+        <SlideText x={100} y={100} size={32} color='white'>
+          Hello Campfire
+        </SlideText>
+      </Slide>
+    </Deck>
+  )
+}


### PR DESCRIPTION
## Summary
- introduce reusable `SlideLayer` wrapper for slides
- refactor `SlideText`, `SlideImage`, and `SlideShape` to use `SlideLayer`
- add storybook entry and tests for `SlideLayer`

## Testing
- `bun test apps/campfire/src/components/Deck/Slide/SlideLayer/__tests__/SlideLayer.test.tsx apps/campfire/src/components/Deck/Slide/SlideText/__tests__/SlideText.test.tsx apps/campfire/src/components/Deck/Slide/SlideImage/__tests__/SlideImage.test.tsx apps/campfire/src/components/Deck/Slide/SlideShape/__tests__/SlideShape.test.tsx`


------
https://chatgpt.com/codex/tasks/task_b_68a55b604d648320be45d5208b84912e