### PR TITLE
feat: add namespace attribute to t directive

### DIFF
--- a/apps/campfire/src/components/Passage/__tests__/Passage.i18n.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Passage.i18n.test.tsx
@@ -248,6 +248,28 @@ describe('Passage i18n directives', () => {
     expect(i18next.hasResourceBundle('en-US', 'ui')).toBe(true)
   })
 
+  it('supports namespace attribute on t directive', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        { type: 'text', value: ':translations[en-US]{ui:bye="Bye"}' },
+        { type: 'text', value: ':t[bye]{ns="ui"}' }
+      ]
+    }
+
+    useStoryDataStore.setState({
+      passages: [passage],
+      currentPassageId: '1'
+    })
+
+    render(<Passage />)
+
+    const text = await screen.findByText('Bye')
+    expect(text).toBeInTheDocument()
+  })
+
   it('updates translations when language changes', async () => {
     i18next.addResource('en-US', 'translation', 'hello', 'Hello')
     i18next.addResource('fr-FR', 'translation', 'hello', 'Bonjour')

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -1354,9 +1354,14 @@ export const useDirectiveHandlers = () => {
       directive,
       parent,
       index,
-      { count: { type: 'number' }, fallback: { type: 'string' } },
+      {
+        count: { type: 'number' },
+        fallback: { type: 'string' },
+        ns: { type: 'string' }
+      },
       { state: gameData }
     )
+    if (attrs.ns) ns = attrs.ns
     const keyPattern = /^[A-Za-z_$][A-Za-z0-9_$]*(?::[A-Za-z0-9_.$-]+)?$/
     let props: Properties
     if (key || keyPattern.test(raw)) {
@@ -1377,6 +1382,7 @@ export const useDirectiveHandlers = () => {
     const rawFallback = rawAttrs.fallback as string | undefined
     delete rawAttrs.count
     delete rawAttrs.fallback
+    delete rawAttrs.ns
     const vars: Record<string, unknown> = {}
     for (const [name, rawVal] of Object.entries(rawAttrs)) {
       if (rawVal == null) continue

--- a/docs/directives/localization.md
+++ b/docs/directives/localization.md
@@ -20,20 +20,23 @@ Change language and handle translations.
 
   ```md
   :t[ui:apple]{count=2}
+  :t[apple]{ns="ui"}
   :t[favoriteFruit]
   :t[missing]{fallback=`Hello ${player}`}
   ```
 
-  Replace `apple` and `ui` with your key and namespace, or supply a JavaScript
-  expression that resolves to one. The `fallback` attribute accepts either a
+  Replace `apple` and `ui` with your key and namespace. You can also provide the
+  namespace via the `ns` attribute or supply a JavaScript expression that
+  resolves to the key. The `fallback` attribute accepts either a
   quoted string or a template literal. For interpolation, use backticks without
   wrapping the value in quotes.
 
-  | Input    | Description                          |
-  | -------- | ------------------------------------ |
-  | ns:key   | Namespace and key of the translation |
-  | count    | Optional count for pluralization     |
-  | fallback | Fallback text when key is missing    |
+  | Input    | Description                            |
+  | -------- | -------------------------------------- |
+  | ns:key   | Namespace and key of the translation   |
+  | ns       | Optional namespace for the translation |
+  | count    | Optional count for pluralization       |
+  | fallback | Fallback text when key is missing      |
 
 - `translations`: Add a translation.
 
@@ -44,6 +47,13 @@ Change language and handle translations.
   Replace `lang` with the locale and `ui` with the namespace. Only one
   `namespace:key="value"` pair is allowed per directive. Repeat the directive
   for additional translations.
+
+  ```md
+  :translations[en]{ui:greeting="Hello, {{name}}!"}
+  :t[greeting]{ns="ui" name="Aiden"}
+  ```
+
+  Attributes on `:t` become interpolation variables for i18next.
 
   | Input  | Description                     |
   | ------ | ------------------------------- |


### PR DESCRIPTION
## Summary
- allow specifying translation namespace via `ns` attribute
- document t directive namespace attribute and interpolation
- test namespace attribute for `:t`

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_b_68ac7da2a364832091f9f7838681c75b