### PR TITLE
feat(text-directive): expose style attribute

### DIFF
--- a/apps/campfire/src/hooks/__tests__/textDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/textDirective.test.tsx
@@ -75,6 +75,25 @@ describe('text directive', () => {
     expect(inner.textContent).toBe('Hello')
   })
 
+  it('supports inline styles via the style attribute', () => {
+    const md = ':::text{style="color: blue; font-weight: 900;"}\nStyled\n:::'
+    render(<MarkdownRunner markdown={md} />)
+    const inner = document.querySelector('[data-testid="slideText"]')
+      ?.firstElementChild as HTMLElement
+    const style = inner.getAttribute('style') || ''
+    const rules = style
+      .split(';')
+      .filter(Boolean)
+      .map(rule => {
+        const [prop, ...rest] = rule.split(':')
+        return [prop.trim(), rest.join(':').trim()]
+      })
+    const styleObj = Object.fromEntries(rules)
+    expect(styleObj.position).toBe('absolute')
+    expect(styleObj.color).toBe('blue')
+    expect(styleObj['font-weight']).toBe('900')
+  })
+
   it('throws when using reserved class attribute', () => {
     const md = ':::text{class="bad"}\nOops\n:::'
     expect(() => render(<MarkdownRunner markdown={md} />)).toThrow(

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -2065,6 +2065,9 @@ export const useDirectiveHandlers = () => {
     weight: { type: 'number' },
     lineHeight: { type: 'number' },
     color: { type: 'string' },
+    className: { type: 'string' },
+    layerClassName: { type: 'string' },
+    style: { type: 'string' },
     from: { type: 'string', expression: false }
   } as const
 
@@ -2306,6 +2309,9 @@ export const useDirectiveHandlers = () => {
     if (typeof mergedAttrs.lineHeight === 'number')
       style.push(`line-height:${mergedAttrs.lineHeight}`)
     if (mergedAttrs.color) style.push(`color:${mergedAttrs.color}`)
+    const styleAttr =
+      typeof mergedAttrs.style === 'string' ? mergedAttrs.style : undefined
+    if (styleAttr) style.push(styleAttr)
     const props: Record<string, unknown> = {}
     if (typeof mergedAttrs.x === 'number') props.x = mergedAttrs.x
     if (typeof mergedAttrs.y === 'number') props.y = mergedAttrs.y
@@ -2318,10 +2324,12 @@ export const useDirectiveHandlers = () => {
     if (mergedAttrs.anchor) props.anchor = mergedAttrs.anchor
     if (style.length) props.style = style.join(';')
     const classAttr =
-      typeof mergedRaw.className === 'string' ? mergedRaw.className : undefined
+      typeof mergedAttrs.className === 'string'
+        ? mergedAttrs.className
+        : undefined
     const layerClassAttr =
-      typeof mergedRaw.layerClassName === 'string'
-        ? mergedRaw.layerClassName
+      typeof mergedAttrs.layerClassName === 'string'
+        ? mergedAttrs.layerClassName
         : undefined
     const classes = ['text-base', 'font-normal']
     if (classAttr) classes.unshift(classAttr)
@@ -2346,6 +2354,7 @@ export const useDirectiveHandlers = () => {
       'color',
       'className',
       'layerClassName',
+      'style',
       'from'
     ])
     const processed = runDirectiveBlock(

--- a/docs/directives/navigation-composition.md
+++ b/docs/directives/navigation-composition.md
@@ -171,7 +171,7 @@ Control the flow between passages or how they reveal.
   :::
   ```
 
-  Accepts the same attributes as the `Text` component, supports a `from` attribute to apply presets, and uses `layerClassName` to add classes to the Layer wrapper.
+  Accepts the same attributes as the `Text` component, including `className` for element classes and `style` for inline CSS. Supports a `from` attribute to apply presets and uses `layerClassName` to add classes to the Layer wrapper.
 
 - `image`: Position an image within a slide.
 


### PR DESCRIPTION
## Summary
- allow `:text` directive to forward `style`, `className`, and `layerClassName`
- test inline style support for `:text`
- document text directive styling options

## Testing
- `bun x prettier --write apps/campfire/src/hooks/useDirectiveHandlers.ts apps/campfire/src/hooks/__tests__/textDirective.test.tsx docs/directives/navigation-composition.md`
- `bun x tsc --noEmit`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_68abd37d3500832296a4567605c04fd8