### PR TITLE
fix: default to dark theme

### DIFF
--- a/apps/storybook/.storybook/preview-head.html
+++ b/apps/storybook/.storybook/preview-head.html
@@ -9,17 +9,17 @@
   @theme {
     --font-libertinus: 'Libertinus Serif';
     /* Gray scale */
-    --color-gray-50: oklch(0.98 0 0);
-    --color-gray-100: oklch(0.95 0 0);
-    --color-gray-200: oklch(0.9 0 0);
-    --color-gray-300: oklch(0.8 0 0);
-    --color-gray-400: oklch(0.7 0 0);
+    --color-gray-50: oklch(0.2 0 0);
+    --color-gray-100: oklch(0.25 0 0);
+    --color-gray-200: oklch(0.3 0 0);
+    --color-gray-300: oklch(0.4 0 0);
+    --color-gray-400: oklch(0.5 0 0);
     --color-gray-500: oklch(0.6 0 0);
-    --color-gray-600: oklch(0.5 0 0);
-    --color-gray-700: oklch(0.4 0 0);
-    --color-gray-800: oklch(0.3 0 0);
-    --color-gray-900: oklch(0.2 0 0);
-    --color-gray-950: oklch(0.12 0 0);
+    --color-gray-600: oklch(0.7 0 0);
+    --color-gray-700: oklch(0.8 0 0);
+    --color-gray-800: oklch(0.9 0 0);
+    --color-gray-900: oklch(0.95 0 0);
+    --color-gray-950: oklch(0.98 0 0);
     /* Breakpoints */
     --breakpoint-xs: 400px;
     --breakpoint-sm: 640px;
@@ -36,23 +36,6 @@
     --size-2xl: 3rem; /* 48px */
   }
 
-  @media (prefers-color-scheme: dark) {
-    @theme {
-      /* Gray scale */
-      --color-gray-50: oklch(0.2 0 0);
-      --color-gray-100: oklch(0.25 0 0);
-      --color-gray-200: oklch(0.3 0 0);
-      --color-gray-300: oklch(0.4 0 0);
-      --color-gray-400: oklch(0.5 0 0);
-      --color-gray-500: oklch(0.6 0 0);
-      --color-gray-600: oklch(0.7 0 0);
-      --color-gray-700: oklch(0.8 0 0);
-      --color-gray-800: oklch(0.9 0 0);
-      --color-gray-900: oklch(0.95 0 0);
-      --color-gray-950: oklch(0.98 0 0);
-    }
-  }
-
   @layer utilities {
     .font-libertinus {
       font-family: var(--font-libertinus), serif;
@@ -66,11 +49,11 @@
       display: none;
     }
     body {
-      @apply dark:bg-[var(--color-gray-50)];
+      @apply bg-[var(--color-gray-50)];
     }
     html {
       font-size: 22px;
-      color-scheme: light dark;
+      color-scheme: dark;
     }
     p,
     h1,
@@ -79,6 +62,7 @@
     h4,
     h5,
     h6,
+    span,
     input,
     textarea,
     button,
@@ -93,7 +77,7 @@
     }
     th,
     td {
-      border-right: 1px solid var(--color-gray-200);
+      border-right: 1px solid var(--color-gray-700);
       padding: var(--size-xxs) var(--size-xs);
     }
     th:last-child,
@@ -101,30 +85,14 @@
       border-right: none;
     }
     thead tr {
-      border-bottom: 1px solid var(--color-gray-200);
-      background-color: var(--color-gray-50);
+      border-bottom: 1px solid var(--color-gray-700);
+      background-color: var(--color-gray-100);
     }
     tr:nth-child(even) {
-      background-color: var(--color-gray-50);
+      background-color: var(--color-gray-100);
     }
     #storybook-root {
       @apply absolute inset-0;
-    }
-  }
-  @media (prefers-color-scheme: dark) {
-    @layer base {
-      th,
-      td {
-        border-right: 1px solid var(--color-gray-700);
-        padding: var(--size-xxs) var(--size-xs);
-      }
-      thead tr {
-        border-bottom: 1px solid var(--color-gray-700);
-        background-color: var(--color-gray-100);
-      }
-      tr:nth-child(even) {
-        background-color: var(--color-gray-100);
-      }
     }
   }
 </style>

