### PR TITLE
refactor(state): centralize immer updates

### DIFF
--- a/apps/campfire/src/state/setImmer.ts
+++ b/apps/campfire/src/state/setImmer.ts
@@ -1,0 +1,15 @@
+import { produce } from 'immer'
+import type { Draft } from 'immer'
+
+/**
+ * Wraps Zustand's set function with Immer's produce for immutable updates.
+ *
+ * @param set - The original Zustand set function.
+ * @returns A function accepting an Immer recipe to update state.
+ */
+type SetFn<T> = (fn: (state: T) => T) => void
+
+export const setImmer =
+  <T extends object>(set: SetFn<T>) =>
+  (fn: (draft: Draft<T>) => void) =>
+    set(produce(fn))

--- a/apps/campfire/src/state/setImmer.ts
+++ b/apps/campfire/src/state/setImmer.ts
@@ -1,5 +1,13 @@
 import { produce } from 'immer'
 import type { Draft } from 'immer'
+import type { StoreApi } from 'zustand'
+
+/**
+ * Zustand's `set` function signature.
+ *
+ * @template T - The state shape managed by the store.
+ */
+type SetFn<T extends object> = StoreApi<T>['setState']
 
 /**
  * Wraps Zustand's set function with Immer's produce for immutable updates.
@@ -7,9 +15,7 @@ import type { Draft } from 'immer'
  * @param set - The original Zustand set function.
  * @returns A function accepting an Immer recipe to update state.
  */
-type SetFn<T> = (fn: (state: T) => T) => void
-
 export const setImmer =
   <T extends object>(set: SetFn<T>) =>
   (fn: (draft: Draft<T>) => void) =>
-    set(produce(fn))
+    set(produce<T>(fn))

--- a/apps/campfire/src/state/useStoryDataStore/index.ts
+++ b/apps/campfire/src/state/useStoryDataStore/index.ts
@@ -1,5 +1,5 @@
-import { produce } from 'immer'
 import { create } from 'zustand'
+import { setImmer } from '@campfire/state/setImmer'
 import type { Element } from 'hast'
 
 export interface StoryDataState {
@@ -14,39 +14,36 @@ export interface StoryDataState {
   getPassageByName: (name: string) => Element | undefined
 }
 
-export const useStoryDataStore = create<StoryDataState>((set, get) => ({
-  storyData: {},
-  passages: [],
-  currentPassageId: undefined,
-  setStoryData: data =>
-    set(
-      produce((state: StoryDataState) => {
+export const useStoryDataStore = create<StoryDataState>((set, get) => {
+  const immer = setImmer<StoryDataState>(set)
+  return {
+    storyData: {},
+    passages: [],
+    currentPassageId: undefined,
+    setStoryData: data =>
+      immer(state => {
         state.storyData = data
-      })
-    ),
-  setPassages: passages =>
-    set(
-      produce((state: StoryDataState) => {
+      }),
+    setPassages: passages =>
+      immer(state => {
         state.passages = passages
-      })
-    ),
-  setCurrentPassage: id =>
-    set(
-      produce((state: StoryDataState) => {
+      }),
+    setCurrentPassage: id =>
+      immer(state => {
         state.currentPassageId = id
-      })
-    ),
-  getCurrentPassage: () => {
-    const state = get()
-    const { currentPassageId } = state
-    if (!currentPassageId) return undefined
-    return (
-      state.getPassageById(currentPassageId) ||
-      state.getPassageByName(currentPassageId)
-    )
-  },
-  getPassageById: id =>
-    get().passages.find(p => String(p.properties?.pid) === String(id)),
-  getPassageByName: name =>
-    get().passages.find(p => p.properties?.name === name)
-}))
+      }),
+    getCurrentPassage: () => {
+      const state = get()
+      const { currentPassageId } = state
+      if (!currentPassageId) return undefined
+      return (
+        state.getPassageById(currentPassageId) ||
+        state.getPassageByName(currentPassageId)
+      )
+    },
+    getPassageById: id =>
+      get().passages.find(p => String(p.properties?.pid) === String(id)),
+    getPassageByName: name =>
+      get().passages.find(p => p.properties?.name === name)
+  }
+})


### PR DESCRIPTION
## Summary
- add `setImmer` helper to wrap Zustand set with Immer produce
- refactor deck, story data, and game stores to use `setImmer`

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_68a630a8c7f48320921fdbcf9c1cea06