### PR TITLE
fix: parse reveal transition attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,14 +638,28 @@ Control the flow between passages or how they reveal.
   :::
   ```
 
-  | Input             | Description                          |
-  | ----------------- | ------------------------------------ |
-  | at                | Deck step when content reveals       |
-  | exitAt            | Deck step when content hides         |
-  | enter             | Enter animation key                  |
-  | exit              | Exit animation key                   |
-  | interruptBehavior | How to handle interrupted animations |
-  | from              | Name of a reveal preset to apply     |
+  Customize animations by passing transition objects to the `enter` and `exit`
+  attributes. Objects may be provided without quotes; wrapping them in quotes
+  leaves the value as a string:
+
+  ```md
+  :::deck
+  :::slide
+  :::reveal{at=0 enter={type:"slide",dir:"left",duration:300} exit={type:"fade",duration:150}}
+  Revealed with custom transitions
+  :::
+  :::
+  :::
+  ```
+
+  | Input             | Description                                             |
+  | ----------------- | ------------------------------------------------------- |
+  | at                | Deck step when content reveals                          |
+  | exitAt            | Deck step when content hides                            |
+  | enter             | Enter transition name or `{type, dir, duration}` object |
+  | exit              | Exit transition name or `{type, dir, duration}` object  |
+  | interruptBehavior | How to handle interrupted animations                    |
+  | from              | Name of a reveal preset to apply                        |
 
 - `text`: Position typographic content within a slide.
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Operations that set, update, or remove scalar values.
 
   Replace `key` with the key name and `value` with the number, string, or
   expression to store. Quoted values are treated as strings, `true`/`false` as
-  booleans, unquoted values wrapped in `{}` as objects, purely numeric values as numbers
+  booleans, values wrapped in `{}` as objects, purely numeric values as numbers
   and any other value is evaluated as an expression or state reference.
 
   | Input | Description                  |
@@ -141,6 +141,7 @@ Operations that set, update, or remove scalar values.
   :set[health=100]
   :set[playerName="John"]
   :set[isActive=true]
+  :set[player={name: "Ada", level: 1}]
   ```
 
 - `setOnce`: Set a key only if it has not been set. This directive is leaf-only

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Operations that set, update, or remove scalar values.
 
   Replace `key` with the key name and `value` with the number, string, or
   expression to store. Quoted values are treated as strings, `true`/`false` as
-  booleans, values wrapped in `{}` as objects, purely numeric values as numbers
+  booleans, unquoted values wrapped in `{}` as objects, purely numeric values as numbers
   and any other value is evaluated as an expression or state reference.
 
   | Input | Description                  |
@@ -639,14 +639,13 @@ Control the flow between passages or how they reveal.
   ```
 
   Customize animations by passing transition objects to the `enter` and `exit`
-  attributes. To avoid parsing issues, wrap object values in **single quotes**.
-  The quotes are removed before parsing, so the value becomes an object rather
-  than a string:
+  attributes. Unquoted object values are parsed directly, while quoted values
+  remain strings:
 
   ```md
   :::deck
   :::slide
-  :::reveal{at=0 enter='{"type":"slide","dir":"left","duration":300}' exit='{"type":"fade","duration":150}'}
+  :::reveal{at=0 enter={type:'slide',dir:'left',duration:300} exit={type:'fade',duration:150}}
   Revealed with custom transitions
   :::
   :::

--- a/README.md
+++ b/README.md
@@ -639,13 +639,14 @@ Control the flow between passages or how they reveal.
   ```
 
   Customize animations by passing transition objects to the `enter` and `exit`
-  attributes. Objects may be provided without quotes; wrapping them in quotes
-  leaves the value as a string:
+  attributes. To avoid parsing issues, wrap object values in **single quotes**.
+  The quotes are removed before parsing, so the value becomes an object rather
+  than a string:
 
   ```md
   :::deck
   :::slide
