### PR TITLE
feat: use bracket syntax for if directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The value is currently :show[testRange]
 :setRange[testRange=(testRange.value+1)]
 :::
 
-:::if{testRange.value === testRange.max}
+:::if[testRange.value === testRange.max]
 [[Next Page->Next]]
 :::
 ```
@@ -394,7 +394,7 @@ Run content only when conditions hold.
   Basic truthy check:
 
   ```md
-  :::if{some_key}
+  :::if[some_key]
   CONTENT WHEN `some_key` IS TRUTHY
   :::
   ```
@@ -402,7 +402,7 @@ Run content only when conditions hold.
   Negation check:
 
   ```md
-  :::if{!some_key}
+  :::if[!some_key]
   CONTENT WHEN `some_key` IS FALSY
   :::
   ```
@@ -410,7 +410,7 @@ Run content only when conditions hold.
   Double negation for boolean coercion:
 
   ```md
-  :::if{!!some_key}
+  :::if[!!some_key]
   CONTENT WHEN `some_key` COERCES TO TRUE
   :::
   ```
@@ -418,7 +418,7 @@ Run content only when conditions hold.
   Comparison operators:
 
   ```md
-  :::if{key_a < key_b}
+  :::if[key_a < key_b]
   CONTENT WHEN `key_a` IS LESS THAN `key_b`
   :::
   ```
@@ -426,7 +426,7 @@ Run content only when conditions hold.
   Type checking:
 
   ```md
-  :::if{typeof key_a !== "string"}
+  :::if[typeof key_a !== "string"]
   CONTENT WHEN `key_a` IS NOT A STRING
   :::
   ```
@@ -434,7 +434,7 @@ Run content only when conditions hold.
   Using with else block:
 
   ```md
-  :::if{some_key}
+  :::if[some_key]
   TRUTHY CONTENT
   :::else
   FALLBACK CONTENT
@@ -444,7 +444,7 @@ Run content only when conditions hold.
   Combining with other directives and links:
 
   ```md
-  :::if{has_key}
+  :::if[has_key]
   You unlock the door.
   :set[door_opened=true]
   [[Enter->Hallway]]

--- a/apps/campfire/src/components/Campfire/__tests__/Campfire.test.tsx
+++ b/apps/campfire/src/components/Campfire/__tests__/Campfire.test.tsx
@@ -83,11 +83,11 @@ describe('Story', () => {
 :::set[open=false]
 :::
 
-:::if{!open}
+:::if[!open]
 not open
 :::
 
-:::if{open}
+:::if[open]
 is open!
 :::</tw-passagedata>
 </tw-storydata>
@@ -109,7 +109,7 @@ is open!
   <tw-passagedata pid="1" name="Start">:::set[open=true]
 :::
 
-:::if{open}
+:::if[open]
 :::trigger{label="open"}
 :::set[clicked=true]
 :::
@@ -135,14 +135,14 @@ is open!
   <tw-passagedata pid="1" name="Start">:::set[open=true]
 :::
 
-:::if{!open}
+:::if[!open]
 not open
 :::</tw-passagedata>
 </tw-storydata>
     `
     render(<Campfire />)
     await waitFor(() => expect(screen.queryByText('not open')).toBeNull())
