### PR TITLE
feat: replace native select with popover menu

### DIFF
--- a/apps/campfire/src/components/Passage/Option.tsx
+++ b/apps/campfire/src/components/Passage/Option.tsx
@@ -47,7 +47,7 @@ export const Option = ({
       data-testid='option'
       className={[
         'campfire-option',
-        'w-full text-left px-3 py-2 transition-colors hover:bg-[oklch(0.9_0_0)]',
+        'w-full text-left px-2 py-2 transition-colors hover:bg-[oklch(0.9_0_0)]',
         ...classes
       ].join(' ')}
       style={mergedStyle}

--- a/apps/campfire/src/components/Passage/Option.tsx
+++ b/apps/campfire/src/components/Passage/Option.tsx
@@ -35,17 +35,21 @@ export const Option = ({
       : []
   const mergedStyle =
     typeof style === 'string'
-      ? `color:oklch(0 0 0);background:oklch(1 0 0);${style}`
+      ? `color:oklch(0 0 0);background:oklch(0.98 0 0);${style}`
       : {
           color: 'oklch(0 0 0)',
-          background: 'oklch(1 0 0)',
+          background: 'oklch(0.98 0 0)',
           ...(style ?? {})
         }
   return (
     <button
       type='button'
       data-testid='option'
-      className={['campfire-option', ...classes].join(' ')}
+      className={[
+        'campfire-option',
+        'w-full text-left px-3 py-2 transition-colors hover:bg-[oklch(0.9_0_0)]',
+        ...classes
+      ].join(' ')}
       style={mergedStyle}
       onClick={() => onSelectOption?.(value)}
       {...rest}

--- a/apps/campfire/src/components/Passage/Option.tsx
+++ b/apps/campfire/src/components/Passage/Option.tsx
@@ -1,9 +1,13 @@
 import type { JSX } from 'preact'
 
-interface OptionProps
-  extends Omit<JSX.OptionHTMLAttributes<HTMLOptionElement>, 'className'> {
+export interface OptionProps
+  extends Omit<JSX.HTMLAttributes<HTMLButtonElement>, 'className'> {
+  /** Value represented by this option. */
+  value: string
   /** Additional CSS classes for the option element. */
   className?: string | string[]
+  /** Callback fired when this option is selected. */
+  onSelectOption?: (value: string) => void
 }
 
 /**
@@ -12,6 +16,7 @@ interface OptionProps
  * @param className - Optional additional classes.
  * @param style - Optional inline styles for the option element.
  * @param children - Display text for the option.
+ * @param onSelectOption - Callback fired when this option is chosen.
  * @param rest - Additional option element attributes.
  * @returns The rendered option element.
  */
@@ -19,6 +24,8 @@ export const Option = ({
   className,
   style,
   children,
+  onSelectOption,
+  value,
   ...rest
 }: OptionProps) => {
   const classes = Array.isArray(className)
@@ -28,17 +35,23 @@ export const Option = ({
       : []
   const mergedStyle =
     typeof style === 'string'
-      ? `color:#000;background:#fff;${style}`
-      : { color: '#000', background: '#fff', ...(style ?? {}) }
+      ? `color:oklch(0 0 0);background:oklch(1 0 0);${style}`
+      : {
+          color: 'oklch(0 0 0)',
+          background: 'oklch(1 0 0)',
+          ...(style ?? {})
+        }
   return (
-    <option
+    <button
+      type='button'
       data-testid='option'
       className={['campfire-option', ...classes].join(' ')}
       style={mergedStyle}
+      onClick={() => onSelectOption?.(value)}
       {...rest}
     >
       {children}
-    </option>
+    </button>
   )
 }
 

--- a/apps/campfire/src/components/Passage/Select.tsx
+++ b/apps/campfire/src/components/Passage/Select.tsx
@@ -1,6 +1,6 @@
 import type { JSX, VNode } from 'preact'
 import { cloneElement, toChildArray } from 'preact'
-import { useEffect, useState } from 'preact/hooks'
+import { useEffect, useRef, useState } from 'preact/hooks'
 import rfdc from 'rfdc'
 import type { RootContent } from 'mdast'
 import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
@@ -10,7 +10,7 @@ import type { OptionProps } from './Option'
 
 const clone = rfdc()
 const selectStyles =
-  'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive'
+  'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-2 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive'
 
 interface SelectProps
   extends Omit<
@@ -72,6 +72,7 @@ export const Select = ({
       ? [className]
       : []
   const [open, setOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
   useEffect(() => {
     if (value === undefined) {
       setGameData({ [stateKey]: initialValue ?? '' })
@@ -84,14 +85,26 @@ export const Select = ({
     onInput?.({} as any)
     setOpen(false)
   }
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [])
   return (
-    <div className='inline-block relative'>
+    <div ref={containerRef} className='inline-block relative'>
       <button
         data-testid='select'
         className={[
           'campfire-select',
           selectStyles,
-          'items-center justify-between cursor-pointer px-0',
+          'items-center justify-between cursor-pointer',
           ...classes
         ].join(' ')}
         style={style}
@@ -123,10 +136,10 @@ export const Select = ({
         }}
         onClick={() => setOpen(prev => !prev)}
       >
-        <span className='flex-1 truncate text-left pl-3'>
+        <span className='flex-1 truncate text-left pr-2'>
           {selected ? selected.props.children : (label ?? '')}
         </span>
-        <span className='flex items-center shrink-0 border-l border-input px-3'>
+        <span className='flex items-center shrink-0 border-l border-input pl-2'>
           <svg
             aria-hidden='true'
             viewBox='0 0 24 24'

--- a/apps/campfire/src/components/Passage/Select.tsx
+++ b/apps/campfire/src/components/Passage/Select.tsx
@@ -85,7 +85,7 @@ export const Select = ({
     setOpen(false)
   }
   return (
-    <div style={{ display: 'inline-block' }}>
+    <div className='inline-block relative'>
       <button
         data-testid='select'
         className={[
@@ -126,7 +126,7 @@ export const Select = ({
         <span className='flex-1 truncate text-left pl-3'>
           {selected ? selected.props.children : (label ?? '')}
         </span>
-        <span className='flex items-center border-l border-input px-3'>
+        <span className='flex items-center shrink-0 border-l border-input px-3'>
           <svg
             aria-hidden='true'
             viewBox='0 0 24 24'
@@ -135,6 +135,7 @@ export const Select = ({
             stroke-width='2'
             stroke-linecap='round'
             stroke-linejoin='round'
+            className='h-4 w-4'
           >
             <path d='m6 9 6 6 6-6' />
           </svg>
@@ -143,7 +144,7 @@ export const Select = ({
       {open && (
         <div
           role='listbox'
-          className='mt-1 flex w-full flex-col divide-y divide-input rounded-md border border-input bg-[oklch(0.98_0_0)] shadow-md overflow-hidden'
+          className='absolute left-0 top-full z-50 mt-1 flex w-full flex-col divide-y divide-input rounded-md border border-input bg-[oklch(0.98_0_0)] shadow-md overflow-hidden'
         >
           {optionNodes.map(opt =>
             cloneElement(opt, {

--- a/apps/campfire/src/components/Passage/Select.tsx
+++ b/apps/campfire/src/components/Passage/Select.tsx
@@ -97,6 +97,15 @@ export const Select = ({
     document.addEventListener('mousedown', handleClick)
     return () => document.removeEventListener('mousedown', handleClick)
   }, [])
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [])
   return (
     <div ref={containerRef} className='inline-block relative'>
       <button

--- a/apps/campfire/src/components/Passage/Select.tsx
+++ b/apps/campfire/src/components/Passage/Select.tsx
@@ -29,6 +29,8 @@ interface SelectProps
   onInput?: JSX.HTMLAttributes<HTMLButtonElement>['onInput']
   /** Initial value if the state key is unset. */
   initialValue?: string
+  /** Text shown when no option is selected. */
+  label?: string
 }
 
 /**
@@ -40,6 +42,7 @@ interface SelectProps
  * @param onFocus - Serialized directives to run on focus.
  * @param onBlur - Serialized directives to run on blur.
  * @param style - Optional inline styles for the select element.
+ * @param label - Text shown when no option is selected.
  * @param rest - Additional select element attributes.
  * @returns The rendered select element.
  */
@@ -53,6 +56,7 @@ export const Select = ({
   style,
   children,
   initialValue,
+  label,
   ...rest
 }: SelectProps) => {
   const value = useGameStore(state => state.gameData[stateKey]) as
@@ -71,15 +75,6 @@ export const Select = ({
       setGameData({ [stateKey]: initialValue ?? '' })
     }
   }, [value, stateKey, initialValue, setGameData])
-  const mergedStyle =
-    typeof style === 'string'
-      ? `border:1px solid oklch(0 0 0);color:oklch(0 0 0);background:oklch(1 0 0);${style}`
-      : {
-          border: '1px solid oklch(0 0 0)',
-          color: 'oklch(0 0 0)',
-          background: 'oklch(1 0 0)',
-          ...(style ?? {})
-        }
   const optionNodes = toChildArray(children) as VNode<OptionProps>[]
   const selected = optionNodes.find(opt => opt.props.value === value)
   const handleSelect = (val: string) => {
@@ -91,8 +86,12 @@ export const Select = ({
     <div style={{ display: 'inline-block' }}>
       <button
         data-testid='select'
-        className={['campfire-select', ...classes].join(' ')}
-        style={mergedStyle}
+        className={[
+          'campfire-select',
+          "inline-flex items-center justify-between gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive bg-primary text-primary-foreground shadow-xs hover:bg-primary/90 h-9 px-4 py-2 has-[>svg]:px-3",
+          ...classes
+        ].join(' ')}
+        style={style}
         value={value ?? ''}
         {...rest}
         onMouseEnter={e => {
@@ -121,7 +120,19 @@ export const Select = ({
         }}
         onClick={() => setOpen(prev => !prev)}
       >
-        {selected ? selected.props.children : ''}
+        {selected ? selected.props.children : (label ?? '')}
+        <svg
+          aria-hidden='true'
+          className='ml-2'
+          viewBox='0 0 24 24'
+          fill='none'
+          stroke='currentColor'
+          stroke-width='2'
+          stroke-linecap='round'
+          stroke-linejoin='round'
+        >
+          <path d='m6 9 6 6 6-6' />
+        </svg>
       </button>
       {open && (
         <div role='listbox'>

--- a/apps/campfire/src/components/Passage/Select.tsx
+++ b/apps/campfire/src/components/Passage/Select.tsx
@@ -9,6 +9,8 @@ import { useGameStore } from '@campfire/state/useGameStore'
 import type { OptionProps } from './Option'
 
 const clone = rfdc()
+const selectStyles =
+  'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive'
 
 interface SelectProps
   extends Omit<
@@ -88,7 +90,8 @@ export const Select = ({
         data-testid='select'
         className={[
           'campfire-select',
-          "inline-flex items-center justify-between gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive bg-primary text-primary-foreground shadow-xs hover:bg-primary/90 h-9 px-4 py-2 has-[>svg]:px-3",
+          selectStyles,
+          'items-center justify-between cursor-pointer px-0',
           ...classes
         ].join(' ')}
         style={style}
@@ -120,22 +123,28 @@ export const Select = ({
         }}
         onClick={() => setOpen(prev => !prev)}
       >
-        {selected ? selected.props.children : (label ?? '')}
-        <svg
-          aria-hidden='true'
-          className='ml-2'
-          viewBox='0 0 24 24'
-          fill='none'
-          stroke='currentColor'
-          stroke-width='2'
-          stroke-linecap='round'
-          stroke-linejoin='round'
-        >
-          <path d='m6 9 6 6 6-6' />
-        </svg>
+        <span className='flex-1 truncate text-left pl-3'>
+          {selected ? selected.props.children : (label ?? '')}
+        </span>
+        <span className='flex items-center border-l border-input px-3'>
+          <svg
+            aria-hidden='true'
+            viewBox='0 0 24 24'
+            fill='none'
+            stroke='currentColor'
+            stroke-width='2'
+            stroke-linecap='round'
+            stroke-linejoin='round'
+          >
+            <path d='m6 9 6 6 6-6' />
+          </svg>
+        </span>
       </button>
       {open && (
-        <div role='listbox'>
+        <div
+          role='listbox'
+          className='mt-1 flex w-full flex-col divide-y divide-input rounded-md border border-input bg-[oklch(0.98_0_0)] shadow-md overflow-hidden'
+        >
           {optionNodes.map(opt =>
             cloneElement(opt, {
               onSelectOption: handleSelect

--- a/apps/campfire/src/components/Passage/Select.tsx
+++ b/apps/campfire/src/components/Passage/Select.tsx
@@ -1,23 +1,19 @@
-import type { JSX } from 'preact'
-import { useEffect } from 'preact/hooks'
+import type { JSX, VNode } from 'preact'
+import { cloneElement, toChildArray } from 'preact'
+import { useEffect, useState } from 'preact/hooks'
 import rfdc from 'rfdc'
 import type { RootContent } from 'mdast'
 import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
 import { runDirectiveBlock } from '@campfire/utils/directiveUtils'
 import { useGameStore } from '@campfire/state/useGameStore'
+import type { OptionProps } from './Option'
 
 const clone = rfdc()
 
 interface SelectProps
   extends Omit<
-    JSX.SelectHTMLAttributes<HTMLSelectElement>,
-    | 'className'
-    | 'value'
-    | 'defaultValue'
-    | 'onInput'
-    | 'onFocus'
-    | 'onBlur'
-    | 'onMouseEnter'
+    JSX.HTMLAttributes<HTMLButtonElement>,
+    'className' | 'onInput' | 'onFocus' | 'onBlur' | 'onMouseEnter'
   > {
   /** Key in game state to bind the select value to. */
   stateKey: string
@@ -30,7 +26,7 @@ interface SelectProps
   /** Serialized directives to run on blur. */
   onBlur?: string
   /** Optional input event handler. */
-  onInput?: JSX.SelectHTMLAttributes<HTMLSelectElement>['onInput']
+  onInput?: JSX.HTMLAttributes<HTMLButtonElement>['onInput']
   /** Initial value if the state key is unset. */
   initialValue?: string
 }
@@ -69,6 +65,7 @@ export const Select = ({
     : className
       ? [className]
       : []
+  const [open, setOpen] = useState(false)
   useEffect(() => {
     if (value === undefined) {
       setGameData({ [stateKey]: initialValue ?? '' })
@@ -76,53 +73,66 @@ export const Select = ({
   }, [value, stateKey, initialValue, setGameData])
   const mergedStyle =
     typeof style === 'string'
-      ? `border:1px solid black;color:#000;background:#fff;${style}`
+      ? `border:1px solid oklch(0 0 0);color:oklch(0 0 0);background:oklch(1 0 0);${style}`
       : {
-          border: '1px solid black',
-          color: '#000',
-          background: '#fff',
+          border: '1px solid oklch(0 0 0)',
+          color: 'oklch(0 0 0)',
+          background: 'oklch(1 0 0)',
           ...(style ?? {})
         }
+  const optionNodes = toChildArray(children) as VNode<OptionProps>[]
+  const selected = optionNodes.find(opt => opt.props.value === value)
+  const handleSelect = (val: string) => {
+    setGameData({ [stateKey]: val })
+    onInput?.({} as any)
+    setOpen(false)
+  }
   return (
-    <select
-      data-testid='select'
-      className={['campfire-select', ...classes].join(' ')}
-      value={value ?? ''}
-      style={mergedStyle}
-      {...rest}
-      onMouseEnter={e => {
-        if (onHover) {
-          runDirectiveBlock(
-            clone(JSON.parse(onHover)) as RootContent[],
-            handlers
-          )
-        }
-      }}
-      onFocus={e => {
-        if (onFocus) {
-          runDirectiveBlock(
-            clone(JSON.parse(onFocus)) as RootContent[],
-            handlers
-          )
-        }
-      }}
-      onBlur={e => {
-        if (onBlur) {
-          runDirectiveBlock(
-            clone(JSON.parse(onBlur)) as RootContent[],
-            handlers
-          )
-        }
-      }}
-      onInput={e => {
-        onInput?.(e)
-        if (e.defaultPrevented) return
-        const target = e.currentTarget as HTMLSelectElement
-        setGameData({ [stateKey]: target.value })
-      }}
-    >
-      {children}
-    </select>
+    <div style={{ display: 'inline-block' }}>
+      <button
+        data-testid='select'
+        className={['campfire-select', ...classes].join(' ')}
+        style={mergedStyle}
+        value={value ?? ''}
+        {...rest}
+        onMouseEnter={e => {
+          if (onHover) {
+            runDirectiveBlock(
+              clone(JSON.parse(onHover)) as RootContent[],
+              handlers
+            )
+          }
+        }}
+        onFocus={e => {
+          if (onFocus) {
+            runDirectiveBlock(
+              clone(JSON.parse(onFocus)) as RootContent[],
+              handlers
+            )
+          }
+        }}
+        onBlur={e => {
+          if (onBlur) {
+            runDirectiveBlock(
+              clone(JSON.parse(onBlur)) as RootContent[],
+              handlers
+            )
+          }
+        }}
+        onClick={() => setOpen(prev => !prev)}
+      >
+        {selected ? selected.props.children : ''}
+      </button>
+      {open && (
+        <div role='listbox'>
+          {optionNodes.map(opt =>
+            cloneElement(opt, {
+              onSelectOption: handleSelect
+            })
+          )}
+        </div>
+      )}
+    </div>
   )
 }
 

--- a/apps/campfire/src/components/Passage/__tests__/Select.directive.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Select.directive.test.tsx
@@ -15,6 +15,43 @@ describe('Select directive', () => {
     resetStores()
   })
 
+  it('displays label when no option is selected', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value:
+            ':::select[color]{label="Choose"}\n:option{value="red" label="Red"}\n:::\n'
+        }
+      ]
+    }
+    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+    render(<Passage />)
+    const select = await screen.findByTestId('select')
+    expect(select.textContent).toBe('Choose')
+  })
+
+  it('displays label when no options are available', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value: ':::select[color]{label="Choose"}\n:::\n'
+        }
+      ]
+    }
+    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+    render(<Passage />)
+    const select = await screen.findByTestId('select')
+    expect(select.textContent).toBe('Choose')
+  })
+
   it('passes className and style attributes', async () => {
     const passage: Element = {
       type: 'element',

--- a/apps/campfire/src/components/Passage/__tests__/Select.directive.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Select.directive.test.tsx
@@ -31,11 +31,11 @@ describe('Select directive', () => {
     useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
     render(<Passage />)
     const select = await screen.findByTestId('select')
-    expect((select as HTMLSelectElement).style.color).toBe('blue')
-    expect((select as HTMLSelectElement).style.border).toBe('1px solid black')
-    expect((select as HTMLSelectElement).style.backgroundColor).toBe('#fff')
+    expect((select as HTMLButtonElement).style.color).toBe('blue')
     expect(select.className.split(' ')).toContain('extra')
-    fireEvent.input(select, { target: { value: 'blue' } })
+    fireEvent.click(select)
+    await new Promise(r => setTimeout(r, 0))
+    fireEvent.click(screen.getAllByTestId('option')[1])
     expect(
       (useGameStore.getState().gameData as Record<string, unknown>).color
     ).toBe('blue')
@@ -59,11 +59,11 @@ describe('Select directive', () => {
     const select = await screen.findByTestId('select')
     expect(useGameStore.getState().gameData.focused).toBeUndefined()
     act(() => {
-      ;(select as HTMLSelectElement).focus()
+      ;(select as HTMLButtonElement).focus()
     })
     expect(useGameStore.getState().gameData.focused).toBe(true)
     act(() => {
-      ;(select as HTMLSelectElement).blur()
+      ;(select as HTMLButtonElement).blur()
     })
     expect(useGameStore.getState().gameData.blurred).toBe(true)
     fireEvent.mouseEnter(select)
@@ -104,7 +104,7 @@ describe('Select directive', () => {
     useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
     render(<Passage />)
     const select = await screen.findByTestId('select')
-    expect((select as HTMLSelectElement).value).toBe('blue')
+    expect((select as HTMLButtonElement).value).toBe('blue')
     expect(
       (useGameStore.getState().gameData as Record<string, unknown>).color
     ).toBe('blue')
@@ -127,7 +127,7 @@ describe('Select directive', () => {
     useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
     render(<Passage />)
     const select = await screen.findByTestId('select')
-    expect((select as HTMLSelectElement).value).toBe('red')
+    expect((select as HTMLButtonElement).value).toBe('red')
     expect(
       (useGameStore.getState().gameData as Record<string, unknown>).color
     ).toBe('red')

--- a/apps/campfire/src/components/Passage/__tests__/Select.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Select.test.tsx
@@ -69,4 +69,28 @@ describe('Select', () => {
       (useGameStore.getState().gameData as Record<string, unknown>).field
     ).toBe('')
   })
+
+  it('positions options absolutely', () => {
+    useGameStore.setState({ gameData: {} })
+    const { getByTestId, getByRole } = render(
+      <Select stateKey='field'>
+        <Option value='a'>A</Option>
+      </Select>
+    )
+    fireEvent.click(getByTestId('select'))
+    const listbox = getByRole('listbox') as HTMLDivElement
+    expect(listbox.className.split(' ')).toContain('absolute')
+  })
+
+  it('renders caret icon', () => {
+    const { getByTestId } = render(
+      <Select stateKey='field'>
+        <Option value='a'>A</Option>
+      </Select>
+    )
+    const caret = getByTestId('select').querySelector('svg') as SVGElement
+    expect(caret.getAttribute('class')?.split(' ')).toEqual(
+      expect.arrayContaining(['h-4', 'w-4'])
+    )
+  })
 })

--- a/apps/campfire/src/components/Passage/__tests__/Select.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Select.test.tsx
@@ -110,4 +110,18 @@ describe('Select', () => {
     await new Promise(r => setTimeout(r, 0))
     expect(queryByRole('listbox')).toBeNull()
   })
+
+  it('closes when pressing Escape', async () => {
+    useGameStore.setState({ gameData: {} })
+    const { getByTestId, queryByRole } = render(
+      <Select stateKey='field'>
+        <Option value='a'>A</Option>
+      </Select>
+    )
+    fireEvent.click(getByTestId('select'))
+    expect(queryByRole('listbox')).not.toBeNull()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    await new Promise(r => setTimeout(r, 0))
+    expect(queryByRole('listbox')).toBeNull()
+  })
 })

--- a/apps/campfire/src/components/Passage/__tests__/Select.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Select.test.tsx
@@ -93,4 +93,21 @@ describe('Select', () => {
       expect.arrayContaining(['h-4', 'w-4'])
     )
   })
+
+  it('closes when clicking outside', async () => {
+    useGameStore.setState({ gameData: {} })
+    const { getByTestId, queryByRole } = render(
+      <div>
+        <Select stateKey='field'>
+          <Option value='a'>A</Option>
+        </Select>
+        <div data-testid='outside'>outside</div>
+      </div>
+    )
+    fireEvent.click(getByTestId('select'))
+    expect(queryByRole('listbox')).not.toBeNull()
+    fireEvent.mouseDown(getByTestId('outside'))
+    await new Promise(r => setTimeout(r, 0))
+    expect(queryByRole('listbox')).toBeNull()
+  })
 })

--- a/apps/campfire/src/components/Passage/__tests__/Select.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Select.test.tsx
@@ -36,6 +36,17 @@ describe('Select', () => {
     expect(field.style.color).toBe('red')
   })
 
+  it('displays label when no value is selected', () => {
+    useGameStore.setState({ gameData: {} })
+    const { getByTestId } = render(
+      <Select stateKey='field' label='Pick one'>
+        <Option value='a'>A</Option>
+      </Select>
+    )
+    const field = getByTestId('select') as HTMLButtonElement
+    expect(field.textContent).toBe('Pick one')
+  })
+
   it('uses existing state value when present', () => {
     useGameStore.setState({ gameData: { field: 'blue' } })
     const { getByTestId } = render(

--- a/apps/campfire/src/test-utils/formFieldTests.tsx
+++ b/apps/campfire/src/test-utils/formFieldTests.tsx
@@ -11,6 +11,7 @@ interface FormFieldTestConfig {
   existingValue: string
   children?: ComponentChildren
   initialState?: Record<string, unknown>
+  triggerInput?: (utils: ReturnType<typeof render>) => void | Promise<void>
 }
 
 /**
@@ -25,18 +26,22 @@ export const runFormFieldTests = ({
   updateValue,
   existingValue,
   children,
-  initialState = {}
+  initialState = {},
+  triggerInput
 }: FormFieldTestConfig) => {
-  it('updates game state on input', () => {
+  it('updates game state on input', async () => {
     useGameStore.setState({ gameData: initialState })
-    const { getByTestId } = render(
-      <Component stateKey='field'>{children}</Component>
-    )
-    const field = getByTestId(testId) as
+    const utils = render(<Component stateKey='field'>{children}</Component>)
+    const field = utils.getByTestId(testId) as
       | HTMLInputElement
       | HTMLTextAreaElement
       | HTMLSelectElement
-    fireEvent.input(field, { target: { value: updateValue } })
+      | HTMLButtonElement
+    if (triggerInput) {
+      await triggerInput(utils)
+    } else {
+      fireEvent.input(field, { target: { value: updateValue } })
+    }
     expect(
       (useGameStore.getState().gameData as Record<string, unknown>).field
     ).toBe(updateValue)
@@ -63,6 +68,7 @@ export const runFormFieldTests = ({
       | HTMLInputElement
       | HTMLTextAreaElement
       | HTMLSelectElement
+      | HTMLButtonElement
     expect(field.value).toBe(existingValue)
   })
 

--- a/apps/storybook/src/SelectDirective.stories.tsx
+++ b/apps/storybook/src/SelectDirective.stories.tsx
@@ -25,6 +25,8 @@ export const Basic: StoryObj = {
 
 :::
 
+This text follows the select.
+
 :::if[color]
 
 You chose

--- a/apps/storybook/src/SelectDirective.stories.tsx
+++ b/apps/storybook/src/SelectDirective.stories.tsx
@@ -18,7 +18,7 @@ export const Basic: StoryObj = {
       <tw-storydata startnode='1' options='debug'>
         <tw-passagedata pid='1' name='Start'>
           {`
-:::select[color]
+:::select[color]{label="Choose a color"}
 
 :option{value="red" label="Red"}
 :option{value="blue" label="Blue"}
@@ -60,7 +60,7 @@ export const WithEvents: StoryObj = {
       <tw-storydata startnode='1' options='debug'>
         <tw-passagedata pid='1' name='Start'>
           {`
-:::select[color]
+:::select[color]{label="Choose a color"}
 
 :option{value="red" label="Red"}
 :option{value="blue" label="Blue"}

--- a/docs/directives/inputs-and-events.md
+++ b/docs/directives/inputs-and-events.md
@@ -77,7 +77,7 @@ Container form:
 | value     | Initial selected value when the key is unset |
 | label     | Text displayed when no option is selected    |
 
-The select button uses the same default styling as trigger and link buttons and includes a downward caret on the right.
+The select button uses the same default styling as trigger and link buttons and includes a downward caret on the right. The menu closes when clicking outside the button or pressing Escape.
 
 `option` directives accept the following inputs:
 

--- a/docs/directives/inputs-and-events.md
+++ b/docs/directives/inputs-and-events.md
@@ -60,10 +60,10 @@ Container form:
 | className   | Optional space-separated classes              |
 | style       | Optional inline style declarations            |
 
-- `select`: Render a dropdown bound to a game state key. Must be used as a container with nested `option` directives. The container form can include event directives. If the key already exists in game state, its value is used; otherwise, the optional `value` attribute sets the initial selection.
+- `select`: Render a dropdown bound to a game state key. Must be used as a container with nested `option` directives. The container form can include event directives. If the key already exists in game state, its value is used; otherwise, the optional `value` attribute sets the initial selection. The optional `label` attribute provides placeholder text when no option is chosen.
 
 ```md
-:::select[color]
+:::select[color]{label="Choose a color"}
 :option{value="red" label="Red"}
 :option{value="blue" label="Blue"}
 :::
@@ -75,9 +75,9 @@ Container form:
 | className | Optional space-separated classes             |
 | style     | Optional inline style declarations           |
 | value     | Initial selected value when the key is unset |
+| label     | Text displayed when no option is selected    |
 
-Both the select and option elements include a visible black border,
-black text, and a white background by default to ensure readability.
+The select button uses the same default styling as trigger and link buttons and includes a downward caret on the right.
 
 `option` directives accept the following inputs:
 


### PR DESCRIPTION
## Summary
- replace native `<select>` with button-driven popover menu
- convert option elements to buttons with callbacks
- expand form field test utility for custom interactions

## Testing
- `bun tsc`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_68b0bcfd6ce48322a19afe17a4f44a16