### PR TITLE
feat: default Libertinus font for div, input, select, and textarea

### DIFF
--- a/apps/storybook/.storybook/preview-head.html
+++ b/apps/storybook/.storybook/preview-head.html
@@ -55,6 +55,7 @@
       font-size: 22px;
       color-scheme: dark;
     }
+    div,
     p,
     h1,
     h2,
@@ -65,6 +66,7 @@
     span,
     input,
     textarea,
+    select,
     button,
     table {
       @apply font-libertinus;

--- a/template.ejs
+++ b/template.ejs
@@ -54,6 +54,7 @@
           font-size: 22px;
           color-scheme: dark;
         }
+        div,
         p,
         h1,
         h2,
@@ -64,6 +65,7 @@
         span,
         input,
         textarea,
+        select,
         button,
         table {
           @apply font-libertinus;


### PR DESCRIPTION
## Summary
- apply Libertinus font to div elements by default
- ensure Storybook preview uses same font defaults
- extend default font to select elements for consistent typography

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68af09b5d6288322b04139ab65085665