### PR TITLE
fix: respect quoted directive attribute values

### DIFF
--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -294,6 +294,8 @@ export const useDirectiveHandlers = () => {
 
     return applyKeyValue(directive, parent, index, {
       parse: (valueRaw, key) => {
+        const match = valueRaw.match(QUOTE_PATTERN)
+        if (match) return match[2]
         if (!valueRaw.startsWith('[') || !valueRaw.endsWith(']')) {
           const msg = `Array directive value must be in [ ] notation: ${key}=${valueRaw}`
           console.error(msg)

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -58,7 +58,8 @@ import {
   evalExpression,
   getTranslationOptions,
   interpolateString,
-  QUOTE_PATTERN
+  QUOTE_PATTERN,
+  extractQuoted
 } from '@campfire/utils/core'
 import {
   createStateManager,
@@ -294,8 +295,8 @@ export const useDirectiveHandlers = () => {
 
     return applyKeyValue(directive, parent, index, {
       parse: (valueRaw, key) => {
-        const match = valueRaw.match(QUOTE_PATTERN)
-        if (match) return match[2]
+        const quoted = extractQuoted(valueRaw)
+        if (quoted !== undefined) return quoted
         if (!valueRaw.startsWith('[') || !valueRaw.endsWith(']')) {
           const msg = `Array directive value must be in [ ] notation: ${key}=${valueRaw}`
           console.error(msg)

--- a/apps/campfire/src/utils/__tests__/directiveUtils.test.ts
+++ b/apps/campfire/src/utils/__tests__/directiveUtils.test.ts
@@ -3,8 +3,12 @@ import { unified } from 'unified'
 import remarkParse from 'remark-parse'
 import remarkDirective from 'remark-directive'
 import type { RootContent } from 'mdast'
-import { runDirectiveBlock } from '@campfire/utils/directiveUtils'
+import {
+  runDirectiveBlock,
+  parseAttributeValue
+} from '@campfire/utils/directiveUtils'
 import type { DirectiveHandler } from '@campfire/remark-campfire'
+import type { AttributeSpec } from '@campfire/utils/directiveUtils'
 
 describe('runDirectiveBlock', () => {
   it('executes directive handlers', () => {
@@ -18,5 +22,19 @@ describe('runDirectiveBlock', () => {
     }
     runDirectiveBlock(nodes, { test: handler })
     expect(called).toBe(true)
+  })
+})
+
+describe('parseAttributeValue', () => {
+  it('returns raw string for quoted object values', () => {
+    const spec: AttributeSpec = { type: 'object' }
+    const value = parseAttributeValue('\'{"a":1}\'', spec)
+    expect(value).toBe('{"a":1}')
+  })
+
+  it('returns raw string for quoted array values', () => {
+    const spec: AttributeSpec = { type: 'array' }
+    const value = parseAttributeValue('`[1,2,3]`', spec)
+    expect(value).toBe('[1,2,3]')
   })
 })

--- a/apps/campfire/src/utils/core.ts
+++ b/apps/campfire/src/utils/core.ts
@@ -4,6 +4,18 @@ import type { JSX } from 'preact'
 /** Pattern matching a string enclosed in matching quotes or backticks. */
 export const QUOTE_PATTERN = /^(['"`])(.*)\1$/
 
+/**
+ * Extracts the inner content from a string wrapped in matching quotes or
+ * backticks.
+ *
+ * @param value - Value to inspect for surrounding quotes.
+ * @returns The unwrapped string when quoted, otherwise undefined.
+ */
+export const extractQuoted = (value: string): string | undefined => {
+  const match = value.match(QUOTE_PATTERN)
+  return match ? match[2] : undefined
+}
+
 /** Cache of compiled expressions keyed by their source string. */
 const cache = new Map<string, (scope: Record<string, unknown>) => unknown>()
 

--- a/apps/campfire/src/utils/directiveUtils.ts
+++ b/apps/campfire/src/utils/directiveUtils.ts
@@ -253,6 +253,8 @@ export const parseAttributeValue = (
     case 'object': {
       if (raw && typeof raw === 'object' && !Array.isArray(raw)) return raw
       if (typeof raw === 'string') {
+        const m = raw.match(QUOTE_PATTERN)
+        if (m) return m[2]
         const evaluated = spec.expression === false ? undefined : evalExpr(raw)
         if (
           evaluated &&
@@ -274,6 +276,8 @@ export const parseAttributeValue = (
     case 'array': {
       if (Array.isArray(raw)) return raw
       if (typeof raw === 'string') {
+        const m = raw.match(QUOTE_PATTERN)
+        if (m) return m[2]
         const evaluated = spec.expression === false ? undefined : evalExpr(raw)
         if (Array.isArray(evaluated)) return evaluated
         try {

--- a/apps/campfire/src/utils/directiveUtils.ts
+++ b/apps/campfire/src/utils/directiveUtils.ts
@@ -1,4 +1,4 @@
-import { evalExpression, QUOTE_PATTERN } from '@campfire/utils/core'
+import { evalExpression, extractQuoted } from '@campfire/utils/core'
 import { unified } from 'unified'
 import remarkParse from 'remark-parse'
 import remarkGfm from 'remark-gfm'
@@ -222,8 +222,8 @@ export const parseAttributeValue = (
   switch (spec.type) {
     case 'string': {
       if (typeof raw === 'string') {
-        const m = raw.match(QUOTE_PATTERN)
-        if (m) return m[2]
+        const quoted = extractQuoted(raw)
+        if (quoted !== undefined) return quoted
         if (spec.expression === false) return raw
         const evaluated = evalExpr(raw)
         if (typeof evaluated === 'string') return evaluated
@@ -253,8 +253,8 @@ export const parseAttributeValue = (
     case 'object': {
       if (raw && typeof raw === 'object' && !Array.isArray(raw)) return raw
       if (typeof raw === 'string') {
-        const m = raw.match(QUOTE_PATTERN)
-        if (m) return m[2]
+        const quoted = extractQuoted(raw)
+        if (quoted !== undefined) return quoted
         const evaluated = spec.expression === false ? undefined : evalExpr(raw)
         if (
           evaluated &&
@@ -276,8 +276,8 @@ export const parseAttributeValue = (
     case 'array': {
       if (Array.isArray(raw)) return raw
       if (typeof raw === 'string') {
-        const m = raw.match(QUOTE_PATTERN)
-        if (m) return m[2]
+        const quoted = extractQuoted(raw)
+        if (quoted !== undefined) return quoted
         const evaluated = spec.expression === false ? undefined : evalExpr(raw)
         if (Array.isArray(evaluated)) return evaluated
         try {
@@ -441,8 +441,8 @@ export const parseTypedValue = (
 ): unknown => {
   const trimmed = raw.trim()
   if (!trimmed) return undefined
-  const quoted = trimmed.match(QUOTE_PATTERN)
-  if (quoted) return quoted[2]
+  const quoted = extractQuoted(trimmed)
+  if (quoted !== undefined) return quoted
   if (trimmed === 'true') return true
   if (trimmed === 'false') return false
   if (trimmed.startsWith('{') && trimmed.endsWith('}')) {


### PR DESCRIPTION
## Summary
- treat quoted array directive values as strings instead of JSON
- avoid JSON parsing quoted attribute strings for object/array types
- test quoted attribute handling

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68aa87681dd8832287d0b7fdaf730eb6