### PR TITLE
feat: add audio directives and manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ See the dedicated docs for detailed usage:
 - [Navigation, composition & transitions](docs/directives/navigation-composition.md)
 - [Persistence](docs/directives/persistence.md)
 - [Localization & internationalization](docs/directives/localization.md)
+- [Audio](docs/directives/audio.md)
 
 Campfire prints descriptive error messages to the browser console when it encounters invalid markup.
 

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ See the dedicated docs for detailed usage:
 - [Conditional logic & iteration](docs/directives/conditional-logic-and-iteration.md)
 - [Event & trigger blocks](docs/directives/event-trigger-blocks.md)
 - [Navigation, composition & transitions](docs/directives/navigation-composition.md)
+- [Audio](docs/directives/audio.md)
 - [Persistence](docs/directives/persistence.md)
 - [Localization & internationalization](docs/directives/localization.md)
-- [Audio](docs/directives/audio.md)
 
 Campfire prints descriptive error messages to the browser console when it encounters invalid markup.
 

--- a/apps/campfire/src/audio/AudioManager.ts
+++ b/apps/campfire/src/audio/AudioManager.ts
@@ -8,6 +8,29 @@ export class AudioManager {
   private bgmBaseVolume = 1
 
   /**
+   * Determines the base URL for resolving relative audio paths.
+   *
+   * @returns The base URL string.
+   */
+  private getBaseUrl(): string {
+    if (
+      typeof window !== 'undefined' &&
+      window.location?.origin &&
+      window.location.origin !== 'null'
+    ) {
+      return window.location.origin
+    }
+    if (
+      typeof document !== 'undefined' &&
+      document.baseURI &&
+      document.baseURI !== 'about:blank'
+    ) {
+      return document.baseURI
+    }
+    return 'http://localhost'
+  }
+
+  /**
    * Retrieves the singleton instance of the AudioManager.
    *
    * @returns The AudioManager instance.
@@ -33,18 +56,8 @@ export class AudioManager {
     if (!src) return undefined
     try {
       // Validate the URL to avoid creating Audio elements with invalid sources
-      const baseUrl =
-        typeof window !== 'undefined' &&
-        window.location?.origin &&
-        window.location.origin !== 'null'
-          ? window.location.origin
-          : typeof document !== 'undefined' &&
-              document.baseURI &&
-              document.baseURI !== 'about:blank'
-            ? document.baseURI
-            : 'http://localhost'
       // eslint-disable-next-line no-new
-      new URL(src, baseUrl)
+      new URL(src, this.getBaseUrl())
     } catch {
       console.error(`Invalid audio source: ${src}`)
       return undefined

--- a/apps/campfire/src/audio/AudioManager.ts
+++ b/apps/campfire/src/audio/AudioManager.ts
@@ -42,10 +42,11 @@ export class AudioManager {
     opts: { src?: string; volume?: number; loop?: boolean; fade?: number } = {}
   ): void {
     let audio: HTMLAudioElement | undefined
+    const source = opts.src ?? id
     if (this.sfxMap.has(id)) {
       audio = this.sfxMap.get(id)!.cloneNode(true) as HTMLAudioElement
-    } else if (opts.src) {
-      const base = new Audio(opts.src)
+    } else if (source) {
+      const base = new Audio(source)
       base.preload = 'auto'
       this.sfxMap.set(id, base)
       audio = base.cloneNode(true) as HTMLAudioElement
@@ -124,10 +125,11 @@ export class AudioManager {
     opts: { src?: string; volume?: number; delay?: number } = {}
   ): void {
     let base: HTMLAudioElement | undefined
+    const source = opts.src ?? id
     if (this.sfxMap.has(id)) {
       base = this.sfxMap.get(id)!
-    } else if (opts.src) {
-      base = new Audio(opts.src)
+    } else if (source) {
+      base = new Audio(source)
       base.preload = 'auto'
       this.sfxMap.set(id, base)
     }

--- a/apps/campfire/src/audio/AudioManager.ts
+++ b/apps/campfire/src/audio/AudioManager.ts
@@ -54,15 +54,15 @@ export class AudioManager {
     if (this.sfxMap.has(id)) return this.sfxMap.get(id)!
     const src = source ?? id
     if (!src) return undefined
+    let href: string
     try {
-      // Validate the URL to avoid creating Audio elements with invalid sources
-      // eslint-disable-next-line no-new
-      new URL(src, this.getBaseUrl())
+      // Resolve and validate the URL to avoid creating elements with invalid sources
+      href = new URL(src, this.getBaseUrl()).href
     } catch {
       console.error(`Invalid audio source: ${src}`)
       return undefined
     }
-    const audio = new Audio(src)
+    const audio = new Audio(href)
     audio.preload = 'auto'
     this.sfxMap.set(id, audio)
     return audio

--- a/apps/campfire/src/audio/AudioManager.ts
+++ b/apps/campfire/src/audio/AudioManager.ts
@@ -1,0 +1,142 @@
+export class AudioManager {
+  private static instance: AudioManager
+  private bgm?: HTMLAudioElement
+  private bgmName?: string
+  private sfxMap: Map<string, HTMLAudioElement> = new Map()
+  private globalSfxVolume = 1
+  private globalBgmVolume = 1
+
+  /**
+   * Retrieves the singleton instance of the AudioManager.
+   *
+   * @returns The AudioManager instance.
+   */
+  static getInstance(): AudioManager {
+    if (!this.instance) this.instance = new AudioManager()
+    return this.instance
+  }
+
+  /**
+   * Preloads an audio file. If the id already exists, it will be ignored.
+   *
+   * @param id - Unique identifier for the audio file.
+   * @param src - Source URL of the audio file.
+   */
+  load(id: string, src: string): void {
+    if (this.sfxMap.has(id)) return
+    const audio = new Audio(src)
+    audio.preload = 'auto'
+    this.sfxMap.set(id, audio)
+  }
+
+  /**
+   * Plays or changes the current background music. A previous track will fade
+   * out if fade duration is provided.
+   *
+   * @param id - Identifier for the track.
+   * @param opts - Optional playback settings.
+   */
+  playBgm(
+    id: string,
+    opts: { src?: string; volume?: number; loop?: boolean; fade?: number } = {}
+  ): void {
+    let audio: HTMLAudioElement | undefined
+    if (this.sfxMap.has(id)) {
+      audio = this.sfxMap.get(id)!.cloneNode(true) as HTMLAudioElement
+    } else if (opts.src) {
+      audio = new Audio(opts.src)
+      audio.preload = 'auto'
+      this.sfxMap.set(id, audio)
+    }
+    if (!audio) return
+
+    if (this.bgm) {
+      this.stopBgm(opts.fade)
+    }
+
+    this.bgm = audio
+    this.bgmName = id
+    audio.loop = opts.loop ?? true
+    audio.volume = (opts.volume ?? 1) * this.globalBgmVolume
+    void audio.play()
+  }
+
+  /**
+   * Stops the current background music with an optional fade out.
+   *
+   * @param fadeMs - Duration of fade in milliseconds.
+   */
+  stopBgm(fadeMs?: number): void {
+    if (!this.bgm) return
+    const current = this.bgm
+    if (fadeMs && fadeMs > 0) {
+      const startVol = current.volume
+      const step = 50
+      let elapsed = 0
+      const timer = setInterval(() => {
+        elapsed += step
+        current.volume = Math.max(0, startVol * (1 - elapsed / fadeMs))
+        if (elapsed >= fadeMs) {
+          clearInterval(timer)
+          current.pause()
+          current.currentTime = 0
+        }
+      }, step)
+    } else {
+      current.pause()
+      current.currentTime = 0
+    }
+    this.bgm = undefined
+    this.bgmName = undefined
+  }
+
+  /**
+   * Sets the global BGM volume and applies it to the current track.
+   *
+   * @param volume - Volume level from 0 to 1.
+   */
+  setBgmVolume(volume: number): void {
+    this.globalBgmVolume = volume
+    if (this.bgm) this.bgm.volume = volume
+  }
+
+  /**
+   * Sets the global SFX volume.
+   *
+   * @param volume - Volume level from 0 to 1.
+   */
+  setSfxVolume(volume: number): void {
+    this.globalSfxVolume = volume
+  }
+
+  /**
+   * Plays a sound effect by id or from a provided source.
+   *
+   * @param id - Identifier for the sound effect.
+   * @param opts - Additional playback options.
+   */
+  playSfx(
+    id: string,
+    opts: { src?: string; volume?: number; delay?: number } = {}
+  ): void {
+    let base: HTMLAudioElement | undefined
+    if (this.sfxMap.has(id)) {
+      base = this.sfxMap.get(id)!
+    } else if (opts.src) {
+      base = new Audio(opts.src)
+      base.preload = 'auto'
+      this.sfxMap.set(id, base)
+    }
+    if (!base) return
+    const audio = base.cloneNode(true) as HTMLAudioElement
+    audio.volume = (opts.volume ?? 1) * this.globalSfxVolume
+    const start = () => {
+      void audio.play()
+    }
+    if (opts.delay && opts.delay > 0) {
+      setTimeout(start, opts.delay)
+    } else {
+      start()
+    }
+  }
+}

