### PR TITLE
feat: rename Appear to SlideReveal

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,7 +523,7 @@ Run directives on specific passage events or group actions.
 
 ### Navigation & composition
 
-Control the flow between passages or how they appear.
+Control the flow between passages or how they reveal.
 
 - `goto`: Jump to another passage.
 
@@ -602,17 +602,17 @@ Control the flow between passages or how they appear.
   | autoplayDelay | Milliseconds between automatic slide advances (defaults to 3000)           |
   | pause         | Start autoplay paused and display a play button                            |
 
-- `appear`: Reveal slide content step-by-step.
+- `reveal`: Reveal slide content step-by-step.
 
   ```md
   :::deck
   :::slide
-  :::appear{at=0}
+  :::reveal{at=0}
   :::text{x=80 y=80}
   First
   :::
   :::
-  :::appear{at=1}
+  :::reveal{at=1}
   :::text{x=80 y=120}
   Second
   :::
@@ -622,12 +622,12 @@ Control the flow between passages or how they appear.
 
   | Input             | Description                          |
   | ----------------- | ------------------------------------ |
-  | at                | Deck step when content appears       |
+  | at                | Deck step when content reveals       |
   | exitAt            | Deck step when content hides         |
   | enter             | Enter animation key                  |
   | exit              | Exit animation key                   |
   | interruptBehavior | How to handle interrupted animations |
-  | from              | Name of an appear preset to apply    |
+  | from              | Name of a reveal preset to apply     |
 
 - `text`: Position typographic content within a slide.
 
@@ -666,7 +666,7 @@ Control the flow between passages or how they appear.
 
   Accepts the same attributes as the `SlideShape` component and supports a `from` attribute to apply presets.
 
-- `preset`: Define reusable attribute sets that can be applied via the `from` attribute on `deck`, `appear`, `image`, `shape`, and `text` directives.
+- `preset`: Define reusable attribute sets that can be applied via the `from` attribute on `deck`, `reveal`, `image`, `shape`, and `text` directives.
 
   ```md
   :preset{type="deck" name="wide" size="16x9"}

--- a/apps/campfire/src/components/Deck/Deck.tsx
+++ b/apps/campfire/src/components/Deck/Deck.tsx
@@ -21,7 +21,7 @@ import {
   prefersReducedMotion,
   runAnimation
 } from '@campfire/components/transition'
-import { Appear } from './Slide/Appear'
+import { SlideReveal } from './Slide/SlideReveal'
 import type { Transition, SlideTransition } from './Slide/types'
 
 export type ThemeTokens = Record<string, string | number>
@@ -75,19 +75,19 @@ const srOnlyStyle: JSX.CSSProperties = {
 }
 
 /**
- * Recursively determines the highest step index contributed by Appear
+ * Recursively determines the highest step index contributed by SlideReveal
  * components within a tree.
  *
  * @param children - Slide children to inspect.
  * @returns The maximum step index discovered.
  */
