### PR TITLE
refactor: share HAST metadata interface

### DIFF
--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -21,6 +21,7 @@ import type {
   Properties,
   Text as HastText
 } from 'hast'
+import type { HastData } from '@campfire/types/hast'
 import type { ContainerDirective } from 'mdast-util-directive'
 import { useStoryDataStore } from '@campfire/state/useStoryDataStore'
 import { type Checkpoint, useGameStore } from '@campfire/state/useGameStore'
@@ -909,14 +910,8 @@ export const useDirectiveHandlers = () => {
      * @param node - The node to inspect.
      * @returns The directive's hName and hProperties if available.
      */
-    const getNodeData = (
-      node: unknown
-    ): { hName?: string; hProperties?: Record<string, unknown> } =>
-      (
-        node as {
-          data?: { hName?: string; hProperties?: Record<string, unknown> }
-        }
-      ).data || {}
+    const getNodeData = (node: unknown): HastData =>
+      (node as { data?: HastData }).data || {}
 
     const output: RootContent[] = []
     for (const item of items) {

--- a/apps/campfire/src/remark-campfire/index.ts
+++ b/apps/campfire/src/remark-campfire/index.ts
@@ -1,6 +1,7 @@
 import { visit } from 'unist-util-visit'
 import type { Root, Parent, Paragraph, Text, InlineCode } from 'mdast'
-import type { Node, Data } from 'unist'
+import type { Node } from 'unist'
+import type { HastData } from '@campfire/types/hast'
 import type {
   ContainerDirective,
   LeafDirective,
@@ -49,16 +50,8 @@ export interface LangDirective extends Omit<TextDirective, 'attributes'> {
 /** RegExp matching safe characters in directive attribute values. */
 const SAFE_ATTR_VALUE_PATTERN = /^[\w\s.,'"`{}\[\]$!-]*$/
 
-/**
- * Data structure for paragraph nodes that may include custom hast element
- * metadata.
- */
-interface ParagraphData extends Data {
-  /** Custom element name applied by rehype */
-  hName?: string
-}
-
-type ParagraphWithData = Paragraph & { data?: ParagraphData }
+/** Paragraph node with optional HAST metadata. */
+type ParagraphWithData = Paragraph & { data?: HastData }
 
 /**
  * Attaches indentation information to directive nodes by capturing trailing

--- a/apps/campfire/src/types/hast.ts
+++ b/apps/campfire/src/types/hast.ts
@@ -1,0 +1,12 @@
+import type { Properties } from 'hast'
+import type { Data } from 'unist'
+
+/**
+ * Metadata for nodes transformed into custom HAST elements.
+ */
+export interface HastData extends Data {
+  /** Tag name applied by rehype */
+  hName?: string
+  /** HAST properties for the generated element */
+  hProperties?: Properties
+}

--- a/apps/campfire/src/utils/remarkStyles.ts
+++ b/apps/campfire/src/utils/remarkStyles.ts
@@ -2,6 +2,7 @@ import { visit } from 'unist-util-visit'
 import type { Root, Paragraph } from 'mdast'
 import type { Data } from 'unist'
 import type { Properties } from 'hast'
+import type { HastData } from '@campfire/types/hast'
 
 /**
  * Appends one or more class names to a node's `hProperties.className`,
@@ -35,14 +36,9 @@ export const appendClassNames = (
  *
  * @returns Transformer attaching class names to paragraph elements.
  */
-interface NodeData extends Data {
-  hName?: string
-  hProperties?: Properties
-}
-
 export const remarkParagraphStyles = () => (tree: Root) => {
   visit(tree, 'paragraph', (node: Paragraph) => {
-    const data = (node.data ?? (node.data = {})) as NodeData
+    const data = (node.data ?? (node.data = {})) as HastData
     if (data.hName) return
     appendClassNames(node, ['font-libertinus', 'text-base'])
   })


### PR DESCRIPTION
## Summary
- add shared `HastData` interface for HAST metadata
- refactor remark utilities to use `HastData`
- update directive handler helpers to consume `HastData`

## Testing
- `bun tsc`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_b_68a9d3bbf9108320ad7c83cc1b6be4f1