--- a/apps/campfire/src/audio/AudioManager.ts
+++ b/apps/campfire/src/audio/AudioManager.ts
@@ -5,6 +5,7 @@ export class AudioManager {
   private sfxMap: Map<string, HTMLAudioElement> = new Map()
   private globalSfxVolume = 1
   private globalBgmVolume = 1
+  private bgmBaseVolume = 1
 
   /**
    * Retrieves the singleton instance of the AudioManager.
@@ -44,9 +45,10 @@ export class AudioManager {
     if (this.sfxMap.has(id)) {
       audio = this.sfxMap.get(id)!.cloneNode(true) as HTMLAudioElement
     } else if (opts.src) {
-      audio = new Audio(opts.src)
-      audio.preload = 'auto'
-      this.sfxMap.set(id, audio)
+      const base = new Audio(opts.src)
+      base.preload = 'auto'
+      this.sfxMap.set(id, base)
+      audio = base.cloneNode(true) as HTMLAudioElement
     }
     if (!audio) return
 
@@ -56,8 +58,9 @@ export class AudioManager {
 
     this.bgm = audio
     this.bgmName = id
+    this.bgmBaseVolume = opts.volume ?? 1
     audio.loop = opts.loop ?? true
-    audio.volume = (opts.volume ?? 1) * this.globalBgmVolume
+    audio.volume = this.bgmBaseVolume * this.globalBgmVolume
     void audio.play()
   }
 
@@ -88,6 +91,7 @@ export class AudioManager {
     }
     this.bgm = undefined
     this.bgmName = undefined
+    this.bgmBaseVolume = 1
   }
 
   /**
@@ -97,7 +101,7 @@ export class AudioManager {
    */
   setBgmVolume(volume: number): void {
     this.globalBgmVolume = volume
-    if (this.bgm) this.bgm.volume = volume
+    if (this.bgm) this.bgm.volume = this.bgmBaseVolume * volume
   }
 
   /**

--- a/apps/campfire/src/audio/AudioManager.ts
+++ b/apps/campfire/src/audio/AudioManager.ts
@@ -31,6 +31,14 @@ export class AudioManager {
     if (this.sfxMap.has(id)) return this.sfxMap.get(id)!
     const src = source ?? id
     if (!src) return undefined
+    try {
+      // Validate the URL to avoid creating Audio elements with invalid sources
+      // eslint-disable-next-line no-new
+      new URL(src, 'http://localhost')
+    } catch {
+      console.error(`Invalid audio source: ${src}`)
+      return undefined
+    }
     const audio = new Audio(src)
     audio.preload = 'auto'
     this.sfxMap.set(id, audio)
@@ -44,7 +52,12 @@ export class AudioManager {
    * @param src - Source URL of the audio file.
    */
   load(id: string, src: string): void {
-    this.getOrCreateAudio(id, src)?.load()
+    const audio = this.getOrCreateAudio(id, src)
+    if (audio) {
+      audio.load()
+    } else {
+      console.error(`Failed to load audio: ${id}`)
+    }
   }
 
   /**

--- a/apps/campfire/src/audio/AudioManager.ts
+++ b/apps/campfire/src/audio/AudioManager.ts
@@ -33,8 +33,18 @@ export class AudioManager {
     if (!src) return undefined
     try {
       // Validate the URL to avoid creating Audio elements with invalid sources
+      const baseUrl =
+        typeof window !== 'undefined' &&
+        window.location?.origin &&
+        window.location.origin !== 'null'
+          ? window.location.origin
+          : typeof document !== 'undefined' &&
+              document.baseURI &&
+              document.baseURI !== 'about:blank'
+            ? document.baseURI
+            : 'http://localhost'
       // eslint-disable-next-line no-new
-      new URL(src, 'http://localhost')
+      new URL(src, baseUrl)
     } catch {
       console.error(`Invalid audio source: ${src}`)
       return undefined

--- a/apps/campfire/src/audio/useAudioManager.ts
+++ b/apps/campfire/src/audio/useAudioManager.ts
@@ -1,0 +1,8 @@
+import { AudioManager } from './AudioManager'
+
+/**
+ * Hook returning the singleton AudioManager instance.
+ *
+ * @returns AudioManager instance.
+ */
+export const useAudioManager = () => AudioManager.getInstance()

--- a/apps/campfire/src/hooks/__tests__/audioDirectives.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/audioDirectives.test.tsx
@@ -53,6 +53,30 @@ describe('audio directives', () => {
     spy.mockRestore()
   })
 
+  it('plays sound effects from src only', () => {
+    const spy = spyOn(audio, 'playSfx').mockImplementation(() => {})
+    const nodes = unified()
+      .use(remarkParse)
+      .use(remarkDirective)
+      .parse(":sound{src='beep.mp3'}").children as RootContent[]
+    runDirectiveBlock(nodes, handlers)
+    expect(spy).toHaveBeenCalled()
+    expect(spy.mock.calls[0][0]).toBe('beep.mp3')
+    spy.mockRestore()
+  })
+
+  it('plays background music from src only', () => {
+    const spy = spyOn(audio, 'playBgm').mockImplementation(() => {})
+    const nodes = unified()
+      .use(remarkParse)
+      .use(remarkDirective)
+      .parse(":bgm{src='ambient.mp3'}").children as RootContent[]
+    runDirectiveBlock(nodes, handlers)
+    expect(spy).toHaveBeenCalled()
+    expect(spy.mock.calls[0][0]).toBe('ambient.mp3')
+    spy.mockRestore()
+  })
+
   it('stops background music', () => {
     const spy = spyOn(audio, 'stopBgm').mockImplementation(() => {})
     const nodes = unified()
@@ -76,5 +100,19 @@ describe('audio directives', () => {
     expect(sfxSpy).toHaveBeenCalledWith(0.7)
     bgmSpy.mockRestore()
     sfxSpy.mockRestore()
+  })
+})
+
+describe('AudioManager', () => {
+  it('scales track volume by global level', () => {
+    const manager = AudioManager.getInstance()
+    const fake = { volume: 0 } as HTMLAudioElement
+    ;(manager as unknown as { bgm: HTMLAudioElement | undefined }).bgm = fake
+    ;(manager as unknown as { bgmBaseVolume: number }).bgmBaseVolume = 0.5
+    manager.setBgmVolume(0.8)
+    expect(fake.volume).toBeCloseTo(0.4)
+    ;(manager as unknown as { bgm: HTMLAudioElement | undefined }).bgm =
+      undefined
+    ;(manager as unknown as { bgmBaseVolume: number }).bgmBaseVolume = 1
   })
 })

--- a/apps/campfire/src/hooks/__tests__/audioDirectives.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/audioDirectives.test.tsx
@@ -62,6 +62,7 @@ describe('audio directives', () => {
     runDirectiveBlock(nodes, handlers)
     expect(spy).toHaveBeenCalled()
     expect(spy.mock.calls[0][0]).toBe('beep.mp3')
+    expect(spy.mock.calls[0][1]?.src).toBeUndefined()
     spy.mockRestore()
   })
 
@@ -74,6 +75,7 @@ describe('audio directives', () => {
     runDirectiveBlock(nodes, handlers)
     expect(spy).toHaveBeenCalled()
     expect(spy.mock.calls[0][0]).toBe('ambient.mp3')
+    expect(spy.mock.calls[0][1]?.src).toBeUndefined()
     spy.mockRestore()
   })
 

--- a/apps/campfire/src/hooks/__tests__/audioDirectives.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/audioDirectives.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, spyOn } from 'bun:test'
+import { render } from '@testing-library/preact'
+import { unified } from 'unified'
+import remarkParse from 'remark-parse'
+import remarkDirective from 'remark-directive'
+import type { RootContent } from 'mdast'
+import { runDirectiveBlock } from '@campfire/utils/directiveUtils'
+import type { DirectiveHandler } from '@campfire/remark-campfire'
+import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
+import { AudioManager } from '@campfire/audio/AudioManager'
+import type { FunctionComponent } from 'preact'
+
+let handlers: Record<string, DirectiveHandler>
+let audio: AudioManager
+
+/**
+ * Component that captures directive handlers for testing.
+ *
+ * @returns Nothing.
+ */
+const HandlerGrabber: FunctionComponent = () => {
+  handlers = useDirectiveHandlers()
+  return null
+}
+
+beforeEach(() => {
+  audio = AudioManager.getInstance()
+  render(<HandlerGrabber />)
+})
+
+describe('audio directives', () => {
+  it('plays sound effects', () => {
+    const spy = spyOn(audio, 'playSfx').mockImplementation(() => {})
+    const nodes = unified()
+      .use(remarkParse)
+      .use(remarkDirective)
+      .parse(":sound[click]{src='click.wav' volume=0.5 delay=100}")
+      .children as RootContent[]
+    runDirectiveBlock(nodes, handlers)
+    expect(spy).toHaveBeenCalled()
+    spy.mockRestore()
+  })
+
+  it('controls background music', () => {
+    const spy = spyOn(audio, 'playBgm').mockImplementation(() => {})
+    const nodes = unified()
+      .use(remarkParse)
+      .use(remarkDirective)
+      .parse(":bgm[theme]{src='theme.mp3' volume=0.4 loop=false fade=200}")
+      .children as RootContent[]
+    runDirectiveBlock(nodes, handlers)
+    expect(spy).toHaveBeenCalled()
+    spy.mockRestore()
+  })
+
+  it('stops background music', () => {
+    const spy = spyOn(audio, 'stopBgm').mockImplementation(() => {})
+    const nodes = unified()
+      .use(remarkParse)
+      .use(remarkDirective)
+      .parse(':bgm{stop=true fade=300}').children as RootContent[]
+    runDirectiveBlock(nodes, handlers)
+    expect(spy).toHaveBeenCalledWith(300)
+    spy.mockRestore()
+  })
+
+  it('sets volume levels', () => {
+    const bgmSpy = spyOn(audio, 'setBgmVolume').mockImplementation(() => {})
+    const sfxSpy = spyOn(audio, 'setSfxVolume').mockImplementation(() => {})
+    const nodes = unified()
+      .use(remarkParse)
+      .use(remarkDirective)
+      .parse(':volume{bgm=0.2 sfx=0.7}').children as RootContent[]
+    runDirectiveBlock(nodes, handlers)
+    expect(bgmSpy).toHaveBeenCalledWith(0.2)
+    expect(sfxSpy).toHaveBeenCalledWith(0.7)
+    bgmSpy.mockRestore()
+    sfxSpy.mockRestore()
+  })
+})

