### PR TITLE
test: share form field test helper

### DIFF
--- a/apps/campfire/src/components/Passage/__tests__/Input.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Input.test.tsx
@@ -1,44 +1,16 @@
-import { describe, it, expect } from 'bun:test'
-import { render, fireEvent } from '@testing-library/preact'
+import { describe } from 'bun:test'
 import { Input } from '@campfire/components/Passage/Input'
-import { useGameStore } from '@campfire/state/useGameStore'
+import { runFormFieldTests } from '@campfire/test-utils/formFieldTests'
 
 /**
  * Tests for the Input component.
  */
 describe('Input', () => {
-  it('updates game state on input', () => {
-    useGameStore.setState({ gameData: {} })
-    const { getByTestId } = render(<Input stateKey='name' />)
-    const field = getByTestId('input') as HTMLInputElement
-    fireEvent.input(field, { target: { value: 'Sam' } })
-    expect(
-      (useGameStore.getState().gameData as Record<string, unknown>).name
-    ).toBe('Sam')
-  })
-
-  it('applies className and style', () => {
-    const { getByTestId } = render(
-      <Input stateKey='field' className='extra' style={{ color: 'red' }} />
-    )
-    const field = getByTestId('input') as HTMLInputElement
-    expect(field.className.split(' ')).toContain('campfire-input')
-    expect(field.className.split(' ')).toContain('extra')
-    expect(field.style.color).toBe('red')
-  })
-
-  it('uses existing state value when present', () => {
-    useGameStore.setState({ gameData: { name: 'Existing' } })
-    const { getByTestId } = render(<Input stateKey='name' />)
-    const field = getByTestId('input') as HTMLInputElement
-    expect(field.value).toBe('Existing')
-  })
-
-  it('initializes state when unset', () => {
-    useGameStore.setState({ gameData: {} })
-    render(<Input stateKey='age' />)
-    expect(
-      (useGameStore.getState().gameData as Record<string, unknown>).age
-    ).toBe('')
+  runFormFieldTests({
+    Component: Input,
+    testId: 'input',
+    campfireClass: 'campfire-input',
+    updateValue: 'Sam',
+    existingValue: 'Existing'
   })
 })

--- a/apps/campfire/src/components/Passage/__tests__/Select.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Select.test.tsx
@@ -1,38 +1,26 @@
 import { describe, it, expect } from 'bun:test'
-import { render, fireEvent } from '@testing-library/preact'
+import { render } from '@testing-library/preact'
 import { Select } from '@campfire/components/Passage/Select'
 import { Option } from '@campfire/components/Passage/Option'
-import { useGameStore } from '@campfire/state/useGameStore'
+import { runFormFieldTests } from '@campfire/test-utils/formFieldTests'
 
 /**
  * Tests for the Select component.
  */
 describe('Select', () => {
-  it('updates game state on change', () => {
-    useGameStore.setState({ gameData: { color: 'red' } })
-    const { getByTestId } = render(
-      <Select stateKey='color'>
+  runFormFieldTests({
+    Component: Select,
+    testId: 'select',
+    campfireClass: 'campfire-select',
+    updateValue: 'blue',
+    existingValue: 'blue',
+    children: (
+      <>
         <Option value='red'>Red</Option>
         <Option value='blue'>Blue</Option>
-      </Select>
-    )
-    const field = getByTestId('select') as HTMLSelectElement
-    fireEvent.input(field, { target: { value: 'blue' } })
-    expect(
-      (useGameStore.getState().gameData as Record<string, unknown>).color
-    ).toBe('blue')
-  })
-
-  it('applies className and style', () => {
-    const { getByTestId } = render(
-      <Select stateKey='field' className='extra' style={{ color: 'red' }}>
-        <Option value='a'>A</Option>
-      </Select>
-    )
-    const field = getByTestId('select') as HTMLSelectElement
-    expect(field.className.split(' ')).toContain('campfire-select')
-    expect(field.className.split(' ')).toContain('extra')
-    expect(field.style.color).toBe('red')
+      </>
+    ),
+    initialState: { field: 'red' }
   })
 
   it('renders with default border, text color, and background', () => {
@@ -45,29 +33,5 @@ describe('Select', () => {
     expect(field.style.border).toBe('1px solid black')
     expect(field.style.color).toBe('#000')
     expect(field.style.backgroundColor).toBe('#fff')
-  })
-
-  it('uses existing state value when present', () => {
-    useGameStore.setState({ gameData: { color: 'blue' } })
-    const { getByTestId } = render(
-      <Select stateKey='color'>
-        <Option value='red'>Red</Option>
-        <Option value='blue'>Blue</Option>
-      </Select>
-    )
-    const field = getByTestId('select') as HTMLSelectElement
-    expect(field.value).toBe('blue')
-  })
-
-  it('initializes state when unset', () => {
-    useGameStore.setState({ gameData: {} })
-    render(
-      <Select stateKey='color'>
-        <Option value='red'>Red</Option>
-      </Select>
-    )
-    expect(
-      (useGameStore.getState().gameData as Record<string, unknown>).color
-    ).toBe('')
   })
 })

--- a/apps/campfire/src/components/Passage/__tests__/Textarea.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Textarea.test.tsx
@@ -1,44 +1,16 @@
-import { describe, it, expect } from 'bun:test'
-import { render, fireEvent } from '@testing-library/preact'
+import { describe } from 'bun:test'
 import { Textarea } from '@campfire/components/Passage/Textarea'
-import { useGameStore } from '@campfire/state/useGameStore'
+import { runFormFieldTests } from '@campfire/test-utils/formFieldTests'
 
 /**
  * Tests for the Textarea component.
  */
 describe('Textarea', () => {
-  it('updates game state on input', () => {
-    useGameStore.setState({ gameData: {} })
-    const { getByTestId } = render(<Textarea stateKey='bio' />)
-    const field = getByTestId('textarea') as HTMLTextAreaElement
-    fireEvent.input(field, { target: { value: 'Hello' } })
-    expect(
-      (useGameStore.getState().gameData as Record<string, unknown>).bio
-    ).toBe('Hello')
-  })
-
-  it('applies className and style', () => {
-    const { getByTestId } = render(
-      <Textarea stateKey='field' className='extra' style={{ color: 'red' }} />
-    )
-    const field = getByTestId('textarea') as HTMLTextAreaElement
-    expect(field.className.split(' ')).toContain('campfire-textarea')
-    expect(field.className.split(' ')).toContain('extra')
-    expect(field.style.color).toBe('red')
-  })
-
-  it('uses existing state value when present', () => {
-    useGameStore.setState({ gameData: { bio: 'Existing' } })
-    const { getByTestId } = render(<Textarea stateKey='bio' />)
-    const field = getByTestId('textarea') as HTMLTextAreaElement
-    expect(field.value).toBe('Existing')
-  })
-
-  it('initializes state when unset', () => {
-    useGameStore.setState({ gameData: {} })
-    render(<Textarea stateKey='note' />)
-    expect(
-      (useGameStore.getState().gameData as Record<string, unknown>).note
-    ).toBe('')
+  runFormFieldTests({
+    Component: Textarea,
+    testId: 'textarea',
+    campfireClass: 'campfire-textarea',
+    updateValue: 'Hello',
+    existingValue: 'Existing'
   })
 })

--- a/apps/campfire/src/test-utils/formFieldTests.tsx
+++ b/apps/campfire/src/test-utils/formFieldTests.tsx
@@ -1,0 +1,76 @@
+import { render, fireEvent } from '@testing-library/preact'
+import type { ComponentChildren, ComponentType } from 'preact'
+import { useGameStore } from '@campfire/state/useGameStore'
+import { expect, it } from 'bun:test'
+
+interface FormFieldTestConfig {
+  Component: ComponentType<any>
+  testId: string
+  campfireClass: string
+  updateValue: string
+  existingValue: string
+  children?: ComponentChildren
+  initialState?: Record<string, unknown>
+}
+
+/**
+ * Runs shared assertions for stateful form fields.
+ *
+ * @param config - Options for the form field tests.
+ */
+export const runFormFieldTests = ({
+  Component,
+  testId,
+  campfireClass,
+  updateValue,
+  existingValue,
+  children,
+  initialState = {}
+}: FormFieldTestConfig) => {
+  it('updates game state on input', () => {
+    useGameStore.setState({ gameData: initialState })
+    const { getByTestId } = render(
+      <Component stateKey='field'>{children}</Component>
+    )
+    const field = getByTestId(testId) as
+      | HTMLInputElement
+      | HTMLTextAreaElement
+      | HTMLSelectElement
+    fireEvent.input(field, { target: { value: updateValue } })
+    expect(
+      (useGameStore.getState().gameData as Record<string, unknown>).field
+    ).toBe(updateValue)
+  })
+
+  it('applies className and style', () => {
+    const { getByTestId } = render(
+      <Component stateKey='field' className='extra' style={{ color: 'red' }}>
+        {children}
+      </Component>
+    )
+    const field = getByTestId(testId) as HTMLElement
+    expect(field.className.split(' ')).toContain(campfireClass)
+    expect(field.className.split(' ')).toContain('extra')
+    expect(field.style.color).toBe('red')
+  })
+
+  it('uses existing state value when present', () => {
+    useGameStore.setState({ gameData: { field: existingValue } })
+    const { getByTestId } = render(
+      <Component stateKey='field'>{children}</Component>
+    )
+    const field = getByTestId(testId) as
+      | HTMLInputElement
+      | HTMLTextAreaElement
+      | HTMLSelectElement
+    expect(field.value).toBe(existingValue)
+  })
+
+  it('initializes state when unset', () => {
+    useGameStore.setState({ gameData: {} })
+    render(<Component stateKey='field'>{children}</Component>)
+    expect(
+      (useGameStore.getState().gameData as Record<string, unknown>).field
+    ).toBe('')
+  })
+}


### PR DESCRIPTION
## Summary
- create `runFormFieldTests` utility to cover common stateful form field behavior
- use helper in Input, Textarea and Select tests to reduce duplication

## Testing
- `bun test apps/campfire/src/components/Passage/__tests__/Input.test.tsx apps/campfire/src/components/Passage/__tests__/Textarea.test.tsx apps/campfire/src/components/Passage/__tests__/Select.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68af258ecfbc8322893524075a9bd5b1