### PR TITLE
refactor: centralize quote pattern utility

### DIFF
--- a/apps/campfire/src/helpers.ts
+++ b/apps/campfire/src/helpers.ts
@@ -1,4 +1,5 @@
 import { evalExpression } from '@campfire/utils/evalExpression'
+import { QUOTE_PATTERN } from '@campfire/utils/quote'
 import { unified } from 'unified'
 import remarkParse from 'remark-parse'
 import remarkGfm from 'remark-gfm'
@@ -8,7 +9,6 @@ import type { Parent, Root, RootContent, Code } from 'mdast'
 import type { DirectiveNode } from '@campfire/remark-campfire/helpers'
 import { ensureKey, removeNode } from '@campfire/remark-campfire/helpers'
 
-const QUOTE_PATTERN = /^(['"`])(.*)\1$/
 /**
  * Parses a raw string into a typed value. Supports quoted strings, booleans,
  * numbers, object literals and expression evaluation against provided data.

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -53,8 +53,8 @@ import {
   createStateManager,
   type SetOptions
 } from '@campfire/state/stateManager'
+import { QUOTE_PATTERN } from '@campfire/utils/quote'
 
-const QUOTE_PATTERN = /^(['"`])(.*)\1$/
 const NUMERIC_PATTERN = /^\d+$/
 const ALLOWED_ONEXIT_DIRECTIVES = new Set([
   'set',

--- a/apps/campfire/src/remark-campfire/helpers.ts
+++ b/apps/campfire/src/remark-campfire/helpers.ts
@@ -1,5 +1,6 @@
 import { toString } from 'mdast-util-to-string'
 import { evalExpression } from '@campfire/utils/evalExpression'
+import { QUOTE_PATTERN } from '@campfire/utils/quote'
 import type { Parent, Paragraph, RootContent } from 'mdast'
 import type {
   ContainerDirective,
@@ -215,8 +216,6 @@ export const ensureKey = (
   removeNode(parent, index)
   return undefined
 }
-
-const QUOTE_PATTERN = /^(['"`])(.*)\1$/
 
 export interface AttributeSpec<T = unknown> {
   type: 'string' | 'number' | 'boolean' | 'object' | 'array'

--- a/apps/campfire/src/utils/quote.ts
+++ b/apps/campfire/src/utils/quote.ts
@@ -1,0 +1,2 @@
+/** Pattern matching a string enclosed in matching quotes or backticks. */
+export const QUOTE_PATTERN = /^(['"`])(.*)\1$/


### PR DESCRIPTION
## Summary
- add shared `QUOTE_PATTERN` utility
- use shared `QUOTE_PATTERN` in helpers and directive handling

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_68a5c87f40a4832080955c5d6ae40e8e