### PR TITLE
refactor: rename campfire root class

### DIFF
--- a/apps/campfire/src/components/Campfire/__tests__/Campfire.test.tsx
+++ b/apps/campfire/src/components/Campfire/__tests__/Campfire.test.tsx
@@ -50,7 +50,7 @@ describe('Story', () => {
     const text = await screen.findByText(/Hello/)
     expect(text).toBeInTheDocument()
     const container = screen.getByTestId('campfire')
-    expect(container.className).toContain('campfire-campfire')
+    expect(container.className).toContain('campfire-base')
   })
 
   it('initializes the story on mount', () => {

--- a/apps/campfire/src/components/Campfire/index.tsx
+++ b/apps/campfire/src/components/Campfire/index.tsx
@@ -128,7 +128,7 @@ export const Campfire = ({
   return (
     <div
       className={
-        'campfire-campfire absolute inset-0 overflow-y-auto overflow-x-hidden'
+        'campfire-base absolute inset-0 overflow-y-auto overflow-x-hidden'
       }
       data-testid='campfire'
     >

--- a/docs/styling-elements.md
+++ b/docs/styling-elements.md
@@ -2,7 +2,7 @@
 
 Campfire's visual components expose unstyled classes prefixed with `campfire-`, letting you theme the interface without having to override defaults. Common selectors include:
 
-- `.campfire-campfire` – root story container
+- `.campfire-base` – root story container
 - `.campfire-passage` – wrapper around rendered passages; includes `h-full` for full height
 - `.campfire-link` – buttons generated from Twine `[[Link]]` syntax
 - `.campfire-trigger` – buttons created by the trigger directive


### PR DESCRIPTION
## Summary
- rename `.campfire-campfire` class to `.campfire-base`
- update docs and tests for renamed class

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68ae98d322308322831470ee1b5d23c5