### PR TITLE
feat: add form field base styles

### DIFF
--- a/apps/campfire/src/components/Passage/Input.tsx
+++ b/apps/campfire/src/components/Passage/Input.tsx
@@ -8,6 +8,9 @@ import { useGameStore } from '@campfire/state/useGameStore'
 
 const clone = rfdc()
 
+const inputStyles =
+  'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive'
+
 interface InputProps
   extends Omit<
     JSX.InputHTMLAttributes<HTMLInputElement>,
@@ -71,7 +74,9 @@ export const Input = ({
   return (
     <input
       data-testid='input'
-      className={['campfire-input', ...classes].join(' ')}
+      className={['campfire-input', inputStyles, ...classes]
+        .filter((c, i, arr) => c && arr.indexOf(c) === i)
+        .join(' ')}
       value={value ?? ''}
       {...rest}
       onMouseEnter={e => {

--- a/apps/campfire/src/components/Passage/Textarea.tsx
+++ b/apps/campfire/src/components/Passage/Textarea.tsx
@@ -8,6 +8,9 @@ import { useGameStore } from '@campfire/state/useGameStore'
 
 const clone = rfdc()
 
+const textareaStyles =
+  'border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm'
+
 interface TextareaProps
   extends Omit<
     JSX.TextareaHTMLAttributes<HTMLTextAreaElement>,
@@ -71,7 +74,9 @@ export const Textarea = ({
   return (
     <textarea
       data-testid='textarea'
-      className={['campfire-textarea', ...classes].join(' ')}
+      className={['campfire-textarea', textareaStyles, ...classes]
+        .filter((c, i, arr) => c && arr.indexOf(c) === i)
+        .join(' ')}
       value={value ?? ''}
       {...rest}
       onMouseEnter={e => {

--- a/apps/storybook/.storybook/preview-head.html
+++ b/apps/storybook/.storybook/preview-head.html
@@ -48,7 +48,10 @@
     --color-primary-950: var(--color-indigo-950);
     --color-primary: var(--color-primary-700);
     --color-primary-foreground: var(--color-gray-950);
+    --color-foreground: var(--color-gray-950);
     --color-ring: var(--color-primary-500);
+    --color-input: var(--color-gray-700);
+    --color-muted-foreground: var(--color-gray-300);
     --color-destructive-50: var(--color-red-50);
     --color-destructive-100: var(--color-red-100);
     --color-destructive-200: var(--color-red-200);

--- a/apps/storybook/src/Input.stories.tsx
+++ b/apps/storybook/src/Input.stories.tsx
@@ -31,3 +31,12 @@ export const Types: StoryObj<typeof Input> = {
     </div>
   )
 }
+
+/**
+ * Demonstrates a file Input.
+ *
+ * @returns File upload Input example.
+ */
+export const File: StoryObj<typeof Input> = {
+  render: () => <Input stateKey='upload' type='file' />
+}

--- a/docs/styling-elements.md
+++ b/docs/styling-elements.md
@@ -27,5 +27,8 @@ The template exposes several CSS variables that map to Tailwind color scales:
 - `--color-primary-50` through `--color-primary-950` alias the indigo palette. `--color-primary` defaults to `--color-primary-700`, and `--color-primary-foreground` uses `--color-gray-950`.
 - `--color-destructive-50` through `--color-destructive-950` alias the red palette. `--color-destructive` defaults to `--color-destructive-500`.
 - `--color-ring` derives from `--color-primary-500` and is used for focus indicators.
+- `--color-input` sets default borders and backgrounds for form fields.
+- `--color-muted-foreground` controls placeholder and other subdued text.
+- `--color-foreground` sets the default text color for file inputs and similar elements.
 
 All values are expressed in `oklch()` notation and can be overridden to suit your theme.

--- a/template.ejs
+++ b/template.ejs
@@ -53,7 +53,10 @@
         --color-primary-950: var(--color-indigo-950);
         --color-primary: var(--color-primary-700);
         --color-primary-foreground: var(--color-gray-950);
+        --color-foreground: var(--color-gray-950);
         --color-ring: var(--color-primary-500);
+        --color-input: var(--color-gray-700);
+        --color-muted-foreground: var(--color-gray-300);
         --color-destructive-50: var(--color-red-50);
         --color-destructive-100: var(--color-red-100);
         --color-destructive-200: var(--color-red-200);


### PR DESCRIPTION
## Summary
- add shadcn-inspired base classes to Textarea and Input components
- define `--color-input`, `--color-muted-foreground`, and `--color-foreground` theme variables
- document new color variables and showcase file input styling in Storybook

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68b0aa9b2c408322905b153ad54a2715