### PR TITLE
docs: sync AGENTS and add directive object attribute rule

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,6 +6,7 @@
 - The project uses [Bun](https://bun.sh/) as the JavaScript runtime and package manager.
 - This monorepo contains the main story format in `apps/campfire` and shared utilities in `packages/*`.
 - Source files are TypeScript/TSX; build artifacts live in `dist/` directories.
+- Whenever `AGENTS.md` is updated, update this file to keep instructions synchronized.
 
 ## Build & Validation
 
@@ -46,6 +47,7 @@
 
 - If a directive attribute's value is surrounded by quotes or backticks, it MUST be treated as a string and NEVER converted into JSON, even if the contents of the string appear to be JSON.
 - Wrap string values in quotes or backticks unless referencing a state key.
+- To pass an object via an attribute, do not wrap the object in quotes (e.g., `:directive{attribute={key: val}}`).
 
 ## Notes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
 - Include JSDoc comments for all functions and components.
 - Always add `data-testid` attributes to visual components.
 - Use Conventional Commits for all commit messages.
+- If this `AGENTS.md` file is updated, also update `.github/copilot-instructions.md` to reflect the changes.
 - If you update the `template.ejs` file, also update the Storybook preview template to keep them in sync.
 - If you update React components, add or update corresponding Storybook stories to reflect the changes.
 
@@ -28,3 +29,4 @@
 
 - If a directive attribute's value is surrounded by quotes or backticks, it MUST be treated as a string and NEVER converted into JSON, even if the contents of the string appear to be JSON.
 - Wrap string values in quotes or backticks unless referencing a state key.
+- To pass an object via an attribute, do not wrap the object in quotes (e.g., `:directive{attribute={key: val}}`).


### PR DESCRIPTION
## Summary
- note to update copilot instructions whenever AGENTS.md changes
- clarify that object attribute values must not be quoted in directives

## Testing
- `bun x prettier --write .`
- `bun run typecheck`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68aa80e729548322a616a1addb1fc265