### PR TITLE
fix: unwrap if and show directives from paragraphs

### DIFF
--- a/apps/campfire/src/rehype-campfire/__tests__/index.test.ts
+++ b/apps/campfire/src/rehype-campfire/__tests__/index.test.ts
@@ -246,4 +246,32 @@ describe('rehypeCampfire', () => {
     expect(content[0].tagName).toBe('show')
     expect(content[1].value).toBe('.')
   })
+
+  it('unwraps paragraphs inside if directive fallback', () => {
+    const tree: Root = {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tagName: 'if',
+          properties: {
+            test: 'false',
+            fallback: JSON.stringify([
+              {
+                type: 'paragraph',
+                children: [{ type: 'text', value: 'Flag is false' }]
+              }
+            ])
+          },
+          children: []
+        }
+      ]
+    }
+    rehypeCampfire()(tree)
+    const first = tree.children[0] as any
+    const fallback = JSON.parse(first.properties.fallback)
+    expect(fallback).toHaveLength(1)
+    expect(fallback[0].type).toBe('text')
+    expect(fallback[0].value).toBe('Flag is false')
+  })
 })


### PR DESCRIPTION
## Summary
- unwrap `if` and `show` directives from surrounding `<p>` tags
- test directive unwrapping in rehype plugin

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_68ae712c4e6083228803f2fc13148db9