### PR TITLE
fix: expose image class attributes

### DIFF
--- a/apps/campfire/src/hooks/__tests__/imageDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/imageDirective.test.tsx
@@ -63,4 +63,16 @@ describe('image directive', () => {
     const img = el.querySelector('img') as HTMLImageElement
     expect(img.getAttribute('src')).toBe('https://example.com/cat.png')
   })
+
+  it('applies class names from presets', () => {
+    const md =
+      ':preset{type="image" name="cat" className="rounded" layerClassName="wrap" src="https://example.com/cat.png"}\n:::reveal\n:image{from="cat"}\n:::\n'
+    render(<MarkdownRunner markdown={md} />)
+    const el = document.querySelector(
+      '[data-testid="slideImage"]'
+    ) as HTMLElement
+    expect(el.className).toContain('wrap')
+    const img = el.querySelector('img') as HTMLImageElement
+    expect(img.className).toContain('rounded')
+  })
 })

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -2086,6 +2086,8 @@ export const useDirectiveHandlers = () => {
     src: { type: 'string', required: true },
     alt: { type: 'string' },
     style: { type: 'string' },
+    className: { type: 'string' },
+    layerClassName: { type: 'string' },
     from: { type: 'string', expression: false }
   } as const
 
@@ -2411,14 +2413,9 @@ export const useDirectiveHandlers = () => {
     if (mergedAttrs.anchor) props.anchor = mergedAttrs.anchor
     if (mergedAttrs.alt) props.alt = mergedAttrs.alt
     if (mergedAttrs.style) props.style = mergedAttrs.style
-    const classAttr =
-      typeof mergedRaw.className === 'string' ? mergedRaw.className : undefined
-    const layerClassAttr =
-      typeof mergedRaw.layerClassName === 'string'
-        ? mergedRaw.layerClassName
-        : undefined
-    if (classAttr) props.className = classAttr
-    if (layerClassAttr) props.layerClassName = layerClassAttr
+    if (mergedAttrs.className) props.className = mergedAttrs.className
+    if (mergedAttrs.layerClassName)
+      props.layerClassName = mergedAttrs.layerClassName
     applyAdditionalAttributes(mergedRaw, props, [
       'x',
       'y',

--- a/docs/directives/navigation-composition.md
+++ b/docs/directives/navigation-composition.md
@@ -183,7 +183,24 @@ Control the flow between passages or how they reveal.
   :::
   ```
 
-  Accepts the same attributes as the `SlideImage` component, supports a `from` attribute to apply presets, and uses `layerClassName` to add classes to the Layer wrapper.
+  Supports a `from` attribute to apply presets.
+
+  | Input          | Description                              |
+  | -------------- | ---------------------------------------- |
+  | x              | Horizontal position in pixels            |
+  | y              | Vertical position in pixels              |
+  | w              | Width in pixels                          |
+  | h              | Height in pixels                         |
+  | z              | z-index value                            |
+  | rotate         | Rotation in degrees                      |
+  | scale          | Scale multiplier                         |
+  | anchor         | Transform origin (`top-left` by default) |
+  | src            | Image source URL                         |
+  | alt            | Alternate text description               |
+  | style          | Inline styles applied to the `<img>`     |
+  | className      | Classes applied to the `<img>`           |
+  | layerClassName | Classes applied to the Layer wrapper     |
+  | from           | Name of an image preset to apply         |
 
 - `shape`: Draw basic shapes within a slide.
 


### PR DESCRIPTION
## Summary
- expose `className` and `layerClassName` on image directive
- document image directive attributes
- test preset class names

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68ac82399f54832296a96c96ccd96ee5