--- a/apps/campfire/src/hooks/__tests__/audioDirectives.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/audioDirectives.test.tsx
@@ -107,14 +107,29 @@ describe('audio directives', () => {
 
 describe('AudioManager', () => {
   it('scales track volume by global level', () => {
+    const original = (globalThis as unknown as { Audio?: unknown }).Audio
+    let clone: any
+    class MockAudio {
+      volume = 1
+      preload = ''
+      loop = false
+      currentTime = 0
+      constructor(public src?: string) {}
+      play = () => Promise.resolve()
+      pause = () => {}
+      load = () => {}
+      cloneNode = () => {
+        clone = new MockAudio(this.src)
+        return clone
+      }
+    }
+    ;(globalThis as unknown as { Audio: unknown }).Audio = MockAudio
+
     const manager = AudioManager.getInstance()
-    const fake = { volume: 0 } as HTMLAudioElement
-    ;(manager as unknown as { bgm: HTMLAudioElement | undefined }).bgm = fake
-    ;(manager as unknown as { bgmBaseVolume: number }).bgmBaseVolume = 0.5
+    manager.playBgm('track', { src: 'test.mp3', volume: 0.5 })
     manager.setBgmVolume(0.8)
-    expect(fake.volume).toBeCloseTo(0.4)
-    ;(manager as unknown as { bgm: HTMLAudioElement | undefined }).bgm =
-      undefined
-    ;(manager as unknown as { bgmBaseVolume: number }).bgmBaseVolume = 1
+    expect(clone.volume).toBeCloseTo(0.4)
+    manager.stopBgm()
+    ;(globalThis as unknown as { Audio: unknown }).Audio = original
   })
 })

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -1610,8 +1610,10 @@ export const useDirectiveHandlers = () => {
     const src = attrs.src
     const volume = typeof attrs.volume === 'number' ? attrs.volume : undefined
     const delay = typeof attrs.delay === 'number' ? attrs.delay : undefined
-    if (id || src) {
-      audio.playSfx(id ?? src!, { src, volume, delay })
+    if (id) {
+      audio.playSfx(id, { src, volume, delay })
+    } else if (src) {
+      audio.playSfx(src, { src, volume, delay })
     } else {
       addError('sound directive requires id or src')
     }
@@ -1643,8 +1645,10 @@ export const useDirectiveHandlers = () => {
     const fade = typeof attrs.fade === 'number' ? attrs.fade : undefined
     if (stop) {
       audio.stopBgm(fade)
-    } else if (id || src) {
-      audio.playBgm(id ?? src!, { src, volume, loop, fade })
+    } else if (id) {
+      audio.playBgm(id, { src, volume, loop, fade })
+    } else if (src) {
+      audio.playBgm(src, { src, volume, loop, fade })
     } else {
       addError('bgm directive requires id or src')
     }

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -1613,7 +1613,7 @@ export const useDirectiveHandlers = () => {
     if (id) {
       audio.playSfx(id, { src, volume, delay })
     } else if (src) {
-      audio.playSfx(src, { src, volume, delay })
+      audio.playSfx(src, { volume, delay })
     } else {
       addError('sound directive requires id or src')
     }
@@ -1648,7 +1648,7 @@ export const useDirectiveHandlers = () => {
     } else if (id) {
       audio.playBgm(id, { src, volume, loop, fade })
     } else if (src) {
-      audio.playBgm(src, { src, volume, loop, fade })
+      audio.playBgm(src, { volume, loop, fade })
     } else {
       addError('bgm directive requires id or src')
     }

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -35,7 +35,8 @@ import {
   getLabel,
   isRange,
   removeNode,
-  stripLabel
+  stripLabel,
+  runWithIdOrSrc
 } from '@campfire/utils/directiveUtils'
 import {
   getRandomInt,
@@ -1592,33 +1593,6 @@ export const useDirectiveHandlers = () => {
   }
 
   /**
-   * Invokes an audio callback using either an id or a source URL.
-   *
-   * @param directive - The directive node being processed.
-   * @param attrs - Attribute map containing optional id and src fields.
-   * @param fn - Callback to invoke with the resolved identifier.
-   * @param opts - Options to pass to the callback.
-   * @param err - Error message when neither id nor src is supplied.
-   */
-  const runWithIdOrSrc = <T extends Record<string, unknown>>(
-    directive: DirectiveNode,
-    attrs: { id?: string; src?: string },
-    fn: (id: string, opts: T & { src?: string }) => void,
-    opts: T,
-    err: string
-  ): void => {
-    const id = hasLabel(directive) ? directive.label : attrs.id
-    const { src } = attrs
-    if (id) {
-      fn(id, { ...opts, src })
-    } else if (src) {
-      fn(src, { ...opts })
-    } else {
-      addError(err)
-    }
-  }
-
-  /**
    * Plays a sound effect or preloaded audio track.
    *
    * @param directive - The directive node being processed.
@@ -1640,7 +1614,8 @@ export const useDirectiveHandlers = () => {
       attrs,
       (id, opts) => audio.playSfx(id, opts),
       { volume, delay },
-      'sound directive requires id or src'
+      'sound directive requires id or src',
+      addError
     )
     return removeNode(parent, index)
   }
@@ -1674,7 +1649,8 @@ export const useDirectiveHandlers = () => {
         attrs,
         (id, opts) => audio.playBgm(id, opts),
         { volume, loop, fade },
-        'bgm directive requires id or src'
+        'bgm directive requires id or src',
+        addError
       )
     }
     return removeNode(parent, index)

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -1587,7 +1587,7 @@ export const useDirectiveHandlers = () => {
     if (id && src) {
       audio.load(id, src)
     } else {
-      addError('preloadAudio directive requires id and src')
+      addError('preloadAudio directive requires an id/label and src')
     }
     return removeNode(parent, index)
   }

--- a/apps/campfire/src/utils/directiveUtils.ts
+++ b/apps/campfire/src/utils/directiveUtils.ts
@@ -118,7 +118,9 @@ export const convertRanges = (obj: unknown): unknown => {
 }
 
 /**
- * Invokes a callback using either an id or a source URL from directive attributes.
+ * Invokes a callback using an id or source URL resolved from directive attributes.
+ * If both are provided, the id (or label) takes precedence and the src is passed
+ * through the options object.
  *
  * @param directive - Directive node being processed.
  * @param attrs - Attribute map containing optional id and src fields.

--- a/apps/campfire/src/utils/directiveUtils.ts
+++ b/apps/campfire/src/utils/directiveUtils.ts
@@ -118,6 +118,36 @@ export const convertRanges = (obj: unknown): unknown => {
 }
 
 /**
+ * Invokes a callback using either an id or a source URL from directive attributes.
+ *
+ * @param directive - Directive node being processed.
+ * @param attrs - Attribute map containing optional id and src fields.
+ * @param fn - Callback to invoke with the resolved identifier.
+ * @param opts - Options to pass to the callback.
+ * @param err - Error message when neither id nor src is supplied.
+ * @param onError - Callback for reporting errors.
+ */
+export const runWithIdOrSrc = <T extends Record<string, unknown>>(
+  directive: DirectiveNode,
+  attrs: { id?: string; src?: string },
+  fn: (id: string, opts: T & { src?: string }) => void,
+  opts: T,
+  err: string,
+  onError: (msg: string) => void = console.error
+): void => {
+  const label = (directive as { label?: unknown }).label
+  const id = typeof label === 'string' ? label : attrs.id
+  const { src } = attrs
+  if (id) {
+    fn(id, { ...opts, src })
+  } else if (src) {
+    fn(src, { ...opts })
+  } else {
+    onError(err)
+  }
+}
+
+/**
  * Removes a node from its parent at the specified index.
  *
  * @param parent - The parent node containing the children array.

--- a/docs/directives/audio.md
+++ b/docs/directives/audio.md
@@ -1,0 +1,57 @@
+# Audio
+
+Play sound effects and music.
+
+- `preloadAudio`: Preload an audio file for later use.
+
+  ```md
+  :preloadAudio[click]{src='audio/click.wav'}
+  ```
+
+  | Attribute | Description                    |
+  | --------- | ------------------------------ |
+  | `src`     | URL of the audio file          |
+  | `id`      | Unique identifier for the clip |
+
+- `sound`: Play a one-off sound effect.
+
+  ```md
+  :sound[click]{volume=0.5 delay=200}
+  ```
+
+  | Attribute | Description                         |
+  | --------- | ----------------------------------- |
+  | `id`      | Name of a preloaded track           |
+  | `src`     | URL of the audio file               |
+  | `volume`  | Volume level from 0–1               |
+  | `delay`   | Milliseconds to wait before playing |
+  | `rate`    | Playback speed                      |
+
+- `bgm`: Control background music. Use `stop=true` to stop.
+
+  ```md
+  :bgm[forest]{volume=0.4 loop=true fade=1000}
+  :bgm{stop=true fade=500}
+  ```
+
+  | Attribute | Description                                    |
+  | --------- | ---------------------------------------------- |
+  | `id`      | Name of a preloaded track                      |
+  | `src`     | URL of the audio file                          |
+  | `volume`  | Volume level from 0–1                          |
+  | `loop`    | Whether the track should loop (default `true`) |
+  | `fade`    | Milliseconds to cross-fade between tracks      |
+  | `stop`    | Stop the current background music when `true`  |
+
+- `volume`: Set global volume levels.
+
+  ```md
+  :volume{bgm=0.2 sfx=0.8}
+  ```
+
+  | Attribute | Description                      |
+  | --------- | -------------------------------- |
+  | `bgm`     | Background music volume from 0–1 |
+  | `sfx`     | Sound effects volume from 0–1    |
+
+Wrap string values in matching quotes or backticks. Unquoted values are treated as state keys when applicable.


### PR DESCRIPTION
## Summary
- add AudioManager singleton for preloading and playing audio
- support :preloadAudio, :sound, :bgm, and :volume directives
- document audio directives and reference in README
- cover audio directive handlers with unit tests

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68acb3060bec8322a6e0833a1b84a7d1