-  :::reveal{at=0 enter={type:"slide",dir:"left",duration:300} exit={type:"fade",duration:150}}
+  :::reveal{at=0 enter='{"type":"slide","dir":"left","duration":300}' exit='{"type":"fade","duration":150}'}
   Revealed with custom transitions
   :::
   :::

--- a/apps/campfire/src/__tests__/directiveUtils.test.ts
+++ b/apps/campfire/src/__tests__/directiveUtils.test.ts
@@ -3,6 +3,7 @@ import type { DirectiveNode } from '@campfire/utils/directiveUtils'
 import type { Parent } from 'mdast'
 import {
   parseTypedValue,
+  parseObjectLiteral,
   extractKeyValue,
   applyKeyValue
 } from '@campfire/utils/directiveUtils'
@@ -29,6 +30,13 @@ describe('parseTypedValue', () => {
 
   it('treats quoted objects as strings', () => {
     expect(parseTypedValue('"{a:1}"')).toBe('{a:1}')
+  })
+})
+
+describe('parseObjectLiteral', () => {
+  it('parses colon-delimited objects without braces', () => {
+    const obj = parseObjectLiteral('a:1, b:"two"')
+    expect(obj).toEqual({ a: 1, b: 'two' })
   })
 })
 

--- a/apps/campfire/src/__tests__/directiveUtils.test.ts
+++ b/apps/campfire/src/__tests__/directiveUtils.test.ts
@@ -26,6 +26,10 @@ describe('parseTypedValue', () => {
     expect(obj.a).toBe(1)
     expect(obj.b).toBe('two')
   })
