### PR TITLE
feat: expose style attribute for text directive

### DIFF
--- a/apps/campfire/src/hooks/__tests__/textDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/textDirective.test.tsx
@@ -75,6 +75,21 @@ describe('text directive', () => {
     expect(inner.textContent).toBe('Hello')
   })
 
+  it('merges inline style with computed values', () => {
+    const md =
+      ':::text{x=10 color="red" style="color: blue; font-weight:900"}\nHi\n:::'
+    render(<MarkdownRunner markdown={md} />)
+    const el = document.querySelector(
+      '[data-testid="slideText"]'
+    ) as HTMLElement
+    const inner = el.firstElementChild as HTMLElement
+    const rawStyle = inner.getAttribute('style') || ''
+    expect(rawStyle).toContain('left: 10px')
+    expect(rawStyle).toContain('color: blue')
+    expect(rawStyle).toContain('font-weight: 900')
+    expect(inner.textContent).toBe('Hi')
+  })
+
   it('throws when using reserved class attribute', () => {
     const md = ':::text{class="bad"}\nOops\n:::'
     expect(() => render(<MarkdownRunner markdown={md} />)).toThrow(

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -2318,6 +2318,17 @@ export const useDirectiveHandlers = () => {
     if (typeof mergedAttrs.lineHeight === 'number')
       style.push(`line-height:${mergedAttrs.lineHeight}`)
     if (mergedAttrs.color) style.push(`color:${mergedAttrs.color}`)
+    const rawStyle = mergedRaw.style
+    if (rawStyle) {
+      if (typeof rawStyle === 'string') {
+        style.push(rawStyle)
+      } else if (typeof rawStyle === 'object') {
+        const entries = Object.entries(rawStyle as Record<string, unknown>).map(
+          ([k, v]) => `${k}:${v}`
+        )
+        style.push(entries.join(';'))
+      }
+    }
     const props: Record<string, unknown> = {}
     if (typeof mergedAttrs.x === 'number') props.x = mergedAttrs.x
     if (typeof mergedAttrs.y === 'number') props.y = mergedAttrs.y
@@ -2356,6 +2367,7 @@ export const useDirectiveHandlers = () => {
       'weight',
       'lineHeight',
       'color',
+      'style',
       'className',
       'layerClassName',
       'from'

--- a/docs/directives/navigation-composition.md
+++ b/docs/directives/navigation-composition.md
@@ -165,13 +165,33 @@ Control the flow between passages or how they reveal.
   ```md
   :::deck
   :::slide
-  :::text{x=100 y=50 align=center size=32}
+  :::text{x=100 y=50 align=center size=32 style="color: blue"}
   Hello
   :::
   :::
   ```
 
-  Accepts the same attributes as the `Text` component, supports a `from` attribute to apply presets, and uses `layerClassName` to add classes to the Layer wrapper.
+  Supports a `from` attribute to apply presets and uses `layerClassName` to add classes to the Layer wrapper.
+
+  | Input          | Description                              |
+  | -------------- | ---------------------------------------- |
+  | x              | Horizontal position in pixels            |
+  | y              | Vertical position in pixels              |
+  | w              | Width in pixels                          |
+  | h              | Height in pixels                         |
+  | z              | z-index value                            |
+  | rotate         | Rotation in degrees                      |
+  | scale          | Scale multiplier                         |
+  | anchor         | Transform origin (`top-left` by default) |
+  | align          | Horizontal text alignment                |
+  | size           | Font size in pixels                      |
+  | weight         | Font weight                              |
+  | lineHeight     | Line height multiplier                   |
+  | color          | Text color                               |
+  | style          | Inline styles applied to the text node   |
+  | className      | Classes applied to the text node         |
+  | layerClassName | Classes applied to the Layer wrapper     |
+  | from           | Name of a text preset to apply           |
 
 - `image`: Position an image within a slide.
 


### PR DESCRIPTION
## Summary
- allow text directive to pass through inline `style`
- document text directive attributes and style support
- test merging directive style with computed values

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68ac94cb26b88322ace97d353adb3570