### PR TITLE
feat: style gfm tables

### DIFF
--- a/apps/campfire/src/utils/__tests__/remarkStyles.test.ts
+++ b/apps/campfire/src/utils/__tests__/remarkStyles.test.ts
@@ -1,13 +1,15 @@
 import { describe, it, expect } from 'bun:test'
-import type { Root } from 'mdast'
+import type { Root as MdRoot } from 'mdast'
+import type { Root as HastRoot } from 'hast'
 import {
   remarkHeadingStyles,
-  remarkParagraphStyles
+  remarkParagraphStyles,
+  rehypeTableStyles
 } from '@campfire/utils/remarkStyles'
 
 describe('remarkHeadingStyles', () => {
   it('appends default classes', () => {
-    const tree: Root = {
+    const tree: MdRoot = {
       type: 'root',
       children: [
         {
@@ -31,7 +33,7 @@ describe('remarkHeadingStyles', () => {
 
 describe('remarkParagraphStyles', () => {
   it('appends default classes', () => {
-    const tree: Root = {
+    const tree: MdRoot = {
       type: 'root',
       children: [
         {
@@ -47,6 +49,131 @@ describe('remarkParagraphStyles', () => {
       'existing',
       'font-libertinus',
       'text-base'
+    ])
+  })
+})
+
+describe('rehypeTableStyles', () => {
+  it('applies default table classes', () => {
+    const tree: HastRoot = {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tagName: 'table',
+          properties: {},
+          children: [
+            {
+              type: 'element',
+              tagName: 'thead',
+              properties: {},
+              children: [
+                {
+                  type: 'element',
+                  tagName: 'tr',
+                  properties: {},
+                  children: [
+                    {
+                      type: 'element',
+                      tagName: 'th',
+                      properties: {},
+                      children: []
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              type: 'element',
+              tagName: 'tbody',
+              properties: {},
+              children: [
+                {
+                  type: 'element',
+                  tagName: 'tr',
+                  properties: {},
+                  children: [
+                    {
+                      type: 'element',
+                      tagName: 'td',
+                      properties: {},
+                      children: []
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              type: 'element',
+              tagName: 'caption',
+              properties: {},
+              children: []
+            }
+          ]
+        }
+      ]
+    }
+
+    rehypeTableStyles()(tree)
+
+    const table = tree.children[0] as any
+    expect(table.properties.className).toEqual([
+      'w-full',
+      'caption-bottom',
+      'text-sm'
+    ])
+
+    const thead = table.children[0] as any
+    expect(thead.properties.className).toEqual(['[&_tr]:border-b'])
+
+    const trHead = thead.children[0] as any
+    expect(trHead.properties.className).toEqual([
+      'hover:bg-muted/50',
+      'data-[state=selected]:bg-muted',
+      'border-b',
+      'transition-colors'
+    ])
+
+    const th = trHead.children[0] as any
+    expect(th.properties.className).toEqual([
+      'text-foreground',
+      'h-10',
+      'px-2',
+      'text-left',
+      'align-middle',
+      'font-medium',
+      'whitespace-nowrap',
+      '[&:has([role=checkbox])]:pr-0',
+      '[&>[role=checkbox]]:translate-y-[2px]',
+      'w-[100px]'
+    ])
+
+    const tbody = table.children[1] as any
+    expect(tbody.properties.className).toEqual(['[&_tr:last-child]:border-0'])
+
+    const trBody = tbody.children[0] as any
+    expect(trBody.properties.className).toEqual([
+      'hover:bg-muted/50',
+      'data-[state=selected]:bg-muted',
+      'border-b',
+      'transition-colors'
+    ])
+
+    const td = trBody.children[0] as any
+    expect(td.properties.className).toEqual([
+      'p-2',
+      'align-middle',
+      'whitespace-nowrap',
+      '[&:has([role=checkbox])]:pr-0',
+      '[&>[role=checkbox]]:translate-y-[2px]',
+      'font-medium'
+    ])
+
+    const caption = table.children[2] as any
+    expect(caption.properties.className).toEqual([
+      'text-muted-foreground',
+      'mt-4',
+      'text-sm'
     ])
   })
 })

--- a/apps/campfire/src/utils/createMarkdownProcessor.ts
+++ b/apps/campfire/src/utils/createMarkdownProcessor.ts
@@ -6,6 +6,7 @@ import remarkCampfire from '@campfire/remark-campfire'
 import remarkRehype from 'remark-rehype'
 import rehypeCampfire from '@campfire/rehype-campfire'
 import rehypeSlideText from '@campfire/utils/rehypeSlideText'
+import { rehypeTableStyles } from '@campfire/utils/remarkStyles'
 import rehypeReact from 'rehype-react'
 import { Fragment, jsx, jsxs } from 'preact/jsx-runtime'
 import type { ComponentType } from 'preact'
@@ -35,4 +36,5 @@ export const createMarkdownProcessor = (
     .use(remarkRehype)
     .use(rehypeCampfire)
     .use(rehypeSlideText)
+    .use(rehypeTableStyles)
     .use(rehypeReact, { Fragment, jsx, jsxs, components })

--- a/apps/campfire/src/utils/remarkStyles.ts
+++ b/apps/campfire/src/utils/remarkStyles.ts
@@ -1,5 +1,6 @@
 import { visit } from 'unist-util-visit'
-import type { Root, Paragraph } from 'mdast'
+import type { Root as MdRoot, Paragraph } from 'mdast'
+import type { Root as HastRoot } from 'hast'
 import type { Data } from 'unist'
 import type { Properties } from 'hast'
 
@@ -40,7 +41,7 @@ interface NodeData extends Data {
   hProperties?: Properties
 }
 
-export const remarkParagraphStyles = () => (tree: Root) => {
+export const remarkParagraphStyles = () => (tree: MdRoot) => {
   visit(tree, 'paragraph', (node: Paragraph) => {
     const data = (node.data ?? (node.data = {})) as NodeData
     if (data.hName) return
@@ -53,7 +54,7 @@ export const remarkParagraphStyles = () => (tree: Root) => {
  *
  * @returns Transformer attaching class names to heading elements.
  */
-export const remarkHeadingStyles = () => (tree: Root) => {
+export const remarkHeadingStyles = () => (tree: MdRoot) => {
   visit(tree, 'heading', node => {
     const mapping: Record<number, string> = {
       1: 'font-libertinus text-4xl font-bold',
@@ -68,3 +69,91 @@ export const remarkHeadingStyles = () => (tree: Root) => {
     appendClassNames(node, cls.split(' '))
   })
 }
+
+/**
+ * Appends class names to a HAST element's `className` property, preserving any
+ * existing classes.
+ *
+ * @param props - Element properties object.
+ * @param classNames - Classes to append.
+ */
+const appendElementClassNames = (
+  props: Record<string, unknown>,
+  classNames: string[]
+): void => {
+  const existing = props.className
+  const classes = Array.isArray(existing)
+    ? existing.filter((c): c is string => typeof c === 'string')
+    : typeof existing === 'string'
+      ? [existing]
+      : []
+  classes.push(...classNames)
+  props.className = classes
+}
+
+/**
+ * Applies Tailwind utility classes to GitHub Flavored Markdown table elements.
+ *
+ * @returns Rehype transformer attaching classes to table-related elements.
+ */
+export const rehypeTableStyles =
+  () =>
+  (tree: HastRoot): void => {
+    visit(tree, 'element', node => {
+      const props = (node.properties ??= {}) as Record<string, unknown>
+      switch (node.tagName) {
+        case 'table':
+          appendElementClassNames(props, [
+            'w-full',
+            'caption-bottom',
+            'text-sm'
+          ])
+          break
+        case 'thead':
+          appendElementClassNames(props, ['[&_tr]:border-b'])
+          break
+        case 'tr':
+          appendElementClassNames(props, [
+            'hover:bg-muted/50',
+            'data-[state=selected]:bg-muted',
+            'border-b',
+            'transition-colors'
+          ])
+          break
+        case 'th':
+          appendElementClassNames(props, [
+            'text-foreground',
+            'h-10',
+            'px-2',
+            'text-left',
+            'align-middle',
+            'font-medium',
+            'whitespace-nowrap',
+            '[&:has([role=checkbox])]:pr-0',
+            '[&>[role=checkbox]]:translate-y-[2px]',
+            'w-[100px]'
+          ])
+          break
+        case 'tbody':
+          appendElementClassNames(props, ['[&_tr:last-child]:border-0'])
+          break
+        case 'td':
+          appendElementClassNames(props, [
+            'p-2',
+            'align-middle',
+            'whitespace-nowrap',
+            '[&:has([role=checkbox])]:pr-0',
+            '[&>[role=checkbox]]:translate-y-[2px]',
+            'font-medium'
+          ])
+          break
+        case 'caption':
+          appendElementClassNames(props, [
+            'text-muted-foreground',
+            'mt-4',
+            'text-sm'
+          ])
+          break
+      }
+    })
+  }

--- a/apps/storybook/src/MarkdownTable.stories.tsx
+++ b/apps/storybook/src/MarkdownTable.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/preact'
+import { h } from 'preact'
+import { Deck, Slide, renderDirectiveMarkdown } from '@campfire/components'
+
+const meta: Meta = {
+  title: 'Campfire/Markdown/Table'
+}
+
+export default meta
+
+const markdown = `
+| Planet | Diameter (km) |
+| ------ | ------------- |
+| Mercury | 4,879 |
+| Venus | 12,104 |
+| Earth | 12,742 |
+`
+
+/**
+ * Demonstrates rendering a styled Markdown table.
+ *
+ * @returns Deck with a slide showing the table.
+ */
+export const Basic: StoryObj = {
+  render: () => (
+    <Deck className='w-[800px] h-[600px]'>
+      <Slide>{renderDirectiveMarkdown(markdown, {})}</Slide>
+    </Deck>
+  )
+}

--- a/apps/storybook/src/MarkdownTable.stories.tsx
+++ b/apps/storybook/src/MarkdownTable.stories.tsx
@@ -10,7 +10,7 @@ export default meta
 
 const markdown = `
 | Planet | Diameter (km) |
-| ------ | ------------- |
+| ------ | :-------------: |
 | Mercury | 4,879 |
 | Venus | 12,104 |
 | Earth | 12,742 |
@@ -23,8 +23,14 @@ const markdown = `
  */
 export const Basic: StoryObj = {
   render: () => (
-    <Deck className='w-[800px] h-[600px]'>
-      <Slide>{renderDirectiveMarkdown(markdown, {})}</Slide>
+    <Deck className='w-[800px] h-[600px]' hideNavigation>
+      <Slide
+        className={
+          'absolute bottom-0 !w-1/2 -translate-x-[50%] -translate-y-[10%] top-[50%] left-[50%]'
+        }
+      >
+        {renderDirectiveMarkdown(markdown, {})}
+      </Slide>
     </Deck>
   )
 }


### PR DESCRIPTION
## Summary
- add rehypeTableStyles to append Tailwind classes to GFM tables
- integrate table styling into Markdown processor
- test default classes on table elements
- demonstrate styled table in Storybook

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68b109aea56883229b8e641f8cc731b5