--- a/template.ejs
+++ b/template.ejs
@@ -14,17 +14,17 @@
       @theme {
         --font-libertinus: 'Libertinus Serif';
         /* Gray scale */
-        --color-gray-50: oklch(0.98 0 0);
-        --color-gray-100: oklch(0.95 0 0);
-        --color-gray-200: oklch(0.9 0 0);
-        --color-gray-300: oklch(0.8 0 0);
-        --color-gray-400: oklch(0.7 0 0);
+        --color-gray-50: oklch(0.2 0 0);
+        --color-gray-100: oklch(0.25 0 0);
+        --color-gray-200: oklch(0.3 0 0);
+        --color-gray-300: oklch(0.4 0 0);
+        --color-gray-400: oklch(0.5 0 0);
         --color-gray-500: oklch(0.6 0 0);
-        --color-gray-600: oklch(0.5 0 0);
-        --color-gray-700: oklch(0.4 0 0);
-        --color-gray-800: oklch(0.3 0 0);
-        --color-gray-900: oklch(0.2 0 0);
-        --color-gray-950: oklch(0.12 0 0);
+        --color-gray-600: oklch(0.7 0 0);
+        --color-gray-700: oklch(0.8 0 0);
+        --color-gray-800: oklch(0.9 0 0);
+        --color-gray-900: oklch(0.95 0 0);
+        --color-gray-950: oklch(0.98 0 0);
         /* Breakpoints */
         --breakpoint-xs: 400px;
         --breakpoint-sm: 640px;
@@ -41,23 +41,6 @@
         --size-2xl: 3rem;     /* 48px */
       }
 
-      @media (prefers-color-scheme: dark) {
-        @theme {
-          /* Gray scale */
-          --color-gray-50: oklch(0.2 0 0);
-          --color-gray-100: oklch(0.25 0 0);
-          --color-gray-200: oklch(0.3 0 0);
-          --color-gray-300: oklch(0.4 0 0);
-          --color-gray-400: oklch(0.5 0 0);
-          --color-gray-500: oklch(0.6 0 0);
-          --color-gray-600: oklch(0.7 0 0);
-          --color-gray-700: oklch(0.8 0 0);
-          --color-gray-800: oklch(0.9 0 0);
-          --color-gray-900: oklch(0.95 0 0);
-          --color-gray-950: oklch(0.98 0 0);
-        }
-      }
-
       @layer utilities {
         .font-libertinus {
           font-family: var(--font-libertinus), serif;
@@ -69,7 +52,7 @@
       @layer base {
         html {
           font-size: 22px;
-          color-scheme: light dark;
+          color-scheme: dark;
         }
         p,
         h1,
@@ -78,6 +61,7 @@
         h4,
         h5,
         h6,
+        span,
         input,
         textarea,
         button,
@@ -92,7 +76,7 @@
         }
         th,
         td {
-          border-right: 1px solid var(--color-gray-200);
+          border-right: 1px solid var(--color-gray-700);
           padding: var(--size-xxs) var(--size-xs);
         }
         th:last-child,
@@ -100,27 +84,11 @@
           border-right: none;
         }
         thead tr {
-          border-bottom: 1px solid var(--color-gray-200);
-          background-color: var(--color-gray-50);
+          border-bottom: 1px solid var(--color-gray-700);
+          background-color: var(--color-gray-100);
         }
         tr:nth-child(even) {
-          background-color: var(--color-gray-50);
-        }
-      }
-      @media (prefers-color-scheme: dark) {
-        @layer base {
-          th,
-          td {
-            border-right: 1px solid var(--color-gray-700);
-            padding: var(--size-xxs) var(--size-xs);
-          }
-          thead tr {
-            border-bottom: 1px solid var(--color-gray-700);
-            background-color: var(--color-gray-100);
-          }
-          tr:nth-child(even) {
-            background-color: var(--color-gray-100);
-          }
+          background-color: var(--color-gray-100);
         }
       }
     </style>


### PR DESCRIPTION
## Summary
- default `span` elements to Libertinus font in base template
- mirror default `span` font in Storybook preview
- remove light theme and default to dark mode in templates

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68adcd92f6b88322b20a871d5e16d3cf