### PR TITLE
refactor: centralize RangeValue type

### DIFF
--- a/apps/campfire/src/state/utils.ts
+++ b/apps/campfire/src/state/utils.ts
@@ -3,6 +3,7 @@ import type { Draft } from 'immer'
 import type { StoreApi } from 'zustand'
 import rfdc from 'rfdc'
 import { clamp } from '@campfire/utils/directiveUtils'
+import type { RangeValue } from '@campfire/utils/math'
 
 /**
  * Zustand's `set` function signature.
@@ -21,13 +22,6 @@ export const setImmer =
   <T extends object>(set: SetFn<T>) =>
   (fn: (draft: Draft<T>) => void) =>
     set(produce<T>(fn))
-
-/** Range value representation */
-export interface RangeValue {
-  min: number
-  max: number
-  value: number
-}
 
 /** Options for setting values */
 export interface SetOptions {
@@ -291,3 +285,4 @@ export class StateManager<T extends Record<string, unknown>> {
 }
 
 export type { StateManager as StateManagerType }
+export type { RangeValue } from '@campfire/utils/math'


### PR DESCRIPTION
## Summary
- remove local RangeValue interface from state utilities
- use shared RangeValue type from `@campfire/utils/math`

## Testing
- `bun tsc`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_68a9c5edfc748320bec5a0f79b8ce631