### PR TITLE
test: add reusable ResizeObserver mock

### DIFF
--- a/apps/campfire/src/components/Deck/Slide/SlideReveal/__tests__/SlideReveal.test.tsx
+++ b/apps/campfire/src/components/Deck/Slide/SlideReveal/__tests__/SlideReveal.test.tsx
@@ -5,6 +5,7 @@ import { Slide } from '@campfire/components/Deck/Slide'
 import { SlideReveal } from '@campfire/components/Deck/Slide'
 import { useDeckStore } from '@campfire/state/useDeckStore'
 import { StubAnimation } from '@campfire/test-utils/stub-animation'
+import { setupResizeObserver } from '@campfire/test-utils/helpers'
 
 /**
  * Resets the deck store to a clean initial state.
@@ -13,15 +14,8 @@ const resetStore = () => {
   useDeckStore.getState().reset()
 }
 
-// Minimal ResizeObserver stub for the tests
-class StubResizeObserver {
-  observe() {}
-  disconnect() {}
-}
-
 beforeEach(() => {
-  // @ts-expect-error override for tests
-  globalThis.ResizeObserver = StubResizeObserver
+  setupResizeObserver()
   resetStore()
   document.body.innerHTML = ''
 })

--- a/apps/campfire/src/components/Deck/Slide/__tests__/Slide.test.tsx
+++ b/apps/campfire/src/components/Deck/Slide/__tests__/Slide.test.tsx
@@ -5,6 +5,7 @@ import { Slide, type SlideProps } from '@campfire/components/Deck/Slide'
 import { useDeckStore } from '@campfire/state/useDeckStore'
 import type { VNode } from 'preact'
 import { StubAnimation } from '@campfire/test-utils/stub-animation'
+import { setupResizeObserver } from '@campfire/test-utils/helpers'
 
 /**
  * Resets the deck store to a clean initial state.
@@ -13,15 +14,8 @@ const resetStore = () => {
   useDeckStore.getState().reset()
 }
 
-// Minimal ResizeObserver stub for the tests
-class StubResizeObserver {
-  observe() {}
-  disconnect() {}
-}
-
 beforeEach(() => {
-  // @ts-expect-error override for tests
-  globalThis.ResizeObserver = StubResizeObserver
+  setupResizeObserver()
   // @ts-expect-error override animate
   HTMLElement.prototype.animate = () => new StubAnimation()
   resetStore()

--- a/apps/campfire/src/components/Deck/Slide/__tests__/SlideDirective.test.tsx
+++ b/apps/campfire/src/components/Deck/Slide/__tests__/SlideDirective.test.tsx
@@ -3,7 +3,7 @@ import { render, act, fireEvent } from '@testing-library/preact'
 import { Deck, Slide, TriggerButton } from '@campfire/components'
 import { useDeckStore } from '@campfire/state/useDeckStore'
 import { useGameStore } from '@campfire/state/useGameStore'
-import { resetStores } from '@campfire/test-utils/helpers'
+import { resetStores, setupResizeObserver } from '@campfire/test-utils/helpers'
 import { StubAnimation } from '@campfire/test-utils/stub-animation'
 import { unified } from 'unified'
 import remarkParse from 'remark-parse'
@@ -24,16 +24,8 @@ const resetDeckStore = () => {
   useDeckStore.getState().reset()
 }
 
-// Minimal ResizeObserver stub for the tests
-class StubResizeObserver {
-  observe() {}
-  unobserve() {}
-  disconnect() {}
-}
-
 beforeEach(() => {
-  globalThis.ResizeObserver =
-    StubResizeObserver as unknown as typeof ResizeObserver
+  setupResizeObserver()
   // @ts-expect-error override animate
   HTMLElement.prototype.animate = () => new StubAnimation()
   resetDeckStore()

--- a/apps/campfire/src/components/Deck/__tests__/Deck.slideTransition.test.tsx
+++ b/apps/campfire/src/components/Deck/__tests__/Deck.slideTransition.test.tsx
@@ -5,6 +5,7 @@ import { Deck } from '@campfire/components/Deck'
 import { Slide } from '@campfire/components/Deck/Slide'
 import { useDeckStore } from '@campfire/state/useDeckStore'
 import { StubAnimation } from '@campfire/test-utils/stub-animation'
+import { setupResizeObserver } from '@campfire/test-utils/helpers'
 
 /**
  * Resets the deck store to a clean initial state.
@@ -13,14 +14,8 @@ const resetStore = (): void => {
   useDeckStore.getState().reset()
 }
 
-/** Minimal ResizeObserver stub for the tests. */
-class StubResizeObserver {
-  observe(): void {}
-  disconnect(): void {}
-}
-
 beforeEach(() => {
-  ;(globalThis as any).ResizeObserver = StubResizeObserver
+  setupResizeObserver()
   resetStore()
   document.body.innerHTML = ''
   const animateStub: typeof HTMLElement.prototype.animate = () =>

--- a/apps/campfire/src/components/Deck/__tests__/Deck.test.tsx
+++ b/apps/campfire/src/components/Deck/__tests__/Deck.test.tsx
@@ -5,6 +5,7 @@ import { SlideReveal, Slide } from '@campfire/components/Deck/Slide'
 import { LinkButton } from '@campfire/components'
 import { useDeckStore } from '@campfire/state/useDeckStore'
 import { StubAnimation } from '@campfire/test-utils/stub-animation'
+import { setupResizeObserver } from '@campfire/test-utils/helpers'
 
 /**
  * Resets the deck store to a clean initial state.
@@ -13,14 +14,8 @@ const resetStore = () => {
   useDeckStore.getState().reset()
 }
 
-// Minimal ResizeObserver stub for the tests
-class StubResizeObserver {
-  observe() {}
-  disconnect() {}
-}
-
 beforeEach(() => {
-  ;(globalThis as any).ResizeObserver = StubResizeObserver
+  setupResizeObserver()
   resetStore()
   document.body.innerHTML = ''
   HTMLElement.prototype.animate = () =>

--- a/apps/campfire/src/hooks/__tests__/useScale.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/useScale.test.tsx
@@ -1,26 +1,7 @@
 import { render, act } from '@testing-library/preact'
 import { describe, it, expect } from 'bun:test'
 import { useScale, MIN_SCALE } from '@campfire/hooks/useScale'
-
-/**
- * Replaces the global ResizeObserver with a mock that allows manual
- * triggering of resize callbacks.
- *
- * @returns A function that invokes the stored resize callback.
- */
-const setupResizeObserver = () => {
-  let callback: ResizeObserverCallback = () => {}
-  class MockResizeObserver {
-    constructor(cb: ResizeObserverCallback) {
-      callback = cb
-    }
-    observe() {}
-    disconnect() {}
-  }
-  // @ts-expect-error override for tests
-  globalThis.ResizeObserver = MockResizeObserver
-  return () => callback([], {} as ResizeObserver)
-}
+import { setupResizeObserver } from '@campfire/test-utils/helpers'
 
 describe('useScale', () => {
   it('updates scale when container size changes', () => {

--- a/apps/campfire/src/test-utils/helpers.ts
+++ b/apps/campfire/src/test-utils/helpers.ts
@@ -38,3 +38,26 @@ export const resetStores = () => {
  */
 export const getSvgClassName = (svg: SVGElement) =>
   typeof svg.className === 'object' ? svg.className.baseVal : svg.className
+
+/**
+ * Installs a minimal `ResizeObserver` mock and returns a trigger function.
+ *
+ * @returns A function that invokes the stored resize callback.
+ */
+export const setupResizeObserver = () => {
+  let callback: ResizeObserverCallback = () => {}
+  class MockResizeObserver {
+    constructor(cb: ResizeObserverCallback) {
+      callback = cb
+    }
+    observe = () => {}
+    unobserve = () => {}
+    disconnect = () => {}
+  }
+  globalThis.ResizeObserver =
+    MockResizeObserver as unknown as typeof ResizeObserver
+  return (
+    entries: ResizeObserverEntry[] = [],
+    observer: ResizeObserver = {} as ResizeObserver
+  ) => callback(entries, observer)
+}


### PR DESCRIPTION
## Summary
- add setupResizeObserver helper for tests
- reuse helper across Deck and hook tests

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68ae989553588322896c9e0f0308be9e