### PR TITLE
fix: add full height class to passage

### DIFF
--- a/apps/campfire/src/components/Passage/Passage.tsx
+++ b/apps/campfire/src/components/Passage/Passage.tsx
@@ -165,7 +165,7 @@ export const Passage = () => {
   }, [passage, processor])
 
   return (
-    <div className='campfire-passage' data-testid='passage'>
+    <div className='campfire-passage h-full' data-testid='passage'>
       {content}
     </div>
   )

--- a/apps/campfire/src/components/Passage/__tests__/Passage.basic.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Passage.basic.test.tsx
@@ -39,6 +39,25 @@ describe('Passage rendering and navigation', () => {
     expect(text).toBeInTheDocument()
   })
 
+  it('applies full height class to passage wrapper', () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [{ type: 'text', value: 'Hello' }]
+    }
+
+    useStoryDataStore.setState({
+      passages: [passage],
+      currentPassageId: '1'
+    })
+
+    render(<Passage />)
+
+    const wrapper = screen.getByTestId('passage')
+    expect(wrapper).toHaveClass('h-full')
+  })
+
   it('preserves line breaks in passage text', async () => {
     const passage: Element = {
       type: 'element',

--- a/docs/styling-elements.md
+++ b/docs/styling-elements.md
@@ -3,7 +3,7 @@
 Campfire's visual components expose unstyled classes prefixed with `campfire-`, letting you theme the interface without having to override defaults. Common selectors include:
 
 - `.campfire-campfire` – root story container
-- `.campfire-passage` – wrapper around rendered passages
+- `.campfire-passage` – wrapper around rendered passages; includes `h-full` for full height
 - `.campfire-link` – buttons generated from Twine `[[Link]]` syntax
 - `.campfire-trigger` – buttons created by the trigger directive
 - `.campfire-deck` – presentation deck container


### PR DESCRIPTION
## Summary
- ensure passage container fills available height
- document full-height passage wrapper
- verify passage wrapper includes h-full class

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68ab3e14de388322a9f801281c99204e