-const getAppearMax = (children: ComponentChildren): number => {
+const getRevealMax = (children: ComponentChildren): number => {
   let max = 0
   const walk = (nodes: ComponentChildren): void => {
     toChildArray(nodes).forEach(node => {
       if (typeof node === 'object' && node !== null && 'type' in node) {
         const child = node as VNode<any>
-        if (child.type === Appear) {
+        if (child.type === SlideReveal) {
           const at = child.props.at ?? 0
           const exitAt = child.props.exitAt ?? at
           max = Math.max(max, at, exitAt)
@@ -138,8 +138,8 @@ export const Deck = ({
         const vnode = cloneElement(slide, { key: index }) as VNode<any>
         cloned.push(vnode)
         const explicit = vnode.props.steps ?? 0
-        const appearMax = getAppearMax(vnode.props.children)
-        steps.push(Math.max(explicit, appearMax))
+        const revealMax = getRevealMax(vnode.props.children)
+        steps.push(Math.max(explicit, revealMax))
       } else {
         cloned.push(slide as unknown as VNode<any>)
         steps.push(0)

--- a/apps/campfire/src/components/Deck/Slide/Slide.tsx
+++ b/apps/campfire/src/components/Deck/Slide/Slide.tsx
@@ -7,27 +7,27 @@ import {
 import { useEffect, useLayoutEffect, useMemo, useRef } from 'preact/hooks'
 import { useDeckStore } from '@campfire/state/useDeckStore'
 import { useSerializedDirectiveRunner } from '@campfire/hooks/useSerializedDirectiveRunner'
-import { Appear } from './Appear'
+import { SlideReveal } from './SlideReveal'
 import { SlideTransitionContext } from './context'
 import type { SlideProps } from './types'
 
 /**
  * Recursively scans the Slide's descendants to determine the highest step
- * index contributed by any {@link Appear} component. The traversal flattens
+ * index contributed by any {@link SlideReveal} component. The traversal flattens
  * fragments via {@link toChildArray} so nested arrays and fragments are
- * inspected. When an `Appear` is encountered, both its `at` and `exitAt`
+ * inspected. When a `SlideReveal` is encountered, both its `at` and `exitAt`
  * values are considered to account for entry and exit steps.
  *
  * @param children - Potentially nested Slide children to inspect.
- * @returns The maximum step index discovered across all Appear elements.
+ * @returns The maximum step index discovered across all SlideReveal elements.
  */
-const getAppearMax = (children: ComponentChildren): number => {
+const getRevealMax = (children: ComponentChildren): number => {
   let max = 0
   const walk = (nodes: ComponentChildren): void => {
     toChildArray(nodes).forEach(node => {
       if (typeof node === 'object' && node !== null && 'type' in node) {
         const child = node as VNode<any>
-        if (child.type === Appear) {
+        if (child.type === SlideReveal) {
           const at = child.props.at ?? 0
           const exitAt = child.props.exitAt ?? at
           max = Math.max(max, Math.max(at, exitAt))
@@ -59,7 +59,7 @@ export const Slide = ({
   const maxSteps = useDeckStore(state => state.maxSteps)
   const setMaxSteps = useDeckStore(state => state.setMaxSteps)
   const computedSteps = useMemo(
-    () => Math.max(steps ?? 0, getAppearMax(children)),
+    () => Math.max(steps ?? 0, getRevealMax(children)),
     [steps, children]
   )
   const runEnter = useSerializedDirectiveRunner(onEnter ?? '[]')

--- a/apps/campfire/src/components/Deck/Slide/SlideReveal/__tests__/SlideReveal.test.tsx
+++ b/apps/campfire/src/components/Deck/Slide/SlideReveal/__tests__/SlideReveal.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, spyOn } from 'bun:test'
 import { render, screen, act } from '@testing-library/preact'
 import { Deck } from '@campfire/components/Deck'
 import { Slide } from '@campfire/components/Deck/Slide'
-import { Appear } from '@campfire/components/Deck/Slide'
+import { SlideReveal } from '@campfire/components/Deck/Slide'
 import { useDeckStore } from '@campfire/state/useDeckStore'
 import { StubAnimation } from '@campfire/test-utils/stub-animation'
 
@@ -26,7 +26,7 @@ beforeEach(() => {
   document.body.innerHTML = ''
 })
 
-describe('Appear', () => {
+describe('SlideReveal', () => {
   it.skip('toggles visibility at the configured steps', async () => {
     // @ts-expect-error override animate
     HTMLElement.prototype.animate = () => new StubAnimation()
@@ -34,7 +34,7 @@ describe('Appear', () => {
     render(
       <Deck>
         <Slide>
-          <Appear at={1}>Hello</Appear>
+          <SlideReveal at={1}>Hello</SlideReveal>
         </Slide>
       </Deck>
     )
@@ -55,7 +55,7 @@ describe('Appear', () => {
     render(
       <Deck>
         <Slide>
-          <Appear exitAt={1}>Bye</Appear>
+          <SlideReveal exitAt={1}>Bye</SlideReveal>
         </Slide>
       </Deck>
     )
@@ -71,11 +71,11 @@ describe('Appear', () => {
     expect(screen.queryByText('Bye')).toBeNull()
   })
 
-  it.skip('shows final state immediately when jumping past appear step', async () => {
+  it.skip('shows final state immediately when jumping past reveal step', async () => {
     render(
       <Deck>
         <Slide>
-          <Appear at={2}>Skip</Appear>
+          <SlideReveal at={2}>Skip</SlideReveal>
         </Slide>
       </Deck>
     )
@@ -95,11 +95,11 @@ describe('Appear', () => {
     render(
       <Deck>
         <Slide>
-          <Appear at={0}>First</Appear>
-          <Appear at={1}>Second</Appear>
+          <SlideReveal at={0}>First</SlideReveal>
+          <SlideReveal at={1}>Second</SlideReveal>
         </Slide>
         <Slide>
-          <Appear at={0}>Next</Appear>
+          <SlideReveal at={0}>Next</SlideReveal>
         </Slide>
       </Deck>
     )
@@ -122,7 +122,7 @@ describe('Appear', () => {
     expect(screen.queryByText('Second')).toBeNull()
   })
 
-  it("uses the slide's transition for all Appear children", async () => {
+  it("uses the slide's transition for all SlideReveal children", async () => {
     const transition = await import('@campfire/components/transition')
     const spy = spyOn(transition, 'runAnimation').mockImplementation(
       () => new StubAnimation() as unknown as Animation
@@ -131,8 +131,8 @@ describe('Appear', () => {
     render(
       <Deck>
         <Slide transition={{ type: 'slide' }}>
-          <Appear at={1}>A</Appear>
-          <Appear at={2}>B</Appear>
+          <SlideReveal at={1}>A</SlideReveal>
+          <SlideReveal at={2}>B</SlideReveal>
         </Slide>
       </Deck>
     )

--- a/apps/campfire/src/components/Deck/Slide/SlideReveal/index.tsx
+++ b/apps/campfire/src/components/Deck/Slide/SlideReveal/index.tsx
@@ -15,7 +15,7 @@ import {
   runAnimation
 } from '@campfire/components/transition'
 
-export interface AppearProps {
+export interface SlideRevealProps {
   at?: number
   exitAt?: number
   enter?: Transition
@@ -27,17 +27,17 @@ export interface AppearProps {
 /**
  * Gradually reveals or hides content based on the current deck step.
  *
- * @param props - Configuration options for the appear component.
+ * @param props - Configuration options for the SlideReveal component.
  * @returns The rendered element when present.
  */
-export const Appear = ({
+export const SlideReveal = ({
   at = 0,
   exitAt,
   enter,
   exit,
   interruptBehavior = 'jumpToEnd',
   children
-}: AppearProps): JSX.Element | null => {
+}: SlideRevealProps): JSX.Element | null => {
   const currentStep = useDeckStore(state => state.currentStep)
   const currentSlide = useDeckStore(state => state.currentSlide)
   const slideTransition = useContext(SlideTransitionContext)
@@ -159,11 +159,11 @@ export const Appear = ({
     <div
       ref={ref}
       style={{ display: visible ? '' : 'none' }}
-      data-testid='appear'
+      data-testid='slide-reveal'
     >
       {children}
     </div>
   )
 }
 
-export default Appear
+export default SlideReveal

--- a/apps/campfire/src/components/Deck/Slide/context.ts
+++ b/apps/campfire/src/components/Deck/Slide/context.ts
@@ -2,17 +2,17 @@ import { createContext } from 'preact'
 import type { Transition } from './types'
 
 /**
- * Context providing default transitions for Appear components within a Slide.
+ * Context providing default transitions for SlideReveal components within a Slide.
  */
 export interface SlideTransitionContextValue {
-  /** Default transition used when Appear lacks explicit enter transition. */
+  /** Default transition used when SlideReveal lacks explicit enter transition. */
   enter?: Transition
-  /** Default transition used when Appear lacks explicit exit transition. */
+  /** Default transition used when SlideReveal lacks explicit exit transition. */
   exit?: Transition
 }
 
 /**
- * Context used to share Slide transitions with descendant Appear components.
+ * Context used to share Slide transitions with descendant SlideReveal components.
  */
 export const SlideTransitionContext =
   createContext<SlideTransitionContextValue>({})

--- a/apps/campfire/src/components/Deck/Slide/index.ts
+++ b/apps/campfire/src/components/Deck/Slide/index.ts
@@ -8,7 +8,7 @@ export type {
   SlideProps
 } from './types'
 export { Slide }
-export { Appear } from './Appear'
+export { SlideReveal } from './SlideReveal'
 export { SlideText } from './SlideText'
 export { SlideImage } from './SlideImage'
 export { SlideShape } from './SlideShape'

--- a/apps/campfire/src/components/Deck/Slide/renderDirectiveMarkdown.ts
+++ b/apps/campfire/src/components/Deck/Slide/renderDirectiveMarkdown.ts
@@ -7,7 +7,7 @@ import { Show } from '@campfire/components/Passage/Show'
 import { OnExit } from '@campfire/components/Passage/OnExit'
 import { Deck } from '@campfire/components/Deck/Deck'
 import { Slide } from './Slide'
-import { Appear } from './Appear'
+import { SlideReveal } from './SlideReveal'
 import { SlideText } from './SlideText'
 import { SlideImage } from './SlideImage'
 import { SlideShape } from './SlideShape'
@@ -33,7 +33,7 @@ export const renderDirectiveMarkdown = (
     onExit: OnExit,
     deck: Deck,
     slide: Slide,
-    appear: Appear,
+    reveal: SlideReveal,
     slideText: SlideText,
     slideImage: SlideImage,
     slideShape: SlideShape

--- a/apps/campfire/src/components/Deck/__tests__/Deck.test.tsx
+++ b/apps/campfire/src/components/Deck/__tests__/Deck.test.tsx
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from 'bun:test'
 import { act, fireEvent, render, screen } from '@testing-library/preact'
 import { Deck } from '@campfire/components/Deck'
-import { Appear, Slide } from '@campfire/components/Deck/Slide'
+import { SlideReveal, Slide } from '@campfire/components/Deck/Slide'
 import { LinkButton } from '@campfire/components'
 import { useDeckStore } from '@campfire/state/useDeckStore'
 import { StubAnimation } from '@campfire/test-utils/stub-animation'
@@ -346,7 +346,7 @@ describe('Deck', () => {
     expect(nav.className).toContain('bottom-2')
   })
 
-  it.skip('sets max steps once for multiple Appear elements', async () => {
+  it.skip('sets max steps once for multiple SlideReveal elements', async () => {
     const original = useDeckStore.getState().setMaxSteps
     const calls: number[] = []
     useDeckStore.setState({
@@ -359,9 +359,9 @@ describe('Deck', () => {
     render(
       <Deck>
         <Slide>
-          <Appear at={0}>One</Appear>
-          <Appear at={1}>Two</Appear>
-          <Appear at={2}>Three</Appear>
+          <SlideReveal at={0}>One</SlideReveal>
+          <SlideReveal at={1}>Two</SlideReveal>
+          <SlideReveal at={2}>Three</SlideReveal>
         </Slide>
       </Deck>
     )
@@ -378,12 +378,12 @@ describe('Deck', () => {
     render(
       <Deck>
         <Slide>
-          <Appear at={0}>One</Appear>
-          <Appear at={1}>Two</Appear>
-          <Appear at={2}>Three</Appear>
+          <SlideReveal at={0}>One</SlideReveal>
+          <SlideReveal at={1}>Two</SlideReveal>
+          <SlideReveal at={2}>Three</SlideReveal>
         </Slide>
         <Slide>
-          <Appear>Only</Appear>
+          <SlideReveal>Only</SlideReveal>
         </Slide>
       </Deck>
     )
@@ -420,13 +420,13 @@ describe('Deck', () => {
     expect(useDeckStore.getState().currentSlide).toBe(0)
   })
 
-  it.skip('stops autoplay after the final appear of the last slide', async () => {
+  it.skip('stops autoplay after the final reveal of the last slide', async () => {
     render(
       <Deck autoAdvanceMs={20}>
         <Slide>Slide 1</Slide>
         <Slide>
-          <Appear at={0}>One</Appear>
-          <Appear at={1}>Two</Appear>
+          <SlideReveal at={0}>One</SlideReveal>
+          <SlideReveal at={1}>Two</SlideReveal>
         </Slide>
       </Deck>
     )

--- a/apps/campfire/src/components/Passage/If.tsx
+++ b/apps/campfire/src/components/Passage/If.tsx
@@ -14,7 +14,7 @@ import { LinkButton } from '@campfire/components/Passage/LinkButton'
 import { TriggerButton } from '@campfire/components/Passage/TriggerButton'
 import { Show } from '@campfire/components/Passage/Show'
 import { OnExit } from '@campfire/components/Passage/OnExit'
-import { Appear } from '@campfire/components/Deck/Slide/Appear'
+import { SlideReveal } from '@campfire/components/Deck/Slide/SlideReveal'
 import { SlideText } from '@campfire/components/Deck/Slide/SlideText'
 import { SlideImage } from '@campfire/components/Deck/Slide/SlideImage'
 import { SlideShape } from '@campfire/components/Deck/Slide/SlideShape'
@@ -50,7 +50,7 @@ export const If = ({ test, content, fallback }: IfProps) => {
           if: If,
           show: Show,
           onExit: OnExit,
-          appear: Appear,
+          reveal: SlideReveal,
           slideText: SlideText,
           slideImage: SlideImage,
           slideShape: SlideShape

--- a/apps/campfire/src/components/Passage/Passage.tsx
+++ b/apps/campfire/src/components/Passage/Passage.tsx
@@ -20,7 +20,7 @@ import { Show } from '@campfire/components/Passage/Show'
 import { OnExit } from '@campfire/components/Passage/OnExit'
 import { Deck } from '@campfire/components/Deck/Deck'
 import { Slide } from '@campfire/components/Deck/Slide/Slide'
-import { Appear } from '@campfire/components/Deck/Slide/Appear'
+import { SlideReveal } from '@campfire/components/Deck/Slide/SlideReveal'
 import { SlideText } from '@campfire/components/Deck/Slide/SlideText'
 import { SlideImage } from '@campfire/components/Deck/Slide/SlideImage'
 import { SlideShape } from '@campfire/components/Deck/Slide/SlideShape'
@@ -119,7 +119,7 @@ export const Passage = () => {
           onExit: OnExit,
           deck: Deck,
           slide: Slide,
-          appear: Appear,
+          reveal: SlideReveal,
           slideText: SlideText,
           slideImage: SlideImage,
           slideShape: SlideShape

--- a/apps/campfire/src/components/index.ts
+++ b/apps/campfire/src/components/index.ts
@@ -12,7 +12,7 @@ export { Deck } from '@campfire/components/Deck'
 export {
   Slide,
   renderDirectiveMarkdown,
-  Appear,
+  SlideReveal,
   Layer,
   SlideText,
   SlideImage,

--- a/apps/campfire/src/hooks/__tests__/deckDirective.leadingNewline.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/deckDirective.leadingNewline.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from 'bun:test'
 import { render } from '@testing-library/preact'
 import { Fragment } from 'preact/jsx-runtime'
 import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
-import { Appear } from '@campfire/components/Deck/Slide'
+import { SlideReveal } from '@campfire/components/Deck/Slide'
 import { renderDirectiveMarkdown } from '@campfire/components/Deck/Slide'
 
 let output: any = null
@@ -21,12 +21,12 @@ describe('deck directive', () => {
   it('handles leading newline before deck', () => {
     const md = `\n:::deck{size='800x600'}
   :::slide{transition='fade'}
-    :::appear{at=0}
+    :::reveal{at=0}
       :::text{x=80 y=80 as="h2"}
       Hello
       :::
     :::
-    :::appear{at=1}
+    :::reveal{at=1}
       :::text{x=100 y=100 as="h2"}
       World
       :::
@@ -50,7 +50,7 @@ describe('deck directive', () => {
       ? slide.props.children
       : [slide.props.children]
     expect(slideChildren).toHaveLength(2)
-    expect(slideChildren[0].type).toBe(Appear)
-    expect(slideChildren[1].type).toBe(Appear)
+    expect(slideChildren[0].type).toBe(SlideReveal)
+    expect(slideChildren[1].type).toBe(SlideReveal)
   })
 })

--- a/apps/campfire/src/hooks/__tests__/deckDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/deckDirective.test.tsx
@@ -5,7 +5,7 @@ import type { ComponentChild } from 'preact'
 import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
 import { Deck } from '@campfire/components/Deck'
 import { Slide } from '@campfire/components/Deck/Slide'
-import { Appear } from '@campfire/components/Deck/Slide'
+import { SlideReveal } from '@campfire/components/Deck/Slide'
 import { SlideText } from '@campfire/components/Deck/Slide'
 import { DEFAULT_DECK_HEIGHT, DEFAULT_DECK_WIDTH } from '@campfire/constants'
 import { renderDirectiveMarkdown } from '@campfire/components/Deck/Slide'
@@ -113,15 +113,15 @@ describe('deck directive', () => {
     expect(text).not.toContain(':::')
   })
 
-  it('keeps nested appear directives within a slide', () => {
+  it('keeps nested reveal directives within a slide', () => {
     const md = `:::deck{size='800x600'}
   :::slide{transition='fade'}
-    :::appear{at=0}
+    :::reveal{at=0}
       :::text{x=80 y=80 as="h2"}
       Hello
       :::
     :::
-    :::appear{at=1}
+    :::reveal{at=1}
       :::text{x=100 y=100 as="h2"}
       World
       :::
@@ -144,8 +144,8 @@ describe('deck directive', () => {
       ? slide.props.children
       : [slide.props.children]
     expect(slideChildren.length).toBe(2)
-    expect(slideChildren[0].type).toBe(Appear)
-    expect(slideChildren[1].type).toBe(Appear)
+    expect(slideChildren[0].type).toBe(SlideReveal)
+    expect(slideChildren[1].type).toBe(SlideReveal)
     const text = getText(output)
     expect(text).not.toContain(':::')
   })
@@ -153,12 +153,12 @@ describe('deck directive', () => {
   it('does not create extra slides from whitespace', () => {
     const md = `:::deck{size='800x600'}
   :::slide{transition='fade'}
-    :::appear{at=0}
+    :::reveal{at=0}
       :::text{x=80 y=80 as="h2"}
       Hello
       :::
     :::
-    :::appear{at=1}
+    :::reveal{at=1}
       :::text{x=100 y=100 as="h2"}
       World
       :::
@@ -181,20 +181,20 @@ describe('deck directive', () => {
       ? slide.props.children
       : [slide.props.children]
     expect(slideChildren.length).toBe(2)
-    expect(slideChildren[0].type).toBe(Appear)
-    expect(slideChildren[1].type).toBe(Appear)
+    expect(slideChildren[0].type).toBe(SlideReveal)
+    expect(slideChildren[1].type).toBe(SlideReveal)
   })
 
-  it('merges stray appear directives into the previous slide', () => {
+  it('merges stray reveal directives into the previous slide', () => {
     const md = `:::deck{size='800x600'}
   :::slide{transition='fade'}
-    :::appear{at=0}
+    :::reveal{at=0}
       :::text{x=80 y=80 as="h2"}
       Hello
       :::
     :::
   :::
-  :::appear{at=1}
+  :::reveal{at=1}
     :::text{x=100 y=100 as="h2"}
     World
     :::
@@ -216,19 +216,19 @@ describe('deck directive', () => {
       ? slide.props.children
       : [slide.props.children]
     expect(slideChildren.length).toBe(2)
-    expect(slideChildren[0].type).toBe(Appear)
-    expect(slideChildren[1].type).toBe(Appear)
+    expect(slideChildren[0].type).toBe(SlideReveal)
+    expect(slideChildren[1].type).toBe(SlideReveal)
   })
 
   it('matches the Storybook deck example', () => {
     const md = `:::deck{size='800x600'}
   :::slide{transition='fade'}
-    :::appear{at=0}
+    :::reveal{at=0}
       :::text{x=80 y=80 as="h2"}
       Hello
       :::
     :::
-    :::appear{at=1}
+    :::reveal{at=1}
       :::text{x=100 y=100 as="h2"}
       World
       :::
@@ -255,14 +255,14 @@ describe('deck directive', () => {
       type: Slide,
       props: { transition: { type: 'fade' } }
     })
-    const appearChildren = Array.isArray(slide.props.children)
+    const revealChildren = Array.isArray(slide.props.children)
       ? slide.props.children
       : [slide.props.children]
-    expect(appearChildren).toHaveLength(2)
-    const [first, second] = appearChildren
-    expect(first).toMatchObject({ type: Appear, props: { at: 0 } })
+    expect(revealChildren).toHaveLength(2)
+    const [first, second] = revealChildren
+    expect(first).toMatchObject({ type: SlideReveal, props: { at: 0 } })
     expect(getText(first)).toBe('Hello')
-    expect(second).toMatchObject({ type: Appear, props: { at: 1 } })
+    expect(second).toMatchObject({ type: SlideReveal, props: { at: 1 } })
     expect(getText(second)).toBe('World')
     const text = getText(output)
     expect(text).toBe('HelloWorld')

--- a/apps/campfire/src/hooks/__tests__/imageDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/imageDirective.test.tsx
@@ -31,7 +31,7 @@ beforeEach(() => {
 describe('image directive', () => {
   it('renders a SlideImage component with props', () => {
     const md =
-      ':::appear\n:image{src="https://example.com/cat.png" x=10 y=20 alt="Cat" class="rounded" style="border:1px solid red" data-test="ok"}\n:::\n'
+      ':::reveal\n:image{src="https://example.com/cat.png" x=10 y=20 alt="Cat" class="rounded" style="border:1px solid red" data-test="ok"}\n:::\n'
     render(<MarkdownRunner markdown={md} />)
     const el = document.querySelector(
       '[data-testid="slideImage"]'
@@ -49,7 +49,7 @@ describe('image directive', () => {
 
   it('applies image presets with overrides', () => {
     const md =
-      ':preset{type="image" name="cat" x=5 y=5 src="https://example.com/cat.png"}\n:::appear\n:image{from="cat" y=10}\n:::\n'
+      ':preset{type="image" name="cat" x=5 y=5 src="https://example.com/cat.png"}\n:::reveal\n:image{from="cat" y=10}\n:::\n'
     render(<MarkdownRunner markdown={md} />)
     const el = document.querySelector(
       '[data-testid="slideImage"]'

--- a/apps/campfire/src/hooks/__tests__/revealDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/revealDirective.test.tsx
@@ -4,7 +4,7 @@ import { Fragment } from 'preact/jsx-runtime'
 import type { ComponentChild } from 'preact'
 import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
 import { renderDirectiveMarkdown } from '@campfire/components/Deck/Slide'
-import { Appear } from '@campfire/components/Deck/Slide'
+import { SlideReveal } from '@campfire/components/Deck/Slide'
 
 let output: ComponentChild | null = null
 
@@ -25,42 +25,42 @@ beforeEach(() => {
   document.body.innerHTML = ''
 })
 
-describe('appear directive', () => {
-  it('renders an Appear component with props', () => {
+describe('reveal directive', () => {
+  it('renders a SlideReveal component with props', () => {
     const md =
-      ':::appear{at=1 exitAt=3 enter="slide" exit="fade" interruptBehavior="cancel" data-test="ok"}\nHello\n:::'
+      ':::reveal{at=1 exitAt=3 enter="slide" exit="fade" interruptBehavior="cancel" data-test="ok"}\nHello\n:::'
     render(<MarkdownRunner markdown={md} />)
-    const getAppear = (node: any): any => {
-      if (Array.isArray(node)) return getAppear(node[0])
-      if (node?.type === Fragment) return getAppear(node.props.children)
+    const getReveal = (node: any): any => {
+      if (Array.isArray(node)) return getReveal(node[0])
+      if (node?.type === Fragment) return getReveal(node.props.children)
       return node
     }
-    const appear = getAppear(output)
-    expect(appear.type).toBe(Appear)
-    expect(appear.props.at).toBe(1)
-    expect(appear.props.exitAt).toBe(3)
-    expect(appear.props.enter).toBe('slide')
-    expect(appear.props.exit).toBe('fade')
-    expect(appear.props.interruptBehavior).toBe('cancel')
-    expect(appear.props['data-test']).toBe('ok')
+    const reveal = getReveal(output)
+    expect(reveal.type).toBe(SlideReveal)
+    expect(reveal.props.at).toBe(1)
+    expect(reveal.props.exitAt).toBe(3)
+    expect(reveal.props.enter).toBe('slide')
+    expect(reveal.props.exit).toBe('fade')
+    expect(reveal.props.interruptBehavior).toBe('cancel')
+    expect(reveal.props['data-test']).toBe('ok')
   })
 
-  it('applies appear presets with overrides', () => {
+  it('applies reveal presets with overrides', () => {
     const md =
-      ':preset{type="appear" name="fade" at=2}\n:::appear{from="fade" exitAt=3}\nHi\n:::'
+      ':preset{type="reveal" name="fade" at=2}\n:::reveal{from="fade" exitAt=3}\nHi\n:::'
     render(<MarkdownRunner markdown={md} />)
-    const getAppear = (node: any): any => {
-      if (Array.isArray(node)) return getAppear(node[0])
-      if (node?.type === Fragment) return getAppear(node.props.children)
+    const getReveal = (node: any): any => {
+      if (Array.isArray(node)) return getReveal(node[0])
+      if (node?.type === Fragment) return getReveal(node.props.children)
       return node
     }
-    const appear = getAppear(output)
-    expect(appear.props.at).toBe(2)
-    expect(appear.props.exitAt).toBe(3)
+    const reveal = getReveal(output)
+    expect(reveal.props.at).toBe(2)
+    expect(reveal.props.exitAt).toBe(3)
   })
 
-  it('does not render stray colons when appear contains directives', () => {
-    const md = `:::appear\n:::if{true}\nHi\n:::\n:::\n`
+  it('does not render stray colons when reveal contains directives', () => {
+    const md = `:::reveal\n:::if{true}\nHi\n:::\n:::\n`
     render(<MarkdownRunner markdown={md} />)
     const getText = (node: any): string => {
       if (!node) return ''

--- a/apps/campfire/src/hooks/__tests__/shapeDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/shapeDirective.test.tsx
@@ -31,7 +31,7 @@ beforeEach(() => {
 describe('shape directive', () => {
   it('renders a SlideShape component with props', () => {
     const md =
-      ':::appear\n:shape{x=10 y=20 w=100 h=50 type="rect" stroke="red" fill="blue" radius=5 shadow=true class="rounded" data-test="ok"}\n:::\n'
+      ':::reveal\n:shape{x=10 y=20 w=100 h=50 type="rect" stroke="red" fill="blue" radius=5 shadow=true class="rounded" data-test="ok"}\n:::\n'
     render(<MarkdownRunner markdown={md} />)
     const el = document.querySelector(
       '[data-testid="slideShape"]'
@@ -53,7 +53,7 @@ describe('shape directive', () => {
 
   it('applies shape presets with overrides', () => {
     const md =
-      ':preset{type="shape" name="box" x=5 y=5 w=10 h=10 fill="red"}\n:::appear\n:shape{from="box" y=20 type="rect"}\n:::\n'
+      ':preset{type="shape" name="box" x=5 y=5 w=10 h=10 fill="red"}\n:::reveal\n:shape{from="box" y=20 type="rect"}\n:::\n'
     render(<MarkdownRunner markdown={md} />)
     const el = document.querySelector(
       '[data-testid="slideShape"]'

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -1702,8 +1702,8 @@ export const useDirectiveHandlers = () => {
       return [SKIP, newIndex]
     }
 
-  /** Schema describing supported appear directive attributes. */
-  const appearSchema = {
+  /** Schema describing supported reveal directive attributes. */
+  const revealSchema = {
     at: { type: 'number' },
     exitAt: { type: 'number' },
     enter: { type: 'string' },
@@ -1712,10 +1712,10 @@ export const useDirectiveHandlers = () => {
     from: { type: 'string', expression: false }
   } as const
 
-  type AppearSchema = typeof appearSchema
-  type AppearAttrs = ExtractedAttrs<AppearSchema>
+  type RevealSchema = typeof revealSchema
+  type RevealAttrs = ExtractedAttrs<RevealSchema>
 
-  const APPEAR_EXCLUDES = [
+  const REVEAL_EXCLUDES = [
     'at',
     'exitAt',
     'enter',
@@ -1807,20 +1807,20 @@ export const useDirectiveHandlers = () => {
   type ShapeAttrs = ExtractedAttrs<ShapeSchema>
 
   /**
-   * Converts `:::appear` directives into Appear elements.
+   * Converts `:::reveal` directives into SlideReveal elements.
    *
-   * @param directive - The appear directive node.
+   * @param directive - The reveal directive node.
    * @param parent - Parent node containing the directive.
    * @param index - Index of the directive within its parent.
    * @returns Visitor instructions after replacement.
    */
-  const handleAppear = createContainerHandler(
-    'appear',
-    appearSchema,
+  const handleReveal = createContainerHandler(
+    'reveal',
+    revealSchema,
     (attrs, raw) => {
       const props: Record<string, unknown> = {}
       const preset = attrs.from
-        ? presetsRef.current['appear']?.[String(attrs.from)]
+        ? presetsRef.current['reveal']?.[String(attrs.from)]
         : undefined
       if (preset) {
         if (typeof preset.at === 'number') props.at = preset.at
@@ -1829,7 +1829,7 @@ export const useDirectiveHandlers = () => {
         if (preset.exit) props.exit = preset.exit
         if (preset.interruptBehavior)
           props.interruptBehavior = preset.interruptBehavior
-        applyAdditionalAttributes(preset, props, APPEAR_EXCLUDES)
+        applyAdditionalAttributes(preset, props, REVEAL_EXCLUDES)
       }
       if (typeof attrs.at === 'number') props.at = attrs.at
       if (typeof attrs.exitAt === 'number') props.exitAt = attrs.exitAt
@@ -1838,7 +1838,7 @@ export const useDirectiveHandlers = () => {
       if (attrs.interruptBehavior)
         props.interruptBehavior = attrs.interruptBehavior
       const mergedRaw = mergeAttrs(preset, raw)
-      applyAdditionalAttributes(mergedRaw, props, [...APPEAR_EXCLUDES, 'from'])
+      applyAdditionalAttributes(mergedRaw, props, [...REVEAL_EXCLUDES, 'from'])
       return props
     }
   )
@@ -2311,7 +2311,7 @@ export const useDirectiveHandlers = () => {
      * pipeline so stray markers do not render in the output. When buffered
      * content has no slide attributes and at least one slide already exists,
      * the nodes are merged into the previous slide instead of creating a new
-     * one. This prevents stray directives, such as `:::appear`, from being
+     * one. This prevents stray directives, such as `:::reveal`, from being
      * lifted to the deck level and causing empty slides.
      */
     const commitPending = () => {
@@ -2538,7 +2538,7 @@ export const useDirectiveHandlers = () => {
       batch: handleBatch,
       trigger: handleTrigger,
       onExit: handleOnExit,
-      appear: handleAppear,
+      reveal: handleReveal,
       text: handleText,
       image: handleImage,
       shape: handleShape,

--- a/apps/storybook/src/Deck.stories.tsx
+++ b/apps/storybook/src/Deck.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/preact'
 import { h } from 'preact'
-import { Deck, Slide, SlideText, Appear } from '@campfire/components'
+import { Deck, Slide, SlideText, SlideReveal } from '@campfire/components'
 
 const meta: Meta<typeof Deck> = {
   component: Deck,
@@ -10,9 +10,9 @@ const meta: Meta<typeof Deck> = {
 export default meta
 
 /**
- * Renders the Deck story with three slides and transitions using the Appear
+ * Renders the Deck story with three slides and transitions using the SlideReveal
  * component to progressively reveal content. The first slide demonstrates
- * three sequential Appear elements to showcase entrance and exit animations.
+ * three sequential SlideReveal elements to showcase entrance and exit animations.
  * Text layers are positioned so they do not overlap.
  *
  * @returns The rendered Deck element.
@@ -25,21 +25,21 @@ const render: StoryObj<typeof Deck>['render'] = () => (
         exit: { type: 'fade', duration: 300 }
       }}
     >
-      <Appear at={0}>
+      <SlideReveal at={0}>
         <SlideText as='h2' x={200} y={200} size={36}>
           Fade Slide
         </SlideText>
-      </Appear>
-      <Appear at={1}>
+      </SlideReveal>
+      <SlideReveal at={1}>
         <SlideText x={500} y={400} size={24}>
           Second step
         </SlideText>
-      </Appear>
-      <Appear at={2}>
+      </SlideReveal>
+      <SlideReveal at={2}>
         <SlideText x={500} y={500} size={24}>
           Third step
         </SlideText>
-      </Appear>
+      </SlideReveal>
     </Slide>
     <Slide
       transition={{
@@ -47,16 +47,16 @@ const render: StoryObj<typeof Deck>['render'] = () => (
         exit: { type: 'slide', dir: 'right', duration: 300 }
       }}
     >
-      <Appear at={0}>
+      <SlideReveal at={0}>
         <SlideText as='h2' x={200} y={200} size={36}>
           Slide Transition
         </SlideText>
-      </Appear>
-      <Appear at={1}>
+      </SlideReveal>
+      <SlideReveal at={1}>
         <SlideText x={500} y={400} size={24}>
           Second step
         </SlideText>
-      </Appear>
+      </SlideReveal>
     </Slide>
     <Slide
       transition={{
@@ -64,16 +64,16 @@ const render: StoryObj<typeof Deck>['render'] = () => (
         exit: { type: 'zoom', duration: 300 }
       }}
     >
-      <Appear at={0}>
+      <SlideReveal at={0}>
         <SlideText as='h2' x={200} y={200} size={36}>
           Zoom Slide
         </SlideText>
-      </Appear>
-      <Appear at={1}>
+      </SlideReveal>
+      <SlideReveal at={1}>
         <SlideText x={500} y={400} size={24}>
           Second step
         </SlideText>
-      </Appear>
+      </SlideReveal>
     </Slide>
     <Slide
       transition={{
@@ -81,26 +81,26 @@ const render: StoryObj<typeof Deck>['render'] = () => (
         exit: { type: 'fade', duration: 400 }
       }}
     >
-      <Appear at={0}>
+      <SlideReveal at={0}>
         <SlideText as='h2' x={200} y={200} size={36}>
           Flip Slide
         </SlideText>
-      </Appear>
-      <Appear at={1}>
+      </SlideReveal>
+      <SlideReveal at={1}>
         <SlideText x={260} y={260} size={28}>
           Second step
         </SlideText>
-      </Appear>
-      <Appear at={2}>
+      </SlideReveal>
+      <SlideReveal at={2}>
         <SlideText x={320} y={320} size={24}>
           Third step
         </SlideText>
-      </Appear>
-      <Appear at={3}>
+      </SlideReveal>
+      <SlideReveal at={3}>
         <SlideText x={440} y={440} size={20}>
           Fourth step
         </SlideText>
-      </Appear>
+      </SlideReveal>
     </Slide>
   </Deck>
 )
@@ -179,7 +179,7 @@ export const WithDisabledControls: StoryObj<typeof Deck> = {
 
 /**
  * Demonstrates automatically advancing slides after a delay. Autoplay pauses
- * once the final appear of the last slide is revealed.
+ * once the final reveal of the last slide is shown.
  *
  * @returns The rendered Deck element with autoplay.
  */
@@ -192,16 +192,16 @@ export const WithAutoplay: StoryObj<typeof Deck> = {
         </SlideText>
       </Slide>
       <Slide>
-        <Appear at={0}>
+        <SlideReveal at={0}>
           <SlideText as='h2' x={200} y={200} size={36}>
             Auto 2
           </SlideText>
-        </Appear>
-        <Appear at={1}>
+        </SlideReveal>
+        <SlideReveal at={1}>
           <SlideText x={200} y={260} size={24}>
             Final Step
           </SlideText>
-        </Appear>
+        </SlideReveal>
       </Slide>
     </Deck>
   )

--- a/apps/storybook/src/Directives.stories.tsx
+++ b/apps/storybook/src/Directives.stories.tsx
@@ -39,15 +39,15 @@ You clicked the button!
 // Expected component composition of the Deck directives below (JSX-style):
 // <Deck size={{ width: 800, height: 600 }}>
 //   <Slide transition={{ type: 'fade' }}>
-//     <Appear at={0}>
+//     <SlideReveal at={0}>
 //       <SlideText as="h2" x={80} y={80}>Hello</SlideText>
-//     </Appear>
-//     <Appear at={1}>
+//     </SlideReveal>
+//     <SlideReveal at={1}>
 //       <SlideShape type="rect" x={150} y={150} w={100} h={50} stroke="blue" fill="#ddf" radius={8} shadow className="opacity-25" />
-//     </Appear>
-//     <Appear at={2}>
+//     </SlideReveal>
+//     <SlideReveal at={2}>
 //       <SlideText as="h2" x={100} y={100}>World</SlideText>
-//     </Appear>
+//     </SlideReveal>
 //   </Slide>
 // </Deck>
 export const Deck: StoryObj = {
@@ -60,15 +60,15 @@ export const Deck: StoryObj = {
 
 :::deck{size='800x600'}
   :::slide{transition='fade'}
-    :::appear{at=0}
+    :::reveal{at=0}
       :::text{from="title"}
       Hello
       :::
     :::
-    :::appear{at=1}
+    :::reveal{at=1}
       :shape{x=150 y=150 w=100 h=50 type='rect' stroke='blue' fill='#ddf' radius=8 shadow=true className='opacity-25'}
     :::
-    :::appear{at=2}
+    :::reveal{at=2}
       :::text{from="title" x=100 y=100}
       World
       :::
@@ -95,13 +95,13 @@ export const MultiPassageDecks: StoryObj = {
 
       [[Next->Second]]
 
-      :::appear{at=0}
+      :::reveal{at=0}
         :::text{x=20 y=20}
         First deck 1
         :::
       :::
 
-      :::appear{at=1}
+      :::reveal{at=1}
         :::text{x=20 y=60}
         First deck 2
         :::
@@ -118,13 +118,13 @@ export const MultiPassageDecks: StoryObj = {
 
       [[Back->Start]]
 
-      :::appear{at=0}
+      :::reveal{at=0}
         :::text{x=20 y=20}
         Second deck 1
         :::
       :::
 
-      :::appear{at=1}
+      :::reveal{at=1}
         :::text{x=20 y=40}
         Second deck 2
         :::

--- a/apps/storybook/src/SlideImage.stories.tsx
+++ b/apps/storybook/src/SlideImage.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/preact'
 import { h } from 'preact'
-import { Appear, Deck, Slide, SlideImage } from '@campfire/components'
+import { Deck, Slide, SlideImage, SlideReveal } from '@campfire/components'
 
 const meta: Meta<typeof SlideImage> = {
   component: SlideImage,
@@ -18,7 +18,7 @@ export const Basic: StoryObj<typeof SlideImage> = {
   render: () => (
     <Deck className='w-[800px] h-[600px]'>
       <Slide>
-        <Appear
+        <SlideReveal
           at={0}
           enter={{ type: 'fade', duration: 300 }}
           exit={{ type: 'fade', duration: 300 }}
@@ -30,8 +30,8 @@ export const Basic: StoryObj<typeof SlideImage> = {
             x={200}
             y={200}
           />
-        </Appear>
-        <Appear
+        </SlideReveal>
+        <SlideReveal
           at={1}
           enter={{ type: 'zoom', dir: 'up', duration: 300 }}
           exit={{ type: 'zoom', dir: 'down', duration: 300 }}
@@ -43,7 +43,7 @@ export const Basic: StoryObj<typeof SlideImage> = {
             x={500}
             y={300}
           />
-        </Appear>
+        </SlideReveal>
       </Slide>
     </Deck>
   )

--- a/apps/storybook/src/SlideReveal.stories.tsx
+++ b/apps/storybook/src/SlideReveal.stories.tsx
@@ -1,27 +1,27 @@
 import type { Meta, StoryObj } from '@storybook/preact'
 import { h } from 'preact'
-import { Deck, Slide, SlideText, Appear } from '@campfire/components'
+import { Deck, Slide, SlideText, SlideReveal } from '@campfire/components'
 
-const meta: Meta<typeof Appear> = {
-  component: Appear,
-  title: 'Campfire/Appear'
+const meta: Meta<typeof SlideReveal> = {
+  component: SlideReveal,
+  title: 'Campfire/SlideReveal'
 }
 
 export default meta
 
 /**
- * Renders a deck demonstrating sequential Appear elements and their
+ * Renders a deck demonstrating sequential SlideReveal elements and their
  * behavior when switching slides.
  *
  * @returns The rendered deck.
  */
-const render: StoryObj<typeof Appear>['render'] = () => (
+const render: StoryObj<typeof SlideReveal>['render'] = () => (
   <Deck className='w-[800px] h-[600px]'>
     <Slide
       transition={{ type: 'slide' }}
       className='bg-gray-100 dark:bg-gray-900'
     >
-      <Appear at={0}>
+      <SlideReveal at={0}>
         <SlideText
           as='h2'
           x={180}
@@ -33,8 +33,8 @@ const render: StoryObj<typeof Appear>['render'] = () => (
         >
           First
         </SlideText>
-      </Appear>
-      <Appear at={1}>
+      </SlideReveal>
+      <SlideReveal at={1}>
         <SlideText
           x={280}
           y={280}
@@ -45,7 +45,7 @@ const render: StoryObj<typeof Appear>['render'] = () => (
         >
           Second
         </SlideText>
-      </Appear>
+      </SlideReveal>
     </Slide>
     <Slide className='bg-gray-100 dark:bg-gray-900'>
       <SlideText
@@ -63,4 +63,4 @@ const render: StoryObj<typeof Appear>['render'] = () => (
   </Deck>
 )
 
-export const Basic: StoryObj<typeof Appear> = { render }
+export const Basic: StoryObj<typeof SlideReveal> = { render }


### PR DESCRIPTION
## Summary
- rename Appear component to SlideReveal
- update appear directive to reveal across handlers, stories, and tests
- document reveal usage in README

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_68a63725c8d08320be305c4c5733c735