+
+  it('treats quoted objects as strings', () => {
+    expect(parseTypedValue('"{a:1}"')).toBe('{a:1}')
+  })
 })
 
 describe('extractKeyValue and applyKeyValue', () => {

--- a/apps/campfire/src/hooks/__tests__/revealDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/revealDirective.test.tsx
@@ -45,24 +45,6 @@ describe('reveal directive', () => {
     expect(reveal.props['data-test']).toBe('ok')
   })
 
-  it('parses object transition definitions', () => {
-    const md =
-      ':::reveal{enter=\'{"type":"slide","dir":"left","duration":200}\' exit=\'{"type":"fade","duration":150}\'}\nHi\n:::'
-    render(<MarkdownRunner markdown={md} />)
-    const getReveal = (node: any): any => {
-      if (Array.isArray(node)) return getReveal(node[0])
-      if (node?.type === Fragment) return getReveal(node.props.children)
-      return node
-    }
-    const reveal = getReveal(output)
-    expect(reveal.props.enter).toEqual({
-      type: 'slide',
-      dir: 'left',
-      duration: 200
-    })
-    expect(reveal.props.exit).toEqual({ type: 'fade', duration: 150 })
-  })
-
   it('applies reveal presets with overrides', () => {
     const md =
       ':preset{type="reveal" name="fade" at=2}\n:::reveal{from="fade" exitAt=3}\nHi\n:::'

--- a/apps/campfire/src/hooks/__tests__/revealDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/revealDirective.test.tsx
@@ -39,10 +39,28 @@ describe('reveal directive', () => {
     expect(reveal.type).toBe(SlideReveal)
     expect(reveal.props.at).toBe(1)
     expect(reveal.props.exitAt).toBe(3)
-    expect(reveal.props.enter).toBe('slide')
-    expect(reveal.props.exit).toBe('fade')
+    expect(reveal.props.enter).toEqual({ type: 'slide' })
+    expect(reveal.props.exit).toEqual({ type: 'fade' })
     expect(reveal.props.interruptBehavior).toBe('cancel')
     expect(reveal.props['data-test']).toBe('ok')
+  })
+
+  it('parses object transition definitions', () => {
+    const md =
+      ':::reveal{enter=\'{"type":"slide","dir":"left","duration":200}\' exit=\'{"type":"fade","duration":150}\'}\nHi\n:::'
+    render(<MarkdownRunner markdown={md} />)
+    const getReveal = (node: any): any => {
+      if (Array.isArray(node)) return getReveal(node[0])
+      if (node?.type === Fragment) return getReveal(node.props.children)
+      return node
+    }
+    const reveal = getReveal(output)
+    expect(reveal.props.enter).toEqual({
+      type: 'slide',
+      dir: 'left',
+      duration: 200
+    })
+    expect(reveal.props.exit).toEqual({ type: 'fade', duration: 150 })
   })
 
   it('applies reveal presets with overrides', () => {

--- a/apps/campfire/src/hooks/__tests__/revealDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/revealDirective.test.tsx
@@ -45,6 +45,23 @@ describe('reveal directive', () => {
     expect(reveal.props['data-test']).toBe('ok')
   })
 
+  it('parses quoted JSON transition objects', () => {
+    const md = `:::reveal{at=0 enter='{"type":"slide","dir":"left","duration":300}' exit='{"type":"fade","duration":150}'}\nHi\n:::`
+    render(<MarkdownRunner markdown={md} />)
+    const getReveal = (node: any): any => {
+      if (Array.isArray(node)) return getReveal(node[0])
+      if (node?.type === Fragment) return getReveal(node.props.children)
+      return node
+    }
+    const reveal = getReveal(output)
+    expect(reveal.props.enter).toEqual({
+      type: 'slide',
+      dir: 'left',
+      duration: 300
+    })
+    expect(reveal.props.exit).toEqual({ type: 'fade', duration: 150 })
+  })
+
   it('applies reveal presets with overrides', () => {
     const md =
       ':preset{type="reveal" name="fade" at=2}\n:::reveal{from="fade" exitAt=3}\nHi\n:::'

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -43,6 +43,7 @@ import {
 } from '@campfire/utils/math'
 import {
   parseTypedValue,
+  parseObjectLiteral,
   extractKeyValue,
   replaceWithIndentation,
   expandIndentedCode,
@@ -1951,19 +1952,8 @@ export const useDirectiveHandlers = () => {
       const quoted = typeof raw === 'string' && QUOTE_PATTERN.test(raw.trim())
       const looksObject = trimmed.startsWith('{') || trimmed.includes(':')
       if (!quoted && looksObject) {
-        const wrapped = trimmed.startsWith('{') ? trimmed : `{${trimmed}}`
-        try {
-          return JSON.parse(wrapped) as Transition
-        } catch {
-          const parsed = parseTypedValue(
-            wrapped,
-            {},
-            { eval: false }
-          ) as unknown
-          if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-            return parsed as Transition
-          }
-        }
+        const parsed = parseObjectLiteral(trimmed)
+        if (parsed) return parsed as unknown as Transition
       }
       if (quoted && looksObject) return trimmed
       return { type: trimmed as Transition['type'] }

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -1936,19 +1936,21 @@ export const useDirectiveHandlers = () => {
 
   /**
    * Parses a transition attribute value into a Transition object.
+   * Returns the raw string when quoted input resembles an object.
    *
    * @param value - Raw transition value from attributes.
-   * @returns Parsed transition configuration or undefined.
+   * @returns Parsed transition configuration, the raw string, or undefined.
    */
   const parseTransition = (
     value: unknown,
     raw?: unknown
-  ): Transition | undefined => {
+  ): Transition | string | undefined => {
     if (!value) return undefined
     if (typeof value === 'string') {
       const trimmed = value.trim()
       const quoted = typeof raw === 'string' && QUOTE_PATTERN.test(raw.trim())
-      if (!quoted && (trimmed.startsWith('{') || trimmed.includes(':'))) {
+      const looksObject = trimmed.startsWith('{') || trimmed.includes(':')
+      if (!quoted && looksObject) {
         const wrapped = trimmed.startsWith('{') ? trimmed : `{${trimmed}}`
         try {
           return JSON.parse(wrapped) as Transition
@@ -1963,6 +1965,7 @@ export const useDirectiveHandlers = () => {
           }
         }
       }
+      if (quoted && looksObject) return trimmed
       return { type: trimmed as Transition['type'] }
     }
     return value as Transition

--- a/apps/campfire/src/remark-campfire/__tests__/extractAttributes.test.ts
+++ b/apps/campfire/src/remark-campfire/__tests__/extractAttributes.test.ts
@@ -81,4 +81,11 @@ describe('extractAttributes', () => {
     })
     expect(result.label).toBe('Label text')
   })
+
+  it('parses unquoted object attributes', () => {
+    const directive = createDirective({ obj: "x:1,y:'two'" })
+    const schema = { obj: { type: 'object' } } as const
+    const result = extractAttributes(directive, undefined, undefined, schema)
+    expect((result.attrs as any).obj).toEqual({ x: 1, y: 'two' })
+  })
 })

--- a/apps/campfire/src/remark-campfire/index.ts
+++ b/apps/campfire/src/remark-campfire/index.ts
@@ -47,7 +47,7 @@ export interface LangDirective extends Omit<TextDirective, 'attributes'> {
 }
 
 /** RegExp matching safe characters in directive attribute values. */
-const SAFE_ATTR_VALUE_PATTERN = /^[\w\s.,'"`{}\[\]$!-]*$/
+const SAFE_ATTR_VALUE_PATTERN = /^[\w\s.,:'"`{}\[\]$!-]*$/
 
 /**
  * Data structure for paragraph nodes that may include custom hast element

--- a/apps/campfire/src/utils/directiveUtils.ts
+++ b/apps/campfire/src/utils/directiveUtils.ts
@@ -260,19 +260,7 @@ export const parseAttributeValue = (
           !Array.isArray(evaluated)
         )
           return evaluated
-        const trimmed = raw.trim()
-        const wrapped = trimmed.startsWith('{') ? trimmed : `{${trimmed}}`
-        try {
-          const json = JSON.parse(wrapped)
-          if (json && typeof json === 'object' && !Array.isArray(json))
-            return json
-        } catch {
-          /* fallback to manual parsing */
-        }
-        const parsed = parseTypedValue(wrapped, state, { eval: false })
-        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed))
-          return parsed
-        return undefined
+        return parseObjectLiteral(raw, state)
       }
       return undefined
     }
@@ -426,6 +414,32 @@ export const extractAttributes = <S extends AttributeSchema>(
     valid: errors.length === 0,
     errors
   }
+}
+
+/**
+ * Parses a string containing an object literal. Supports both JSON-style
+ * objects and colon-delimited forms without surrounding braces.
+ *
+ * @param value - Raw string to parse.
+ * @param state - Optional context for nested value parsing.
+ * @returns Parsed object or undefined when parsing fails.
+ */
+export const parseObjectLiteral = (
+  value: string,
+  state: Record<string, unknown> = {}
+): Record<string, unknown> | undefined => {
+  const trimmed = value.trim()
+  const wrapped = trimmed.startsWith('{') ? trimmed : `{${trimmed}}`
+  try {
+    const json = JSON.parse(wrapped)
+    if (json && typeof json === 'object' && !Array.isArray(json)) return json
+  } catch {
+    /* fallback to manual parsing */
+  }
+  const parsed = parseTypedValue(wrapped, state, { eval: false })
+  return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+    ? (parsed as Record<string, unknown>)
+    : undefined
 }
 
 /**


### PR DESCRIPTION
## Summary
- document how to customize `reveal` directive transitions
- parse `reveal` enter/exit attributes into transition objects so custom animations work
- add tests for object transition definitions

## Testing
- `bun x prettier --write .`
- `bun tsc && echo 'tsc completed'`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_68a8b3ee6820832093b996d3b6c58120