### PR TITLE
feat: allow style attribute on text directive

### DIFF
--- a/apps/campfire/src/hooks/__tests__/textDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/textDirective.test.tsx
@@ -28,7 +28,7 @@ beforeEach(() => {
 describe('text directive', () => {
   it('renders a SlideText component with styles', () => {
     const md =
-      ':::text{x=10 y=20 w=100 h=50 z=5 rotate=45 scale=1.5 anchor=center as="h2" align=center size=24 weight=700 lineHeight=1.2 color="red" className="underline" layerClassName="wrapper" data-test="ok"}\nHello\n:::'
+      ':::text{x=10 y=20 w=100 h=50 z=5 rotate=45 scale=1.5 anchor=center as="h2" align=center size=24 weight=700 lineHeight=1.2 color="red" className="underline" layerClassName="wrapper" style="background: blue" data-test="ok"}\nHello\n:::'
     render(<MarkdownRunner markdown={md} />)
     const el = document.querySelector(
       '[data-testid="slideText"]'
@@ -63,6 +63,7 @@ describe('text directive', () => {
     expect(styleObj.fontWeight).toBe('700')
     expect(styleObj.lineHeight).toBe('1.2')
     expect(styleObj.color).toBe('red')
+    expect(styleObj.background).toBe('blue')
     expect(inner.className.split(' ')).toEqual(
       expect.arrayContaining([
         'campfire-slide-text',

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -2050,6 +2050,7 @@ export const useDirectiveHandlers = () => {
     weight: { type: 'number' },
     lineHeight: { type: 'number' },
     color: { type: 'string' },
+    style: { type: 'string' },
     from: { type: 'string', expression: false }
   } as const
 
@@ -2284,6 +2285,7 @@ export const useDirectiveHandlers = () => {
     if (typeof mergedAttrs.lineHeight === 'number')
       style.push(`line-height:${mergedAttrs.lineHeight}`)
     if (mergedAttrs.color) style.push(`color:${mergedAttrs.color}`)
+    if (mergedAttrs.style) style.push(String(mergedAttrs.style))
     const props: Record<string, unknown> = {}
     if (typeof mergedAttrs.x === 'number') props.x = mergedAttrs.x
     if (typeof mergedAttrs.y === 'number') props.y = mergedAttrs.y
@@ -2322,6 +2324,7 @@ export const useDirectiveHandlers = () => {
       'weight',
       'lineHeight',
       'color',
+      'style',
       'className',
       'layerClassName',
       'from'

--- a/docs/directives/navigation-composition.md
+++ b/docs/directives/navigation-composition.md
@@ -143,7 +143,26 @@ Control the flow between passages or how they reveal.
   :::
   ```
 
-  Accepts the same attributes as the `Text` component, supports a `from` attribute to apply presets, and uses `layerClassName` to add classes to the Layer wrapper.
+  | Input          | Description                             |
+  | -------------- | --------------------------------------- |
+  | x              | Horizontal position in pixels           |
+  | y              | Vertical position in pixels             |
+  | w              | Width in pixels                         |
+  | h              | Height in pixels                        |
+  | z              | Z-index order                           |
+  | rotate         | Rotation in degrees                     |
+  | scale          | Scale factor                            |
+  | anchor         | Positioning anchor point                |
+  | as             | HTML tag to render (e.g., `p`, `h1`)    |
+  | align          | Text alignment                          |
+  | size           | Font size in pixels                     |
+  | weight         | Font weight                             |
+  | lineHeight     | Line height multiplier                  |
+  | color          | Text color                              |
+  | className      | Additional classes for the text element |
+  | style          | Inline CSS rules for the text element   |
+  | layerClassName | Classes added to the Layer wrapper      |
+  | from           | Name of a text preset to apply          |
 
 - `image`: Position an image within a slide.
 


### PR DESCRIPTION
## Summary
- allow `:text` directives to pass inline `style`
- document `style` usage
- list text directive attributes in docs
- test `:text` style attribute support

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68abdf9546f88322b75102b20df075cf