-    expect(screen.queryByText(':::if{!open}')).toBeNull()
+    expect(screen.queryByText(':::if[!open]')).toBeNull()
   })
 
   it('does not render ::: when if has no else', async () => {
@@ -151,7 +151,7 @@ not open
   <tw-passagedata pid="1" name="Start">:::set[open=true]
 :::
 
-:::if{open}
+:::if[open]
 :::set[done=true]
 :::
 :::
@@ -171,7 +171,7 @@ not open
   <tw-passagedata pid="1" name="Start">:::set[open=true]
 :::
 
-:::if{open}
+:::if[open]
 :::set[yes=true]
 :::
 :::else
@@ -193,7 +193,7 @@ not open
   <tw-passagedata pid="1" name="Start">:::set[open=false]
 :::
 
-:::if{open}
+:::if[open]
 :::set[yes=true]
 :::
 :::else

--- a/apps/campfire/src/components/DebugWindow/index.tsx
+++ b/apps/campfire/src/components/DebugWindow/index.tsx
@@ -65,13 +65,13 @@ const normalizeDirectiveIndentation = (input: string): string =>
     .replace(new RegExp(`^[ ]{4,}(?=(${DIRECTIVE_MARKER_PATTERN}))`, 'gm'), '')
 
 /**
- * Converts legacy if directive syntax using braces into label-based
+ * Converts legacy if directive syntax using braces into bracket-based
  * directives.
  *
  * @param input - Raw passage text.
  * @returns Passage text with if directives normalized.
  */
-const normalizeIfDirectives = (input: string): string =>
+const normalizeLegacyIfDirectives = (input: string): string =>
   input
     .split('\n')
     .map(line => {
@@ -193,7 +193,7 @@ export const DebugWindow = () => {
         setJsxPassage('')
         return
       }
-      const normalized = normalizeIfDirectives(
+      const normalized = normalizeLegacyIfDirectives(
         normalizeDirectiveIndentation(rawPassage)
       )
       const file = await processor.process(normalized)

--- a/apps/campfire/src/components/Passage/Passage.tsx
+++ b/apps/campfire/src/components/Passage/Passage.tsx
@@ -47,7 +47,7 @@ const normalizeDirectiveIndentation = (input: string): string =>
     .replace(new RegExp(`^[ ]{4,}(?=(${DIRECTIVE_MARKER_PATTERN}))`, 'gm'), '')
 
 /**
- * Converts legacy if directive syntax using braces into label-based directives.
+ * Converts legacy if directive syntax using braces into bracket-based directives.
  *
  * Remark's directive parser only accepts attribute names with characters valid
  * in HTML. Expressions like `!open` or `a < b` therefore cause the `:::if`
@@ -56,7 +56,7 @@ const normalizeDirectiveIndentation = (input: string): string =>
  * characters are allowed, enabling complex JavaScript conditions. Supports
  * directives with leading whitespace and expressions containing nested braces.
  */
-const normalizeIfDirectives = (input: string): string =>
+const normalizeLegacyIfDirectives = (input: string): string =>
   input
     .split('\n')
     .map(line => {
@@ -193,7 +193,7 @@ export const Passage = () => {
             : ''
         )
         .join('')
-      const normalized = normalizeIfDirectives(
+      const normalized = normalizeLegacyIfDirectives(
         normalizeDirectiveIndentation(text)
       )
       if (controller.signal.aborted) return

--- a/apps/campfire/src/components/Passage/__tests__/If.directive.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/If.directive.test.tsx
@@ -20,7 +20,7 @@ describe('If directive', () => {
         {
           type: 'text',
           value:
-            ':::if{true}\n  :::trigger{label="One"}\n  :::\n  :::trigger{label="Two"}\n  :::\n:::'
+            ':::if[true]\n  :::trigger{label="One"}\n  :::\n  :::trigger{label="Two"}\n  :::\n:::'
         }
       ]
     }
@@ -46,7 +46,7 @@ describe('If directive', () => {
         {
           type: 'text',
           value:
-            ':::if{true}\n  :::trigger{label="One"}\n  :::\n  :::trigger{label="Two"}\n  :::\n:::'
+            ':::if[true]\n  :::trigger{label="One"}\n  :::\n  :::trigger{label="Two"}\n  :::\n:::'
         }
       ]
     }
@@ -70,7 +70,7 @@ describe('If directive', () => {
         {
           type: 'text',
           value:
-            ':::if{false}\n  :::trigger{label="One"}\n  :::\n  :::trigger{label="Two"}\n  :::\n:::'
+            ':::if[false]\n  :::trigger{label="One"}\n  :::\n  :::trigger{label="Two"}\n  :::\n:::'
         }
       ]
     }

--- a/apps/campfire/src/components/Passage/__tests__/Passage.basic.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Passage.basic.test.tsx
@@ -392,7 +392,7 @@ describe('Passage rendering and navigation', () => {
       children: [
         {
           type: 'text',
-          value: ':include["Second"]\n:::if{true}\nAfter\n:::'
+          value: ':include["Second"]\n:::if[true]\nAfter\n:::'
         }
       ]
     }

--- a/apps/campfire/src/hooks/__tests__/deckDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/deckDirective.test.tsx
@@ -107,7 +107,7 @@ describe('deck directive', () => {
   })
 
   it('does not render stray colons when slide contains directives', () => {
-    const md = `:::deck\n:::slide\n:::if{true}\nHi\n:::\n:::\n:::\n`
+    const md = `:::deck\n:::slide\n:::if[true]\nHi\n:::\n:::\n:::\n`
     render(<MarkdownRunner markdown={md} />)
     const text = getText(output)
     expect(text).not.toContain(':::')

--- a/apps/campfire/src/hooks/__tests__/revealDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/revealDirective.test.tsx
@@ -60,7 +60,7 @@ describe('reveal directive', () => {
   })
 
   it('does not render stray colons when reveal contains directives', () => {
-    const md = `:::reveal\n:::if{true}\nHi\n:::\n:::\n`
+    const md = `:::reveal\n:::if[true]\nHi\n:::\n:::\n`
     render(<MarkdownRunner markdown={md} />)
     const getText = (node: any): string => {
       if (!node) return ''

--- a/apps/campfire/src/hooks/__tests__/shapeDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/shapeDirective.test.tsx
@@ -66,7 +66,7 @@ describe('shape directive', () => {
   })
 
   it('does not render stray colons after shape blocks', () => {
-    const md = ':shape{type="rect"}\n:::if{true}\nHi\n:::\n'
+    const md = ':shape{type="rect"}\n:::if[true]\nHi\n:::\n'
     render(<MarkdownRunner markdown={md} />)
     const text = document.body.textContent || ''
     expect(text).not.toContain(':::')

--- a/apps/storybook/src/Directives.stories.tsx
+++ b/apps/storybook/src/Directives.stories.tsx
@@ -21,7 +21,7 @@ export const Trigger: StoryObj = {
   :set[test=false]
 :::
 
-:::if{!test}
+:::if[!test]
 You clicked the button!
 :::
 

--- a/apps/storybook/src/ForDirective.stories.tsx
+++ b/apps/storybook/src/ForDirective.stories.tsx
@@ -46,7 +46,7 @@ export const Fruits: StoryObj = {
 
 :::for[fruit in fruits]
 
-  :::if{fruit !== "banana"}
+  :::if[fruit !== "banana"]
 
   - :show[fruit]
 

--- a/apps/storybook/src/IfDirective.stories.tsx
+++ b/apps/storybook/src/IfDirective.stories.tsx
@@ -20,7 +20,7 @@ export const Truthy: StoryObj = {
           {`
 :set[flag=true]
 
-:::if{flag}
+:::if[flag]
 Flag is true
 :::else
 Flag is false
@@ -46,7 +46,7 @@ export const Falsy: StoryObj = {
           {`
 :set[flag=false]
 
-:::if{flag}
+:::if[flag]
 Flag is true
 :::else
 Flag is false


### PR DESCRIPTION
## Summary
- switch `if` directive to square bracket syntax
- handle legacy curly-brace `if` directives via `normalizeLegacyIfDirectives`
- update docs, stories, and tests for bracketed `if`

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_68a7d25cd3a88320b200ccce6c525393