### PR TITLE
fix: handle nested quotes in extractQuoted

### DIFF
--- a/apps/campfire/src/utils/__tests__/core.test.ts
+++ b/apps/campfire/src/utils/__tests__/core.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'bun:test'
+import { extractQuoted } from '@campfire/utils/core'
+
+describe('extractQuoted', () => {
+  it('unwraps single-quoted strings', () => {
+    expect(extractQuoted("'hello'")).toBe('hello')
+  })
+
+  it('unwraps double-quoted strings', () => {
+    expect(extractQuoted('"hello"')).toBe('hello')
+  })
+
+  it('unwraps back-quoted strings', () => {
+    expect(extractQuoted('`hello`')).toBe('hello')
+  })
+
+  it('handles nested quotes', () => {
+    expect(extractQuoted('\'He said "hi"\'')).toBe('He said "hi"')
+    expect(extractQuoted('"It\'s fine"')).toBe("It's fine")
+    expect(extractQuoted('`mix "and" \'match\'`')).toBe('mix "and" \'match\'')
+  })
+})

--- a/apps/campfire/src/utils/core.ts
+++ b/apps/campfire/src/utils/core.ts
@@ -2,7 +2,7 @@ import { compile } from 'expression-eval'
 import type { JSX } from 'preact'
 
 /** Pattern matching a string enclosed in matching quotes or backticks. */
-export const QUOTE_PATTERN = /^(['"`])(.*)\1$/
+export const QUOTE_PATTERN = /^(['"`])(.*?)\1$/
 
 /**
  * Extracts the inner content from a string wrapped in matching quotes or


### PR DESCRIPTION
## Summary
- make QUOTE_PATTERN non-greedy to better parse nested quoted strings
- cover extractQuoted with tests for single, double, backtick, and nested quotes

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68ae48a1239083229bce9153aaf33960