### PR TITLE
refactor: unify DirectiveNode type

### DIFF
--- a/apps/campfire/src/remark-campfire/__tests__/attributes.test.ts
+++ b/apps/campfire/src/remark-campfire/__tests__/attributes.test.ts
@@ -2,14 +2,10 @@ import { describe, it, expect } from 'bun:test'
 import { unified } from 'unified'
 import remarkParse from 'remark-parse'
 import remarkDirective from 'remark-directive'
-import remarkCampfire, { type DirectiveHandler } from '../index'
-import type {
-  ContainerDirective,
-  LeafDirective,
-  TextDirective
-} from 'mdast-util-directive'
-
-type DirectiveNode = ContainerDirective | LeafDirective | TextDirective
+import remarkCampfire, {
+  type DirectiveHandler,
+  type DirectiveNode
+} from '../index'
 
 /**
  * Processes markdown containing a directive and returns the directive node.

--- a/apps/campfire/src/utils/directiveUtils.ts
+++ b/apps/campfire/src/utils/directiveUtils.ts
@@ -5,17 +5,16 @@ import remarkGfm from 'remark-gfm'
 import remarkDirective from 'remark-directive'
 import remarkCampfire, {
   remarkCampfireIndentation,
-  type DirectiveHandler
+  type DirectiveHandler,
+  type DirectiveNode
 } from '@campfire/remark-campfire'
 import { toString } from 'mdast-util-to-string'
 import type { Parent, Root, RootContent, Code, Paragraph } from 'mdast'
-import type {
-  ContainerDirective,
-  LeafDirective,
-  TextDirective
-} from 'mdast-util-directive'
+import type { ContainerDirective } from 'mdast-util-directive'
 import type { Node } from 'unist'
 import type { RangeValue } from '@campfire/utils/math'
+
+export type { DirectiveNode }
 
 /**
  * Shared remark parser for expanding indented code blocks.
@@ -34,8 +33,6 @@ export {
   parseRange
 } from '@campfire/utils/math'
 export type { RangeValue } from '@campfire/utils/math'
-
-export type DirectiveNode = ContainerDirective | LeafDirective | TextDirective
 
 interface ParagraphLabel extends Paragraph {
   data: { directiveLabel: true }


### PR DESCRIPTION
## Summary
- expose shared DirectiveNode type from remark-campfire
- use shared DirectiveNode in directive utilities and tests

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_68a9cfc65ef08320800dd9618bddb33b