### PR TITLE
feat: add interpolation support for show and t fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,14 +369,17 @@ Create or modify lists of values.
 
 Read or compute data without mutating state.
 
-- `show`: Display a key's value or the result of an expression.
+- `show`: Display a key's value, the result of an expression, or an
+  interpolated string.
 
   ```md
   :show[hp]
+  :show[`Hello ${name}`]
   :show[some_key > 1 ? "X" : " "]
   ```
 
-  Replace the content with a key or JavaScript expression to display.
+  Replace the content with a key, template string, or JavaScript expression to
+  display.
 
   | Input | Description          |
   | ----- | -------------------- |
@@ -816,20 +819,24 @@ Change language and handle translations.
   | locale | Locale code to activate |
 
 - `t`: Output a translated string or expression. Use the optional `count`
-  attribute for pluralization.
+  attribute for pluralization and `fallback` for default text when the
+  translation is missing.
 
   ```md
   :t[ui:apple]{count=2}
   :t[favoriteFruit]
+  :t[missing]{fallback="`Hello ${player}`"}
   ```
 
   Replace `apple` and `ui` with your key and namespace, or supply a JavaScript
-  expression that resolves to one.
+  expression that resolves to one. Wrap fallback text in quotes or backticks to
+  enable string interpolation.
 
-  | Input  | Description                          |
-  | ------ | ------------------------------------ |
-  | ns:key | Namespace and key of the translation |
-  | count  | Optional count for pluralization     |
+  | Input    | Description                          |
+  | -------- | ------------------------------------ |
+  | ns:key   | Namespace and key of the translation |
+  | count    | Optional count for pluralization     |
+  | fallback | Fallback text when key is missing    |
 
 - `translations`: Add a translation.
 

--- a/apps/campfire/src/components/Passage/Show.tsx
+++ b/apps/campfire/src/components/Passage/Show.tsx
@@ -1,6 +1,6 @@
 import { useGameStore } from '@campfire/state/useGameStore'
 import { isRange } from '@campfire/remark-campfire/helpers'
