### PR TITLE
fix: allow unquoted fallback template literals

### DIFF
--- a/README.md
+++ b/README.md
@@ -825,12 +825,13 @@ Change language and handle translations.
   ```md
   :t[ui:apple]{count=2}
   :t[favoriteFruit]
-  :t[missing]{fallback="`Hello ${player}`"}
+  :t[missing]{fallback=`Hello ${player}`}
   ```
 
   Replace `apple` and `ui` with your key and namespace, or supply a JavaScript
-  expression that resolves to one. Wrap fallback text in quotes or backticks to
-  enable string interpolation.
+  expression that resolves to one. The `fallback` attribute accepts either a
+  quoted string or a template literal. For interpolation, use backticks without
+  wrapping the value in quotes.
 
   | Input    | Description                          |
   | -------- | ------------------------------------ |

--- a/apps/campfire/src/components/Passage/__tests__/Passage.i18n.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Passage.i18n.test.tsx
@@ -174,7 +174,7 @@ describe('Passage i18n directives', () => {
       tagName: 'tw-passagedata',
       properties: { pid: '1', name: 'Start' },
       children: [
-        { type: 'text', value: ':t[missing]{fallback="`Hello ${player}`"}' }
+        { type: 'text', value: ':t[missing]{fallback=`Hello ${player}`}' }
       ]
     }
 

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -1437,10 +1437,12 @@ export const useDirectiveHandlers = () => {
       try {
         fallback = match
           ? interpolateString(inner, gameData)
-          : ((): string | undefined => {
-              const val = evalExpression(inner, gameData)
-              return val != null ? String(val) : undefined
-            })()
+          : trimmed.includes('${')
+            ? interpolateString(inner, gameData)
+            : ((): string | undefined => {
+                const val = evalExpression(inner, gameData)
+                return val != null ? String(val) : undefined
+              })()
       } catch (error) {
         const msg = `Failed to evaluate t directive fallback: ${rawFallback}`
         console.error(msg, error)

--- a/apps/campfire/src/remark-campfire/index.ts
+++ b/apps/campfire/src/remark-campfire/index.ts
@@ -1,5 +1,5 @@
 import { visit } from 'unist-util-visit'
-import type { Root, Parent, Paragraph, Text } from 'mdast'
+import type { Root, Parent, Paragraph, Text, InlineCode } from 'mdast'
 import type { Node, Data } from 'unist'
 import type {
   ContainerDirective,
@@ -103,16 +103,37 @@ const parseFallbackAttributes = (
   index: number
 ) => {
   const next = parent.children[index + 1]
-  if (!next || next.type !== 'text') return
-  const textNode = next as Text
-  const match = textNode.value.match(/^\{([\w-]+)=([^}]*)\}$/)
-  if (match) {
-    const [, name, raw] = match
-    if (/^[\w\s.,'"`\[\]-]*$/.test(raw)) {
-      directive.attributes = { [name]: raw }
-      parent.children.splice(index + 1, 1)
-    } else {
-      directive.attributes = undefined
+  if (!next) return
+  if (next.type === 'text') {
+    const textNode = next as Text
+    const match = textNode.value.match(/^\{([\w-]+)=([^}]*)\}$/)
+    if (match) {
+      const [, name, raw] = match
+      if (/^[\w\s.,'"`{}\[\]$!-]*$/.test(raw)) {
+        directive.attributes = { [name]: raw }
+        parent.children.splice(index + 1, 1)
+      } else {
+        directive.attributes = undefined
+      }
+      return
+    }
+    const open = textNode.value.match(/^\{([\w-]+)=$/)
+    const codeNode = parent.children[index + 2]
+    const close = parent.children[index + 3]
+    if (
+      open &&
+      codeNode &&
+      codeNode.type === 'inlineCode' &&
+      close &&
+      close.type === 'text' &&
+      close.value === '}'
+    ) {
+      const [, name] = open
+      const raw = (codeNode as InlineCode).value
+      if (/^[\w\s.,'"`{}\[\]$!-]*$/.test(raw)) {
+        directive.attributes = { [name]: raw }
+      }
+      parent.children.splice(index + 1, 3)
     }
   }
 }


### PR DESCRIPTION
## Summary
- support template literal fallbacks without surrounding quotes
- document interpolation using backticks for t directive fallback
- test fallback attribute using unquoted template literal

## Testing
- `bun x prettier --write apps/campfire/src/remark-campfire/index.ts apps/campfire/src/hooks/useDirectiveHandlers.ts apps/campfire/src/components/Passage/__tests__/Passage.i18n.test.tsx README.md`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_68a76817f1b4832082317e613fbce489