### PR TITLE
feat: add select and option directives

### DIFF
--- a/apps/campfire/src/components/Deck/Slide/renderDirectiveMarkdown.ts
+++ b/apps/campfire/src/components/Deck/Slide/renderDirectiveMarkdown.ts
@@ -3,6 +3,8 @@ import type { DirectiveHandler } from '@campfire/remark-campfire'
 import { LinkButton } from '@campfire/components/Passage/LinkButton'
 import { TriggerButton } from '@campfire/components/Passage/TriggerButton'
 import { Input } from '@campfire/components/Passage/Input'
+import { Select } from '@campfire/components/Passage/Select'
+import { Option } from '@campfire/components/Passage/Option'
 import { If } from '@campfire/components/Passage/If'
 import { Show } from '@campfire/components/Passage/Show'
 import { Translate } from '@campfire/components/Passage/Translate'
@@ -30,6 +32,8 @@ export const renderDirectiveMarkdown = (
     button: LinkButton,
     trigger: TriggerButton,
     input: Input,
+    select: Select,
+    option: Option,
     if: If,
     show: Show,
     translate: Translate,

--- a/apps/campfire/src/components/Passage/Option.tsx
+++ b/apps/campfire/src/components/Passage/Option.tsx
@@ -28,8 +28,8 @@ export const Option = ({
       : []
   const mergedStyle =
     typeof style === 'string'
-      ? `color:#000;${style}`
-      : { color: '#000', ...(style ?? {}) }
+      ? `color:#000;background:#fff;${style}`
+      : { color: '#000', background: '#fff', ...(style ?? {}) }
   return (
     <option
       data-testid='option'

--- a/apps/campfire/src/components/Passage/Option.tsx
+++ b/apps/campfire/src/components/Passage/Option.tsx
@@ -10,20 +10,31 @@ interface OptionProps
  * Option element used within a select directive.
  *
  * @param className - Optional additional classes.
+ * @param style - Optional inline styles for the option element.
  * @param children - Display text for the option.
  * @param rest - Additional option element attributes.
  * @returns The rendered option element.
  */
-export const Option = ({ className, children, ...rest }: OptionProps) => {
+export const Option = ({
+  className,
+  style,
+  children,
+  ...rest
+}: OptionProps) => {
   const classes = Array.isArray(className)
     ? className
     : className
       ? [className]
       : []
+  const mergedStyle =
+    typeof style === 'string'
+      ? `color:#000;${style}`
+      : { color: '#000', ...(style ?? {}) }
   return (
     <option
       data-testid='option'
       className={['campfire-option', ...classes].join(' ')}
+      style={mergedStyle}
       {...rest}
     >
       {children}

--- a/apps/campfire/src/components/Passage/Option.tsx
+++ b/apps/campfire/src/components/Passage/Option.tsx
@@ -1,0 +1,34 @@
+import type { JSX } from 'preact'
+
+interface OptionProps
+  extends Omit<JSX.OptionHTMLAttributes<HTMLOptionElement>, 'className'> {
+  /** Additional CSS classes for the option element. */
+  className?: string | string[]
+}
+
+/**
+ * Option element used within a select directive.
+ *
+ * @param className - Optional additional classes.
+ * @param children - Display text for the option.
+ * @param rest - Additional option element attributes.
+ * @returns The rendered option element.
+ */
+export const Option = ({ className, children, ...rest }: OptionProps) => {
+  const classes = Array.isArray(className)
+    ? className
+    : className
+      ? [className]
+      : []
+  return (
+    <option
+      data-testid='option'
+      className={['campfire-option', ...classes].join(' ')}
+      {...rest}
+    >
+      {children}
+    </option>
+  )
+}
+
+export default Option

--- a/apps/campfire/src/components/Passage/Passage.tsx
+++ b/apps/campfire/src/components/Passage/Passage.tsx
@@ -19,6 +19,8 @@ import { useDeckStore } from '@campfire/state/useDeckStore'
 import { LinkButton } from '@campfire/components/Passage/LinkButton'
 import { TriggerButton } from '@campfire/components/Passage/TriggerButton'
 import { Input } from '@campfire/components/Passage/Input'
+import { Select } from '@campfire/components/Passage/Select'
+import { Option } from '@campfire/components/Passage/Option'
 import { If } from '@campfire/components/Passage/If'
 import { Show } from '@campfire/components/Passage/Show'
 import { Translate } from '@campfire/components/Passage/Translate'
@@ -83,6 +85,8 @@ export const Passage = () => {
           button: LinkButton,
           trigger: TriggerButton,
           input: Input,
+          select: Select,
+          option: Option,
           if: If,
           show: Show,
           translate: Translate,

--- a/apps/campfire/src/components/Passage/Select.tsx
+++ b/apps/campfire/src/components/Passage/Select.tsx
@@ -61,8 +61,13 @@ export const Select = ({
       : []
   const mergedStyle =
     typeof style === 'string'
-      ? `border:1px solid black;color:#000;${style}`
-      : { border: '1px solid black', color: '#000', ...(style ?? {}) }
+      ? `border:1px solid black;color:#000;background:#fff;${style}`
+      : {
+          border: '1px solid black',
+          color: '#000',
+          background: '#fff',
+          ...(style ?? {})
+        }
   return (
     <select
       data-testid='select'

--- a/apps/campfire/src/components/Passage/Select.tsx
+++ b/apps/campfire/src/components/Passage/Select.tsx
@@ -34,6 +34,7 @@ interface SelectProps
  * @param onHover - Serialized directives to run when hovered.
  * @param onFocus - Serialized directives to run on focus.
  * @param onBlur - Serialized directives to run on blur.
+ * @param style - Optional inline styles for the select element.
  * @param rest - Additional select element attributes.
  * @returns The rendered select element.
  */
@@ -44,6 +45,7 @@ export const Select = ({
   onFocus,
   onBlur,
   onInput,
+  style,
   children,
   ...rest
 }: SelectProps) => {
@@ -57,11 +59,16 @@ export const Select = ({
     : className
       ? [className]
       : []
+  const mergedStyle =
+    typeof style === 'string'
+      ? `border:1px solid black;color:#000;${style}`
+      : { border: '1px solid black', color: '#000', ...(style ?? {}) }
   return (
     <select
       data-testid='select'
       className={['campfire-select', ...classes].join(' ')}
       value={value ?? ''}
+      style={mergedStyle}
       {...rest}
       onMouseEnter={e => {
         if (onHover) {

--- a/apps/campfire/src/components/Passage/Select.tsx
+++ b/apps/campfire/src/components/Passage/Select.tsx
@@ -1,0 +1,102 @@
+import type { JSX } from 'preact'
+import rfdc from 'rfdc'
+import type { RootContent } from 'mdast'
+import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
+import { runDirectiveBlock } from '@campfire/utils/directiveUtils'
+import { useGameStore } from '@campfire/state/useGameStore'
+
+const clone = rfdc()
+
+interface SelectProps
+  extends Omit<
+    JSX.SelectHTMLAttributes<HTMLSelectElement>,
+    'className' | 'value' | 'onInput' | 'onFocus' | 'onBlur' | 'onMouseEnter'
+  > {
+  /** Key in game state to bind the select value to. */
+  stateKey: string
+  /** Additional CSS classes for the select element. */
+  className?: string | string[]
+  /** Serialized directives to run when hovered. */
+  onHover?: string
+  /** Serialized directives to run on focus. */
+  onFocus?: string
+  /** Serialized directives to run on blur. */
+  onBlur?: string
+  /** Optional input event handler. */
+  onInput?: JSX.SelectHTMLAttributes<HTMLSelectElement>['onInput']
+}
+
+/**
+ * Select element bound to a game state key. Updates the key on selection change.
+ *
+ * @param stateKey - Key in game state to store the selected value.
+ * @param className - Optional additional classes.
+ * @param onHover - Serialized directives to run when hovered.
+ * @param onFocus - Serialized directives to run on focus.
+ * @param onBlur - Serialized directives to run on blur.
+ * @param rest - Additional select element attributes.
+ * @returns The rendered select element.
+ */
+export const Select = ({
+  stateKey,
+  className,
+  onHover,
+  onFocus,
+  onBlur,
+  onInput,
+  children,
+  ...rest
+}: SelectProps) => {
+  const value = useGameStore(state => state.gameData[stateKey]) as
+    | string
+    | undefined
+  const setGameData = useGameStore(state => state.setGameData)
+  const handlers = useDirectiveHandlers()
+  const classes = Array.isArray(className)
+    ? className
+    : className
+      ? [className]
+      : []
+  return (
+    <select
+      data-testid='select'
+      className={['campfire-select', ...classes].join(' ')}
+      value={value ?? ''}
+      {...rest}
+      onMouseEnter={e => {
+        if (onHover) {
+          runDirectiveBlock(
+            clone(JSON.parse(onHover)) as RootContent[],
+            handlers
+          )
+        }
+      }}
+      onFocus={e => {
+        if (onFocus) {
+          runDirectiveBlock(
+            clone(JSON.parse(onFocus)) as RootContent[],
+            handlers
+          )
+        }
+      }}
+      onBlur={e => {
+        if (onBlur) {
+          runDirectiveBlock(
+            clone(JSON.parse(onBlur)) as RootContent[],
+            handlers
+          )
+        }
+      }}
+      onInput={e => {
+        onInput?.(e)
+        if (e.defaultPrevented) return
+        const target = e.currentTarget as HTMLSelectElement
+        setGameData({ [stateKey]: target.value })
+      }}
+    >
+      {children}
+    </select>
+  )
+}
+
+export default Select

--- a/apps/campfire/src/components/Passage/__tests__/Select.directive.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Select.directive.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach } from 'bun:test'
+import { render, screen, fireEvent, act } from '@testing-library/preact'
+import type { Element } from 'hast'
+import { Passage } from '@campfire/components/Passage/Passage'
+import { useStoryDataStore } from '@campfire/state/useStoryDataStore'
+import { useGameStore } from '@campfire/state/useGameStore'
+import { resetStores } from '@campfire/test-utils/helpers'
+
+/**
+ * Tests for Select directive attributes.
+ */
+describe('Select directive', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    resetStores()
+  })
+
+  it('passes className and style attributes', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value:
+            ':::select[color]{className="extra" style="color:blue"}\n:option{value="red" label="Red"}\n:option{value="blue" label="Blue"}\n:::\n'
+        }
+      ]
+    }
+    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+    render(<Passage />)
+    const select = await screen.findByTestId('select')
+    expect((select as HTMLSelectElement).style.color).toBe('blue')
+    expect(select.className.split(' ')).toContain('extra')
+    fireEvent.input(select, { target: { value: 'blue' } })
+    expect(
+      (useGameStore.getState().gameData as Record<string, unknown>).color
+    ).toBe('blue')
+  })
+
+  it('runs event directives when used as a container', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value:
+            ':::select[color]\n:option{value="red" label="Red"}\n:option{value="blue" label="Blue"}\n:::onFocus\n:set[focused=true]\n:::\n:::onHover\n:set[hovered=true]\n:::\n:::\n'
+        }
+      ]
+    }
+    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+    render(<Passage />)
+    const select = await screen.findByTestId('select')
+    act(() => {
+      ;(select as HTMLSelectElement).focus()
+    })
+    expect(useGameStore.getState().gameData.focused).toBe(true)
+    fireEvent.mouseEnter(select)
+    expect(useGameStore.getState().gameData.hovered).toBe(true)
+  })
+
+  it('removes directive markers for container selects', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value: ':::select[color]\n:option{value="red" label="Red"}\n:::\n'
+        }
+      ]
+    }
+    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+    render(<Passage />)
+    await screen.findByTestId('select')
+    expect(document.body.textContent).not.toContain(':::')
+  })
+})

--- a/apps/campfire/src/components/Passage/__tests__/Select.directive.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Select.directive.test.tsx
@@ -33,6 +33,7 @@ describe('Select directive', () => {
     const select = await screen.findByTestId('select')
     expect((select as HTMLSelectElement).style.color).toBe('blue')
     expect((select as HTMLSelectElement).style.border).toBe('1px solid black')
+    expect((select as HTMLSelectElement).style.backgroundColor).toBe('#fff')
     expect(select.className.split(' ')).toContain('extra')
     fireEvent.input(select, { target: { value: 'blue' } })
     expect(

--- a/apps/campfire/src/components/Passage/__tests__/Select.directive.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Select.directive.test.tsx
@@ -32,6 +32,7 @@ describe('Select directive', () => {
     render(<Passage />)
     const select = await screen.findByTestId('select')
     expect((select as HTMLSelectElement).style.color).toBe('blue')
+    expect((select as HTMLSelectElement).style.border).toBe('1px solid black')
     expect(select.className.split(' ')).toContain('extra')
     fireEvent.input(select, { target: { value: 'blue' } })
     expect(

--- a/apps/campfire/src/components/Passage/__tests__/Select.directive.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Select.directive.test.tsx
@@ -41,7 +41,7 @@ describe('Select directive', () => {
     ).toBe('blue')
   })
 
-  it('runs event directives when used as a container', async () => {
+  it('runs event directives only on interaction', async () => {
     const passage: Element = {
       type: 'element',
       tagName: 'tw-passagedata',
@@ -50,17 +50,22 @@ describe('Select directive', () => {
         {
           type: 'text',
           value:
-            ':::select[color]\n:option{value="red" label="Red"}\n:option{value="blue" label="Blue"}\n:::onFocus\n:set[focused=true]\n:::\n:::onHover\n:set[hovered=true]\n:::\n:::\n'
+            ':::select[color]\n:option{value="red" label="Red"}\n:option{value="blue" label="Blue"}\n:::onFocus\n:set[focused=true]\n:::\n:::onBlur\n:set[blurred=true]\n:::\n:::onHover\n:set[hovered=true]\n:::\n:::\n'
         }
       ]
     }
     useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
     render(<Passage />)
     const select = await screen.findByTestId('select')
+    expect(useGameStore.getState().gameData.focused).toBeUndefined()
     act(() => {
       ;(select as HTMLSelectElement).focus()
     })
     expect(useGameStore.getState().gameData.focused).toBe(true)
+    act(() => {
+      ;(select as HTMLSelectElement).blur()
+    })
+    expect(useGameStore.getState().gameData.blurred).toBe(true)
     fireEvent.mouseEnter(select)
     expect(useGameStore.getState().gameData.hovered).toBe(true)
   })

--- a/apps/campfire/src/components/Passage/__tests__/Select.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Select.test.tsx
@@ -34,4 +34,15 @@ describe('Select', () => {
     expect(field.className.split(' ')).toContain('extra')
     expect(field.style.color).toBe('red')
   })
+
+  it('renders with default border and text color', () => {
+    const { getByTestId } = render(
+      <Select stateKey='field'>
+        <Option value='a'>A</Option>
+      </Select>
+    )
+    const field = getByTestId('select') as HTMLSelectElement
+    expect(field.style.border).toBe('1px solid black')
+    expect(field.style.color).toBe('#000')
+  })
 })

--- a/apps/campfire/src/components/Passage/__tests__/Select.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Select.test.tsx
@@ -35,7 +35,7 @@ describe('Select', () => {
     expect(field.style.color).toBe('red')
   })
 
-  it('renders with default border and text color', () => {
+  it('renders with default border, text color, and background', () => {
     const { getByTestId } = render(
       <Select stateKey='field'>
         <Option value='a'>A</Option>
@@ -44,5 +44,6 @@ describe('Select', () => {
     const field = getByTestId('select') as HTMLSelectElement
     expect(field.style.border).toBe('1px solid black')
     expect(field.style.color).toBe('#000')
+    expect(field.style.backgroundColor).toBe('#fff')
   })
 })

--- a/apps/campfire/src/components/Passage/__tests__/Select.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Select.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'bun:test'
+import { render, fireEvent } from '@testing-library/preact'
+import { Select } from '@campfire/components/Passage/Select'
+import { Option } from '@campfire/components/Passage/Option'
+import { useGameStore } from '@campfire/state/useGameStore'
+
+/**
+ * Tests for the Select component.
+ */
+describe('Select', () => {
+  it('updates game state on change', () => {
+    useGameStore.setState({ gameData: { color: 'red' } })
+    const { getByTestId } = render(
+      <Select stateKey='color'>
+        <Option value='red'>Red</Option>
+        <Option value='blue'>Blue</Option>
+      </Select>
+    )
+    const field = getByTestId('select') as HTMLSelectElement
+    fireEvent.input(field, { target: { value: 'blue' } })
+    expect(
+      (useGameStore.getState().gameData as Record<string, unknown>).color
+    ).toBe('blue')
+  })
+
+  it('applies className and style', () => {
+    const { getByTestId } = render(
+      <Select stateKey='field' className='extra' style={{ color: 'red' }}>
+        <Option value='a'>A</Option>
+      </Select>
+    )
+    const field = getByTestId('select') as HTMLSelectElement
+    expect(field.className.split(' ')).toContain('campfire-select')
+    expect(field.className.split(' ')).toContain('extra')
+    expect(field.style.color).toBe('red')
+  })
+})

--- a/apps/campfire/src/components/index.ts
+++ b/apps/campfire/src/components/index.ts
@@ -4,6 +4,8 @@ export { evaluateUserScript } from '@campfire/components/Campfire/evaluateUserSc
 export { Passage } from '@campfire/components/Passage/Passage'
 export { LinkButton } from '@campfire/components/Passage/LinkButton'
 export { Input } from '@campfire/components/Passage/Input'
+export { Select } from '@campfire/components/Passage/Select'
+export { Option } from '@campfire/components/Passage/Option'
 export { TriggerButton } from '@campfire/components/Passage/TriggerButton'
 export { If } from '@campfire/components/Passage/If'
 export { Show } from '@campfire/components/Passage/Show'

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -1270,8 +1270,7 @@ export const useDirectiveHandlers = () => {
     const classAttr = typeof attrs.className === 'string' ? attrs.className : ''
     const styleAttr = typeof attrs.style === 'string' ? attrs.style : undefined
     const rawChildren = runDirectiveBlock(
-      expandIndentedCode(container.children as RootContent[]),
-      handlersRef.current
+      expandIndentedCode(container.children as RootContent[])
     )
     const { events, remaining } = extractEventProps(rawChildren)
     const options = remaining.filter(node => !isWhitespaceNode(node))

--- a/apps/storybook/src/SelectDirective.stories.tsx
+++ b/apps/storybook/src/SelectDirective.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from '@storybook/preact'
+import { Campfire } from '@campfire/components'
+
+const meta: Meta = {
+  title: 'Campfire/Directives/Select'
+}
+
+export default meta
+
+/**
+ * Demonstrates the `select` directive bound to game state.
+ *
+ * @returns Campfire story showcasing the `select` directive.
+ */
+export const Basic: StoryObj = {
+  render: () => (
+    <>
+      <tw-storydata startnode='1' options='debug'>
+        <tw-passagedata pid='1' name='Start'>
+          {`
+:::select[color]
+:option{value="red" label="Red"}
+:option{value="blue" label="Blue"}
+:::
+:::if[color]
+You chose :show[color].
+:::
+          `}
+        </tw-passagedata>
+      </tw-storydata>
+      <Campfire />
+    </>
+  )
+}
+
+/**
+ * Demonstrates the `select` directive with event directives.
+ *
+ * @returns Campfire story showcasing select events.
+ */
+export const WithEvents: StoryObj = {
+  render: () => (
+    <>
+      <tw-storydata startnode='1' options='debug'>
+        <tw-passagedata pid='1' name='Start'>
+          {`
+:::select[color]
+:option{value="red" label="Red"}
+:option{value="blue" label="Blue"}
+:::onFocus
+  :set[focused=true]
+:::
+:::onBlur
+  :unset[focused]
+:::
+:::if[focused]
+Focused!
+:::
+:::
+          `}
+        </tw-passagedata>
+      </tw-storydata>
+      <Campfire />
+    </>
+  )
+}

--- a/docs/directives/inputs-and-events.md
+++ b/docs/directives/inputs-and-events.md
@@ -26,6 +26,30 @@ Collect data or trigger actions directly in the passage.
   | className   | Optional space-separated classes           |
   | style       | Optional inline style declarations         |
 
+- `select`: Render a dropdown bound to a game state key. Must be used as a container with nested `option` directives. The container form can include event directives.
+
+  ```md
+  :::select[color]
+  :option{value="red" label="Red"}
+  :option{value="blue" label="Blue"}
+  :::
+  ```
+
+  | Input     | Description                                 |
+  | --------- | ------------------------------------------- |
+  | state_key | Key in game state to store the select value |
+  | className | Optional space-separated classes            |
+  | style     | Optional inline style declarations          |
+
+  `option` directives accept the following inputs:
+
+  | Input     | Description                        |
+  | --------- | ---------------------------------- |
+  | value     | Value to store when selected       |
+  | label     | Text displayed for the option      |
+  | className | Optional space-separated classes   |
+  | style     | Optional inline style declarations |
+
 - `trigger`: Render a button that runs directives when clicked. Supports event directives inside the block.
 
   ```md

--- a/docs/directives/inputs-and-events.md
+++ b/docs/directives/inputs-and-events.md
@@ -41,6 +41,9 @@ Collect data or trigger actions directly in the passage.
   | className | Optional space-separated classes            |
   | style     | Optional inline style declarations          |
 
+  Both the select and option elements include a visible black border,
+  black text, and a white background by default to ensure readability.
+
   `option` directives accept the following inputs:
 
   | Input     | Description                        |

--- a/docs/directives/inputs-and-events.md
+++ b/docs/directives/inputs-and-events.md
@@ -8,10 +8,16 @@ Collect data or trigger actions directly in the passage.
 
 - `input`: Render a text input bound to a game state key. Use as a leaf or container. The container form can include event directives.
 
+  Leaf form:
+
   ```md
   :input[name]{placeholder="Your name"}
+  ```
 
-  :::input[name]
+  Container form:
+
+  ```md
+  :::input[email]
   :::onFocus
   :set[focused=true]
   :::

--- a/docs/directives/inputs-and-events.md
+++ b/docs/directives/inputs-and-events.md
@@ -81,7 +81,7 @@ Collect data or trigger actions directly in the passage.
 
 ### Event directives
 
-Use event directives inside `input` or `trigger` blocks to run directives on interaction.
+Use event directives inside `input`, `select`, or `trigger` blocks to run directives on interaction.
 
 | Directive | Fires when the element... |
 | --------- | ------------------------- |


### PR DESCRIPTION
## Summary
- add Select and Option components for new `:select` and `:option` directives
- wire directives into handler pipeline and document usage
- cover new interactive directives with tests and Storybook stories

## Testing
- `bun tsc`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_68addfbf394c832284e272e2a20a12f4