-import { evalExpression } from '@campfire/utils/core'
+import { evalExpression, interpolateString } from '@campfire/utils/core'
 
 interface ShowProps {
   /** Game data key to display */
@@ -20,7 +20,12 @@ export const Show = (props: ShowProps) => {
   const expr = props['data-expr']
   if (expr) {
     try {
-      const result = evalExpression(expr, gameData)
+      let result: unknown
+      if (expr.startsWith('`') && expr.endsWith('`')) {
+        result = interpolateString(expr.slice(1, -1), gameData)
+      } else {
+        result = evalExpression(expr, gameData)
+      }
       if (result == null) return null
       const display = isRange(result) ? result.value : result
       return <span data-testid='show'>{String(display)}</span>

--- a/apps/campfire/src/components/Passage/Translate.tsx
+++ b/apps/campfire/src/components/Passage/Translate.tsx
@@ -14,6 +14,8 @@ interface TranslateProps {
   'data-i18n-count'?: number
   /** Interpolation values for the translation */
   'data-i18n-vars'?: string
+  /** Fallback text when translation key is missing */
+  'data-i18n-fallback'?: string
 }
 
 /**
@@ -27,6 +29,7 @@ export const Translate = (props: TranslateProps) => {
   let ns = props['data-i18n-ns']
   let tKey = props['data-i18n-key']
   const expr = props['data-i18n-expr']
+  const fallback = props['data-i18n-fallback']
   if (!tKey && expr) {
     try {
       const result = evalExpression(expr, gameData)
@@ -43,10 +46,11 @@ export const Translate = (props: TranslateProps) => {
       const msg = `Failed to evaluate translation expression: ${expr}`
       console.error(msg, error)
       addError(msg)
-      return null
+      return fallback ? <span data-testid='translate'>{fallback}</span> : null
     }
   }
-  if (!tKey) return null
+  if (!tKey)
+    return fallback ? <span data-testid='translate'>{fallback}</span> : null
   let vars: Record<string, unknown> = {}
   if (typeof props['data-i18n-vars'] === 'string') {
     try {
@@ -60,7 +64,8 @@ export const Translate = (props: TranslateProps) => {
   }
   const options = {
     ...vars,
-    ...getTranslationOptions({ ns, count: props['data-i18n-count'] })
+    ...getTranslationOptions({ ns, count: props['data-i18n-count'] }),
+    defaultValue: fallback
   }
   return <span data-testid='translate'>{t(tKey, options)}</span>
 }

--- a/apps/campfire/src/components/Passage/__tests__/Passage.i18n.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Passage.i18n.test.tsx
@@ -168,6 +168,28 @@ describe('Passage i18n directives', () => {
     expect(text).toBeInTheDocument()
   })
 
+  it('uses fallback when translation is missing', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        { type: 'text', value: ':t[missing]{fallback="`Hello ${player}`"}' }
+      ]
+    }
+
+    useGameStore.setState({ gameData: { player: 'Sam' } })
+    useStoryDataStore.setState({
+      passages: [passage],
+      currentPassageId: '1'
+    })
+
+    render(<Passage />)
+
+    const text = await screen.findByText('Hello Sam')
+    expect(text).toBeInTheDocument()
+  })
+
   it('resolves translations inside links', async () => {
     const start: Element = {
       type: 'element',

--- a/apps/campfire/src/components/Passage/__tests__/Translate.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Translate.test.tsx
@@ -39,4 +39,9 @@ describe('Translate', () => {
     render(<Translate data-i18n-expr='key' />)
     expect(screen.getByText('Hello')).toBeInTheDocument()
   })
+
+  it('renders fallback when translation key is missing', () => {
+    render(<Translate data-i18n-key='missing' data-i18n-fallback='Hello Sam' />)
+    expect(screen.getByText('Hello Sam')).toBeInTheDocument()
+  })
 })

--- a/apps/campfire/src/utils/core.ts
+++ b/apps/campfire/src/utils/core.ts
@@ -42,6 +42,32 @@ export const clearExpressionCache = (): void => {
 }
 
 /**
+ * Interpolates `${}` placeholders in a template string using the provided scope.
+ *
+ * @param template - String containing `${}` placeholders.
+ * @param scope - Scope object supplying variables for interpolation.
+ * @returns The interpolated string.
+ */
+export const interpolateString = (
+  template: string,
+  scope: Record<string, unknown> = {}
+): string =>
+  template.replace(/\$\{([^}]+)\}/g, (_, expr: string) => {
+    try {
+      const value = evalExpression(expr, scope)
+      const result =
+        value &&
+        typeof value === 'object' &&
+        'value' in (value as Record<string, unknown>)
+          ? (value as Record<string, unknown>).value
+          : value
+      return result != null ? String(result) : ''
+    } catch {
+      return ''
+    }
+  })
+
+/**
  * Converts a CSS style string into a JSX style object.
  *
  * Accepts either a style object or a semicolon-delimited string and

--- a/apps/storybook/src/Translate.stories.tsx
+++ b/apps/storybook/src/Translate.stories.tsx
@@ -31,11 +31,16 @@ export const Examples: StoryObj<typeof Translate> = {
       }
     }
     void init()
-    useGameStore.getState().setGameData({ greet: 'hello' })
+    useGameStore.getState().setGameData({ greet: 'hello', player: 'Sam' })
+    const player = useGameStore.getState().gameData.player as string
     return (
       <div className='flex flex-col gap-2'>
         <Translate data-i18n-key='hello' />
         <Translate data-i18n-expr='greet' />
+        <Translate
+          data-i18n-key='missing'
+          data-i18n-fallback={`Hello, ${player}!`}
+        />
       </div>
     )
   }


### PR DESCRIPTION
## Summary
- allow `:show` directives to interpolate values within template strings
- add optional `fallback` param to `:t` with template string support
- demonstrate translation fallback in storybook

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_68a719f19fa48320a8064679077b6ed1