### PR TITLE
fix(campfire): reset game state on unmount

### DIFF
--- a/apps/campfire/src/components/Campfire/__tests__/Campfire.test.tsx
+++ b/apps/campfire/src/components/Campfire/__tests__/Campfire.test.tsx
@@ -75,6 +75,14 @@ describe('Story', () => {
     expect(i18next.options.debug).toBe(true)
   })
 
+  it('resets game state on unmount', () => {
+    useGameStore.getState().init({ hp: 10 })
+    useGameStore.getState().setGameData({ hp: 5 })
+    const { unmount } = render(<Campfire />)
+    unmount()
+    expect(useGameStore.getState().gameData).toEqual({ hp: 10 })
+  })
+
   it('renders content based on if directives', async () => {
     document.body.innerHTML = `
 <tw-storydata name="Story" startnode="1">

--- a/apps/campfire/src/components/Campfire/index.tsx
+++ b/apps/campfire/src/components/Campfire/index.tsx
@@ -5,6 +5,7 @@ import {
   type StoryDataState,
   useStoryDataStore
 } from '@campfire/state/useStoryDataStore'
+import { useGameStore } from '@campfire/state/useGameStore'
 import { Passage } from '@campfire/components/Passage/Passage'
 import { DebugWindow } from '@campfire/components/DebugWindow'
 import { LoadingScreen } from '@campfire/components/LoadingScreen'
@@ -118,6 +119,8 @@ export const Campfire = ({
       setI18nInitialized(true)
     }
   }, [])
+
+  useEffect(() => useGameStore.getState().reset, [])
 
   if (!i18nInitialized) return null
   if (!passage) {


### PR DESCRIPTION
## Summary
- reset game store when Campfire unmounts to avoid leaking state
- add regression test for game state reset
- inline game store reset to avoid unnecessary binding

## Testing
- `bun x prettier --write apps/campfire/src/components/Campfire/index.tsx`
- `bun tsc`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_68af57e9b58c8322bf43cd330ba34b3e