### PR TITLE
feat(shape): expose shape directive class attributes

### DIFF
--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -2113,6 +2113,8 @@ export const useDirectiveHandlers = () => {
     fill: { type: 'string' },
     radius: { type: 'number' },
     shadow: { type: 'boolean' },
+    className: { type: 'string' },
+    layerClassName: { type: 'string' },
     style: { type: 'string' },
     from: { type: 'string', expression: false }
   } as const
@@ -2498,14 +2500,9 @@ export const useDirectiveHandlers = () => {
     if (typeof mergedAttrs.shadow === 'boolean')
       props.shadow = mergedAttrs.shadow
     if (mergedAttrs.style) props.style = mergedAttrs.style
-    const classAttr =
-      typeof mergedRaw.className === 'string' ? mergedRaw.className : undefined
-    const layerClassAttr =
-      typeof mergedRaw.layerClassName === 'string'
-        ? mergedRaw.layerClassName
-        : undefined
-    if (classAttr) props.className = classAttr
-    if (layerClassAttr) props.layerClassName = layerClassAttr
+    if (mergedAttrs.className) props.className = mergedAttrs.className
+    if (mergedAttrs.layerClassName)
+      props.layerClassName = mergedAttrs.layerClassName
     applyAdditionalAttributes(mergedRaw, props, [
       'x',
       'y',

--- a/apps/storybook/src/ShapeDirective.stories.tsx
+++ b/apps/storybook/src/ShapeDirective.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/preact'
+import { Campfire } from '@campfire/components'
+
+const meta: Meta = {
+  title: 'Campfire/Directives/Shape'
+}
+
+export default meta
+
+/**
+ * Draws basic shapes within a slide using the `shape` directive.
+ *
+ * @returns Campfire story showcasing the `shape` directive.
+ */
+export const Basic: StoryObj = {
+  render: () => (
+    <>
+      <tw-storydata startnode='1' options='debug'>
+        <tw-passagedata pid='1' name='Start'>
+          {`
+:::deck{size="800x600"}
+  :::slide
+    :shape{type='rect' x=120 y=120 w=120 h=80 fill='#60a5fa' stroke='#1e3a8a'}
+    :shape{type='ellipse' x=400 y=160 w=100 h=100 fill='#facc15' stroke='#92400e' className='opacity-75'}
+  :::
+:::
+          `}
+        </tw-passagedata>
+      </tw-storydata>
+      <Campfire />
+    </>
+  )
+}

--- a/docs/directives/navigation-composition.md
+++ b/docs/directives/navigation-composition.md
@@ -195,7 +195,31 @@ Control the flow between passages or how they reveal.
   :::
   ```
 
-  Accepts the same attributes as the `SlideShape` component, supports a `from` attribute to apply presets, and uses `layerClassName` to add classes to the Layer wrapper.
+  | Input          | Description                                       |
+  | -------------- | ------------------------------------------------- |
+  | x              | Horizontal position in pixels                     |
+  | y              | Vertical position in pixels                       |
+  | w              | Width in pixels                                   |
+  | h              | Height in pixels                                  |
+  | z              | z-index value                                     |
+  | rotate         | Rotation in degrees                               |
+  | scale          | Scale multiplier                                  |
+  | anchor         | Transform origin (`top-left` by default)          |
+  | type           | Shape type (`rect`, `ellipse`, `line`, `polygon`) |
+  | points         | Points for polygon shapes                         |
+  | x1             | Starting x-coordinate for line shapes             |
+  | y1             | Starting y-coordinate for line shapes             |
+  | x2             | Ending x-coordinate for line shapes               |
+  | y2             | Ending y-coordinate for line shapes               |
+  | stroke         | Stroke color                                      |
+  | strokeWidth    | Stroke width in pixels                            |
+  | fill           | Fill color (`none` by default)                    |
+  | radius         | Corner radius for rectangles                      |
+  | shadow         | Adds a drop shadow when true                      |
+  | className      | Classes applied to the `<svg>` element            |
+  | layerClassName | Classes applied to the Layer wrapper              |
+  | style          | Inline styles applied to the `<svg>` element      |
+  | from           | Name of a shape preset to apply                   |
 
 - `preset`: Define reusable attribute sets that can be applied via the `from` attribute on `deck`, `reveal`, `image`, `shape`, and `text` directives.
 


### PR DESCRIPTION
## Summary
- expose `className` and `layerClassName` on `:shape` directive
- document shape directive's accepted attributes in a table

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68abf3926fb88322a86d3c08edfa0148