### PR TITLE
fix(passage): reset deck state on passage change

### DIFF
--- a/apps/campfire/src/components/Passage/Passage.tsx
+++ b/apps/campfire/src/components/Passage/Passage.tsx
@@ -15,6 +15,7 @@ import {
   useStoryDataStore,
   type StoryDataState
 } from '@campfire/state/useStoryDataStore'
+import { useDeckStore } from '@campfire/state/useDeckStore'
 import { LinkButton } from '@campfire/components/Passage/LinkButton'
 import { TriggerButton } from '@campfire/components/Passage/TriggerButton'
 import { If } from '@campfire/components/Passage/If'
@@ -140,6 +141,7 @@ export const Passage = () => {
   const storyData = useStoryDataStore(
     (state: StoryDataState) => state.storyData
   )
+  const resetDeck = useDeckStore(state => state.reset)
   const [content, setContent] = useState<ComponentChild | null>(null)
   const prevPassageId = useRef<string | undefined>(undefined)
 
@@ -153,6 +155,7 @@ export const Passage = () => {
     if (isNewPassage) {
       prevPassageId.current = id
       clearTitleOverride()
+      resetDeck()
     }
     const name =
       typeof passage.properties?.name === 'string'
@@ -173,7 +176,7 @@ export const Passage = () => {
         document.title = title
       }
     }
-  }, [passage, storyData])
+  }, [passage, storyData, resetDeck])
 
   useEffect(() => {
     const controller = new AbortController()

--- a/apps/campfire/src/components/Passage/__tests__/Passage.deckReset.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Passage.deckReset.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach } from 'bun:test'
+import { render, screen, act } from '@testing-library/preact'
+import i18next from 'i18next'
+import { initReactI18next } from 'react-i18next'
+import type { Element } from 'hast'
+import { Passage } from '@campfire/components/Passage/Passage'
+import { useStoryDataStore } from '@campfire/state/useStoryDataStore'
+import { useDeckStore } from '@campfire/state/useDeckStore'
+import { resetStores } from '@campfire/test-utils/helpers'
+import { StubAnimation } from '@campfire/test-utils/stub-animation'
+
+describe('Passage deck state', () => {
+  beforeEach(async () => {
+    document.body.innerHTML = ''
+    resetStores()
+    HTMLElement.prototype.animate = () =>
+      new StubAnimation() as unknown as Animation
+    if (!i18next.isInitialized) {
+      await i18next.use(initReactI18next).init({ lng: 'en-US', resources: {} })
+    } else {
+      await i18next.changeLanguage('en-US')
+      i18next.services.resourceStore.data = {}
+    }
+  })
+
+  it('resets deck step when navigating between passages', async () => {
+    const passage1: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value: `:::deck{size='400x300'}\n:::slide\n:::reveal{at=0}\nFirst deck 1\n:::\n:::reveal{at=1}\nFirst deck 2\n:::\n:::\n:::\n`
+        }
+      ]
+    }
+    const passage2: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '2', name: 'Second' },
+      children: [
+        {
+          type: 'text',
+          value: `:::deck{size='400x300'}\n:::slide\n:::reveal{at=0}\nSecond deck 1\n:::\n:::reveal{at=1}\nSecond deck 2\n:::\n:::\n:::\n`
+        }
+      ]
+    }
+
+    useStoryDataStore.setState({
+      passages: [passage1, passage2],
+      currentPassageId: '1'
+    })
+
+    const { rerender } = render(<Passage />)
+
+    await screen.findByText('First deck 1')
+    act(() => {
+      useDeckStore.getState().next()
+    })
+    await screen.findByText('First deck 2')
+
+    act(() => {
+      useStoryDataStore.setState({ currentPassageId: '2' })
+    })
+    rerender(<Passage />)
+
+    await screen.findByText('Second deck 1')
+    expect(screen.queryByText('Second deck 2')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- reset deck store when passage changes to avoid carrying over reveal steps
- add regression test for deck state across passages

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_68a787bed2708320883cdc06f917cb0b