### PR TITLE
feat(trigger): expose style attribute

### DIFF
--- a/apps/campfire/src/components/Passage/TriggerButton.tsx
+++ b/apps/campfire/src/components/Passage/TriggerButton.tsx
@@ -6,12 +6,12 @@ import type { JSX } from 'preact'
 
 const clone = rfdc()
 
-interface TriggerButtonProps {
+interface TriggerButtonProps
+  extends Omit<JSX.HTMLAttributes<HTMLButtonElement>, 'className'> {
   className?: string | string[]
   content: string
   children?: string
   disabled?: boolean
-  style?: JSX.CSSProperties
 }
 
 /**
@@ -28,7 +28,9 @@ export const TriggerButton = ({
   content,
   children,
   disabled,
-  style
+  style,
+  onClick,
+  ...rest
 }: TriggerButtonProps) => {
   const handlers = useDirectiveHandlers()
   const classes = Array.isArray(className)
@@ -48,8 +50,11 @@ export const TriggerButton = ({
       ].join(' ')}
       disabled={disabled}
       style={style}
+      {...rest}
       onClick={e => {
         e.stopPropagation()
+        onClick?.(e)
+        if (e.defaultPrevented) return
         runDirectiveBlock(clone(JSON.parse(content)) as RootContent[], handlers)
       }}
     >

--- a/apps/campfire/src/components/Passage/__tests__/TriggerButton.directive.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/TriggerButton.directive.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach } from 'bun:test'
+import { render, screen } from '@testing-library/preact'
+import type { Element } from 'hast'
+import { Passage } from '@campfire/components/Passage/Passage'
+import { useStoryDataStore } from '@campfire/state/useStoryDataStore'
+import { resetStores } from '@campfire/test-utils/helpers'
+
+/**
+ * Tests for TriggerButton directive attributes.
+ */
+describe('TriggerButton directive', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    resetStores()
+  })
+
+  it('passes style attribute to the component', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value: ':::trigger{label="Styled" style="color:blue"}\n:::'
+        }
+      ]
+    }
+    useStoryDataStore.setState({
+      passages: [passage],
+      currentPassageId: '1'
+    })
+    render(<Passage />)
+    const button = await screen.findByRole('button', { name: 'Styled' })
+    expect((button as HTMLButtonElement).style.color).toBe('blue')
+  })
+})

--- a/apps/campfire/src/components/Passage/__tests__/TriggerButton.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/TriggerButton.test.tsx
@@ -20,4 +20,15 @@ describe('TriggerButton', () => {
     fireEvent.click(getByTestId('trigger-button'))
     expect(clicked).toBe(false)
   })
+
+  it('applies inline styles when provided', () => {
+    const { getByTestId } = render(
+      <TriggerButton content='[]' style={{ color: 'red' }}>
+        Fire
+      </TriggerButton>
+    )
+    expect(
+      (getByTestId('trigger-button') as HTMLButtonElement).style.color
+    ).toBe('red')
+  })
 })

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -1098,6 +1098,7 @@ export const useDirectiveHandlers = () => {
       typeof attrs.disabled === 'string'
         ? attrs.disabled !== 'false'
         : Boolean(attrs.disabled)
+    const styleAttr = typeof attrs.style === 'string' ? attrs.style : undefined
     const content = JSON.stringify(
       stripLabel(container.children as RootContent[])
     )
@@ -1110,7 +1111,8 @@ export const useDirectiveHandlers = () => {
         hProperties: {
           className: classes,
           content,
-          disabled
+          disabled,
+          ...(styleAttr ? { style: styleAttr } : {})
         }
       }
     }

--- a/apps/storybook/src/TriggerButton.stories.tsx
+++ b/apps/storybook/src/TriggerButton.stories.tsx
@@ -24,3 +24,19 @@ export const States: StoryObj<typeof TriggerButton> = {
     </div>
   )
 }
+
+/**
+ * Displays a TriggerButton with custom inline styles.
+ *
+ * @returns A styled TriggerButton example.
+ */
+export const Styled: StoryObj<typeof TriggerButton> = {
+  render: () => (
+    <TriggerButton
+      content='[]'
+      style={{ backgroundColor: '#2563eb', color: '#fff' }}
+    >
+      Styled
+    </TriggerButton>
+  )
+}

--- a/docs/directives/event-trigger-blocks.md
+++ b/docs/directives/event-trigger-blocks.md
@@ -37,7 +37,7 @@ Run directives on specific passage events or group actions.
 - `trigger`: Render a button that runs directives when clicked.
 
   ```md
-  :::trigger{label="Do it" className="primary" disabled}
+  :::trigger{label="Do it" className="primary" disabled style="color:red"}
   :set[key=value]
   :::
   ```
@@ -51,3 +51,4 @@ Run directives on specific passage events or group actions.
   | label     | Text displayed on the button           |
   | className | Optional space-separated classes       |
   | disabled  | Optional boolean to disable the button |
+  | style     | Optional inline style declarations     |


### PR DESCRIPTION
## Summary
- allow TriggerButton to accept standard HTML attributes and inline styles
- support `style` attribute in trigger directive
- document and demonstrate styling for trigger buttons

## Testing
- `bun tsc && echo tsc-ok`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68abf00940648322b9dbc4c6d17b1c2c