### PR TITLE
feat: style checkboxes as buttons

### DIFF
--- a/apps/campfire/src/components/Passage/Checkbox.tsx
+++ b/apps/campfire/src/components/Passage/Checkbox.tsx
@@ -1,0 +1,147 @@
+import type { JSX } from 'preact'
+import { useEffect } from 'preact/hooks'
+import rfdc from 'rfdc'
+import type { RootContent } from 'mdast'
+import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
+import { runDirectiveBlock } from '@campfire/utils/directiveUtils'
+import { useGameStore } from '@campfire/state/useGameStore'
+import {
+  checkboxStyles,
+  checkboxIndicatorStyles
+} from '@campfire/utils/remarkStyles'
+
+const clone = rfdc()
+
+interface CheckboxProps
+  extends Omit<
+    JSX.ButtonHTMLAttributes<HTMLButtonElement>,
+    | 'className'
+    | 'value'
+    | 'defaultValue'
+    | 'onFocus'
+    | 'onBlur'
+    | 'onMouseEnter'
+  > {
+  /** Key in game state to bind the checkbox value to. */
+  stateKey: string
+  /** Additional CSS classes for the checkbox element. */
+  className?: string | string[]
+  /** Serialized directives to run when hovered. */
+  onHover?: string
+  /** Serialized directives to run on focus. */
+  onFocus?: string
+  /** Serialized directives to run on blur. */
+  onBlur?: string
+  /** Initial value if the state key is unset. */
+  initialValue?: boolean
+}
+
+/**
+ * Checkbox bound to a game state key. Updates the key on user interaction.
+ *
+ * @param stateKey - Key in game state to store the value.
+ * @param className - Optional additional classes.
+ * @param onHover - Serialized directives to run when hovered.
+ * @param onFocus - Serialized directives to run on focus.
+ * @param onBlur - Serialized directives to run on blur.
+ * @param rest - Additional button element attributes.
+ * @returns The rendered checkbox element.
+ */
+export const Checkbox = ({
+  stateKey,
+  className,
+  onHover,
+  onFocus,
+  onBlur,
+  onClick,
+  initialValue,
+  ...rest
+}: CheckboxProps) => {
+  const value = useGameStore(state => state.gameData[stateKey]) as
+    | boolean
+    | string
+    | undefined
+  const handlers = useDirectiveHandlers()
+  const setGameData = useGameStore(state => state.setGameData)
+  useEffect(() => {
+    if (value === undefined) {
+      const init =
+        typeof initialValue === 'string'
+          ? initialValue === 'true'
+          : (initialValue ?? false)
+      setGameData({ [stateKey]: init })
+    }
+  }, [value, stateKey, initialValue, setGameData])
+  const classes = Array.isArray(className)
+    ? className
+    : className
+      ? [className]
+      : []
+  const checked = typeof value === 'string' ? value === 'true' : Boolean(value)
+  return (
+    <button
+      type='button'
+      role='checkbox'
+      data-testid='checkbox'
+      className={['campfire-checkbox', checkboxStyles, ...classes]
+        .filter((c, i, arr) => c && arr.indexOf(c) === i)
+        .join(' ')}
+      aria-checked={checked}
+      data-state={checked ? 'checked' : 'unchecked'}
+      {...rest}
+      onMouseEnter={e => {
+        if (onHover) {
+          runDirectiveBlock(
+            clone(JSON.parse(onHover)) as RootContent[],
+            handlers
+          )
+        }
+      }}
+      onFocus={e => {
+        if (onFocus) {
+          runDirectiveBlock(
+            clone(JSON.parse(onFocus)) as RootContent[],
+            handlers
+          )
+        }
+      }}
+      onBlur={e => {
+        if (onBlur) {
+          runDirectiveBlock(
+            clone(JSON.parse(onBlur)) as RootContent[],
+            handlers
+          )
+        }
+      }}
+      onClick={e => {
+        onClick?.(e)
+        if (e.defaultPrevented) return
+        setGameData({ [stateKey]: !checked })
+      }}
+    >
+      <span
+        data-state={checked ? 'checked' : 'unchecked'}
+        data-slot='checkbox-indicator'
+        className={checkboxIndicatorStyles}
+        style='pointer-events:none'
+      >
+        <svg
+          xmlns='http://www.w3.org/2000/svg'
+          width='24'
+          height='24'
+          viewBox='0 0 24 24'
+          fill='none'
+          stroke='currentColor'
+          stroke-width='2'
+          stroke-linecap='round'
+          stroke-linejoin='round'
+          className='lucide lucide-check size-3.5'
+        >
+          <path d='M20 6 9 17l-5-5' />
+        </svg>
+      </span>
+    </button>
+  )
+}
+
+export default Checkbox

--- a/apps/campfire/src/components/Passage/Checkbox.tsx
+++ b/apps/campfire/src/components/Passage/Checkbox.tsx
@@ -125,20 +125,22 @@ export const Checkbox = ({
         className={checkboxIndicatorStyles}
         style='pointer-events:none'
       >
-        <svg
-          xmlns='http://www.w3.org/2000/svg'
-          width='24'
-          height='24'
-          viewBox='0 0 24 24'
-          fill='none'
-          stroke='currentColor'
-          stroke-width='2'
-          stroke-linecap='round'
-          stroke-linejoin='round'
-          className='lucide lucide-check size-3.5'
-        >
-          <path d='M20 6 9 17l-5-5' />
-        </svg>
+        {checked && (
+          <svg
+            xmlns='http://www.w3.org/2000/svg'
+            width='24'
+            height='24'
+            viewBox='0 0 24 24'
+            fill='none'
+            stroke='currentColor'
+            stroke-width='2'
+            stroke-linecap='round'
+            stroke-linejoin='round'
+            className='lucide lucide-check size-3.5'
+          >
+            <path d='M20 6 9 17l-5-5' />
+          </svg>
+        )}
       </span>
     </button>
   )

--- a/apps/campfire/src/components/Passage/Passage.tsx
+++ b/apps/campfire/src/components/Passage/Passage.tsx
@@ -19,6 +19,7 @@ import { useDeckStore } from '@campfire/state/useDeckStore'
 import { LinkButton } from '@campfire/components/Passage/LinkButton'
 import { TriggerButton } from '@campfire/components/Passage/TriggerButton'
 import { Input } from '@campfire/components/Passage/Input'
+import { Checkbox } from '@campfire/components/Passage/Checkbox'
 import { Textarea } from '@campfire/components/Passage/Textarea'
 import { Select } from '@campfire/components/Passage/Select'
 import { Option } from '@campfire/components/Passage/Option'
@@ -86,6 +87,7 @@ export const Passage = () => {
           button: LinkButton,
           trigger: TriggerButton,
           input: Input,
+          checkbox: Checkbox,
           textarea: Textarea,
           select: Select,
           option: Option,

--- a/apps/campfire/src/components/Passage/__tests__/Checkbox.directive.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Checkbox.directive.test.tsx
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach } from 'bun:test'
+import { render, screen, fireEvent, act } from '@testing-library/preact'
+import type { Element } from 'hast'
+import { Passage } from '@campfire/components/Passage/Passage'
+import { useStoryDataStore } from '@campfire/state/useStoryDataStore'
+import { useGameStore } from '@campfire/state/useGameStore'
+import { resetStores } from '@campfire/test-utils/helpers'
+
+/**
+ * Tests for Checkbox directive attributes.
+ */
+describe('Checkbox directive', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    resetStores()
+  })
+
+  it('passes style attribute', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value: ':checkbox[agree]{style="color:blue"}\n'
+        }
+      ]
+    }
+    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+    render(<Passage />)
+    const button = await screen.findByTestId('checkbox')
+    expect((button as HTMLButtonElement).style.color).toBe('blue')
+  })
+
+  it('runs event directives when used as a container', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value:
+            ':::checkbox[agree]\n:::onFocus\n:set[focused=true]\n:::\n:::onHover\n:set[hovered=true]\n:::\n:::\n'
+        }
+      ]
+    }
+    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+    render(<Passage />)
+    const button = await screen.findByTestId('checkbox')
+    act(() => {
+      ;(button as HTMLButtonElement).focus()
+    })
+    expect(useGameStore.getState().gameData.focused).toBe(true)
+    fireEvent.mouseEnter(button)
+    expect(useGameStore.getState().gameData.hovered).toBe(true)
+  })
+
+  it('removes directive markers for container checkboxes', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value: ':::checkbox[agree]\n:::\n'
+        }
+      ]
+    }
+    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+    render(<Passage />)
+    await screen.findByTestId('checkbox')
+    expect(document.body.textContent).not.toContain(':::')
+  })
+
+  it('initializes state from value attribute', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value: ':checkbox[agree]{value=true}\n'
+        }
+      ]
+    }
+    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+    render(<Passage />)
+    const button = await screen.findByTestId('checkbox')
+    expect(button.getAttribute('aria-checked')).toBe('true')
+    expect((useGameStore.getState().gameData as any).agree).toBe(true)
+  })
+
+  it('uses existing state value when present', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value: ':checkbox[agree]{value=true}\n'
+        }
+      ]
+    }
+    useGameStore.setState({ gameData: { agree: false } })
+    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+    render(<Passage />)
+    const button = await screen.findByTestId('checkbox')
+    expect(button.getAttribute('aria-checked')).toBe('false')
+    expect((useGameStore.getState().gameData as any).agree).toBe(false)
+  })
+})

--- a/apps/campfire/src/components/Passage/__tests__/Checkbox.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Checkbox.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'bun:test'
+import { render, fireEvent } from '@testing-library/preact'
+import { Checkbox } from '@campfire/components/Passage/Checkbox'
+import { useGameStore } from '@campfire/state/useGameStore'
+
+/**
+ * Tests for the Checkbox component.
+ */
+describe('Checkbox', () => {
+  it('toggles game state on click', () => {
+    useGameStore.setState({ gameData: {} })
+    const { getByTestId } = render(<Checkbox stateKey='flag' />)
+    const button = getByTestId('checkbox') as HTMLButtonElement
+    fireEvent.click(button)
+    expect(useGameStore.getState().gameData.flag).toBe(true)
+    fireEvent.click(button)
+    expect(useGameStore.getState().gameData.flag).toBe(false)
+  })
+
+  it('applies className and style', () => {
+    const { getByTestId } = render(
+      <Checkbox stateKey='flag' className='extra' style={{ color: 'red' }} />
+    )
+    const button = getByTestId('checkbox') as HTMLButtonElement
+    expect(button.className.split(' ')).toContain('campfire-checkbox')
+    expect(button.className.split(' ')).toContain('extra')
+    expect(button.style.color).toBe('red')
+  })
+
+  it('uses existing state value when present', () => {
+    useGameStore.setState({ gameData: { flag: true } })
+    const { getByTestId } = render(<Checkbox stateKey='flag' />)
+    const button = getByTestId('checkbox') as HTMLButtonElement
+    expect(button.getAttribute('aria-checked')).toBe('true')
+  })
+
+  it('initializes state when unset', () => {
+    useGameStore.setState({ gameData: {} })
+    render(<Checkbox stateKey='flag' />)
+    expect(useGameStore.getState().gameData.flag).toBe(false)
+  })
+})

--- a/apps/campfire/src/components/Passage/__tests__/Checkbox.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Checkbox.test.tsx
@@ -39,4 +39,13 @@ describe('Checkbox', () => {
     render(<Checkbox stateKey='flag' />)
     expect(useGameStore.getState().gameData.flag).toBe(false)
   })
+
+  it('renders checkmark only when checked', () => {
+    useGameStore.setState({ gameData: {} })
+    const { getByTestId } = render(<Checkbox stateKey='flag' />)
+    const button = getByTestId('checkbox') as HTMLButtonElement
+    expect(button.querySelector('svg')).toBeNull()
+    fireEvent.click(button)
+    expect(button.querySelector('svg')).not.toBeNull()
+  })
 })

--- a/apps/campfire/src/components/index.ts
+++ b/apps/campfire/src/components/index.ts
@@ -4,6 +4,7 @@ export { evaluateUserScript } from '@campfire/components/Campfire/evaluateUserSc
 export { Passage } from '@campfire/components/Passage/Passage'
 export { LinkButton } from '@campfire/components/Passage/LinkButton'
 export { Input } from '@campfire/components/Passage/Input'
+export { Checkbox } from '@campfire/components/Passage/Checkbox'
 export { Textarea } from '@campfire/components/Passage/Textarea'
 export { Select } from '@campfire/components/Passage/Select'
 export { Option } from '@campfire/components/Passage/Option'

--- a/apps/campfire/src/utils/__tests__/remarkStyles.test.ts
+++ b/apps/campfire/src/utils/__tests__/remarkStyles.test.ts
@@ -239,4 +239,70 @@ describe('rehypeChecklistButtons', () => {
       'gap-[var(--size-xs)]'
     ])
   })
+
+  it('aligns items and strikes through completed text', () => {
+    const tree: HastRoot = {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tagName: 'ul',
+          properties: { className: ['contains-task-list'] },
+          children: [
+            {
+              type: 'element',
+              tagName: 'li',
+              properties: { className: ['task-list-item'] },
+              children: [
+                {
+                  type: 'element',
+                  tagName: 'input',
+                  properties: { type: 'checkbox' },
+                  children: []
+                },
+                { type: 'text', value: ' ' },
+                { type: 'text', value: 'todo' }
+              ]
+            } as any,
+            {
+              type: 'element',
+              tagName: 'li',
+              properties: { className: ['task-list-item'] },
+              children: [
+                {
+                  type: 'element',
+                  tagName: 'input',
+                  properties: { type: 'checkbox', checked: true },
+                  children: []
+                },
+                { type: 'text', value: ' ' },
+                { type: 'text', value: 'done' }
+              ]
+            } as any
+          ]
+        } as any
+      ]
+    }
+    rehypeChecklistButtons()(tree)
+    const ul = tree.children[0] as any
+    const unchecked = ul.children[0] as any
+    const checked = ul.children[1] as any
+
+    expect(unchecked.properties.className).toEqual([
+      'task-list-item',
+      'flex',
+      'items-center',
+      'gap-[var(--size-xs)]'
+    ])
+    expect(unchecked.children[1].properties.className).toEqual([
+      'peer-data-[state=checked]:line-through'
+    ])
+    expect(unchecked.children[1].children[0].value).toBe('todo')
+
+    expect(checked.children[0].properties['data-state']).toBe('checked')
+    expect(checked.children[1].properties.className).toEqual([
+      'peer-data-[state=checked]:line-through'
+    ])
+    expect(checked.children[1].children[0].value).toBe('done')
+  })
 })

--- a/apps/campfire/src/utils/__tests__/remarkStyles.test.ts
+++ b/apps/campfire/src/utils/__tests__/remarkStyles.test.ts
@@ -4,7 +4,8 @@ import type { Root as HastRoot } from 'hast'
 import {
   remarkHeadingStyles,
   remarkParagraphStyles,
-  rehypeTableStyles
+  rehypeTableStyles,
+  rehypeChecklistButtons
 } from '@campfire/utils/remarkStyles'
 
 describe('remarkHeadingStyles', () => {
@@ -175,5 +176,27 @@ describe('rehypeTableStyles', () => {
       'mt-4',
       'text-sm'
     ])
+  })
+})
+
+describe('rehypeChecklistButtons', () => {
+  it('converts checklist inputs to buttons', () => {
+    const tree: HastRoot = {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tagName: 'input',
+          properties: { type: 'checkbox', checked: true },
+          children: []
+        } as any
+      ]
+    }
+    rehypeChecklistButtons()(tree)
+    const btn = tree.children[0] as any
+    expect(btn.tagName).toBe('button')
+    expect(btn.properties['data-state']).toBe('checked')
+    expect(btn.properties.disabled).toBe(true)
+    expect(btn.children[0].tagName).toBe('span')
   })
 })

--- a/apps/campfire/src/utils/__tests__/remarkStyles.test.ts
+++ b/apps/campfire/src/utils/__tests__/remarkStyles.test.ts
@@ -198,5 +198,45 @@ describe('rehypeChecklistButtons', () => {
     expect(btn.properties['data-state']).toBe('checked')
     expect(btn.properties.disabled).toBe(true)
     expect(btn.children[0].tagName).toBe('span')
+    expect(btn.children[0].children[0].tagName).toBe('svg')
+  })
+
+  it('omits checkmark when unchecked', () => {
+    const tree: HastRoot = {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tagName: 'input',
+          properties: { type: 'checkbox' },
+          children: []
+        } as any
+      ]
+    }
+    rehypeChecklistButtons()(tree)
+    const btn = tree.children[0] as any
+    expect(btn.children[0].children).toEqual([])
+  })
+
+  it('styles task list containers', () => {
+    const tree: HastRoot = {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tagName: 'ul',
+          properties: { className: ['contains-task-list'] },
+          children: []
+        } as any
+      ]
+    }
+    rehypeChecklistButtons()(tree)
+    const ul = tree.children[0] as any
+    expect(ul.properties.className).toEqual([
+      'contains-task-list',
+      'flex',
+      'flex-col',
+      'gap-[var(--size-xs)]'
+    ])
   })
 })

--- a/apps/campfire/src/utils/createMarkdownProcessor.ts
+++ b/apps/campfire/src/utils/createMarkdownProcessor.ts
@@ -6,7 +6,10 @@ import remarkCampfire from '@campfire/remark-campfire'
 import remarkRehype from 'remark-rehype'
 import rehypeCampfire from '@campfire/rehype-campfire'
 import rehypeSlideText from '@campfire/utils/rehypeSlideText'
-import { rehypeTableStyles } from '@campfire/utils/remarkStyles'
+import {
+  rehypeTableStyles,
+  rehypeChecklistButtons
+} from '@campfire/utils/remarkStyles'
 import rehypeReact from 'rehype-react'
 import { Fragment, jsx, jsxs } from 'preact/jsx-runtime'
 import type { ComponentType } from 'preact'
@@ -36,5 +39,6 @@ export const createMarkdownProcessor = (
     .use(remarkRehype)
     .use(rehypeCampfire)
     .use(rehypeSlideText)
+    .use(rehypeChecklistButtons)
     .use(rehypeTableStyles)
     .use(rehypeReact, { Fragment, jsx, jsxs, components })

--- a/apps/campfire/src/utils/remarkStyles.ts
+++ b/apps/campfire/src/utils/remarkStyles.ts
@@ -166,10 +166,11 @@ export const rehypeTableStyles =
 
 /**
  * Replaces `<input type="checkbox">` elements produced by Markdown checklists
- * with styled button elements. The buttons are disabled so the user cannot
- * interact with static checklist items.
+ * with styled button elements and applies flex column layout and spacing to the
+ * task list container. The buttons are disabled so the user cannot interact
+ * with static checklist items.
  *
- * @returns Rehype transformer converting checklist inputs to buttons.
+ * @returns Rehype transformer converting checklist inputs to buttons and styling lists.
  */
 export const rehypeChecklistButtons =
   () =>
@@ -178,6 +179,22 @@ export const rehypeChecklistButtons =
       tree,
       'element',
       (node: any, index: number | undefined, parent: any) => {
+        if (node.tagName === 'ul') {
+          const props = (node.properties ??= {}) as Record<string, unknown>
+          const className = props.className
+          const classes = Array.isArray(className)
+            ? className
+            : typeof className === 'string'
+              ? [className]
+              : []
+          if (classes.includes('contains-task-list')) {
+            appendElementClassNames(props, [
+              'flex',
+              'flex-col',
+              'gap-[var(--size-xs)]'
+            ])
+          }
+        }
         if (
           node.tagName === 'input' &&
           (node.properties as any)?.type === 'checkbox' &&
@@ -207,32 +224,34 @@ export const rehypeChecklistButtons =
                   className: checkboxIndicatorStyles,
                   style: 'pointer-events:none'
                 },
-                children: [
-                  {
-                    type: 'element',
-                    tagName: 'svg',
-                    properties: {
-                      xmlns: 'http://www.w3.org/2000/svg',
-                      width: 24,
-                      height: 24,
-                      viewBox: '0 0 24 24',
-                      fill: 'none',
-                      stroke: 'currentColor',
-                      'stroke-width': 2,
-                      'stroke-linecap': 'round',
-                      'stroke-linejoin': 'round',
-                      className: 'lucide lucide-check size-3.5'
-                    },
-                    children: [
+                children: checked
+                  ? [
                       {
                         type: 'element',
-                        tagName: 'path',
-                        properties: { d: 'M20 6 9 17l-5-5' },
-                        children: []
+                        tagName: 'svg',
+                        properties: {
+                          xmlns: 'http://www.w3.org/2000/svg',
+                          width: 24,
+                          height: 24,
+                          viewBox: '0 0 24 24',
+                          fill: 'none',
+                          stroke: 'currentColor',
+                          'stroke-width': 2,
+                          'stroke-linecap': 'round',
+                          'stroke-linejoin': 'round',
+                          className: 'lucide lucide-check size-3.5'
+                        },
+                        children: [
+                          {
+                            type: 'element',
+                            tagName: 'path',
+                            properties: { d: 'M20 6 9 17l-5-5' },
+                            children: []
+                          }
+                        ]
                       }
                     ]
-                  }
-                ]
+                  : []
               }
             ]
           }

--- a/apps/campfire/src/utils/remarkStyles.ts
+++ b/apps/campfire/src/utils/remarkStyles.ts
@@ -255,7 +255,38 @@ export const rehypeChecklistButtons =
               }
             ]
           }
+
           parent.children.splice(index, 1, button)
+
+          const parentProps = (parent.properties ??= {}) as Record<
+            string,
+            unknown
+          >
+          appendElementClassNames(parentProps, [
+            'flex',
+            'items-center',
+            'gap-[var(--size-xs)]'
+          ])
+
+          const rest = parent.children.splice(index + 1)
+          if (
+            rest.length &&
+            rest[0].type === 'text' &&
+            typeof (rest[0] as any).value === 'string' &&
+            !(rest[0] as any).value.trim()
+          ) {
+            rest.shift()
+          }
+          if (rest.length) {
+            parent.children.splice(index + 1, 0, {
+              type: 'element',
+              tagName: 'span',
+              properties: {
+                className: ['peer-data-[state=checked]:line-through']
+              },
+              children: rest
+            })
+          }
         }
       }
     )

--- a/apps/storybook/src/Checkbox.stories.tsx
+++ b/apps/storybook/src/Checkbox.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from '@storybook/preact'
+import { h } from 'preact'
+import { Checkbox } from '@campfire/components'
+
+const meta: Meta<typeof Checkbox> = {
+  component: Checkbox,
+  title: 'Campfire/Checkbox'
+}
+
+export default meta
+
+/**
+ * Displays a basic Checkbox bound to game state.
+ *
+ * @returns A Checkbox example.
+ */
+export const Basic: StoryObj<typeof Checkbox> = {
+  render: () => <Checkbox stateKey='agree' /> // simple example
+}

--- a/apps/storybook/src/CheckboxDirective.stories.tsx
+++ b/apps/storybook/src/CheckboxDirective.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/preact'
+import { Campfire } from '@campfire/components'
+
+const meta: Meta = {
+  title: 'Campfire/Directives/Checkbox'
+}
+
+export default meta
+
+/**
+ * Demonstrates the `checkbox` directive bound to game state.
+ *
+ * @returns Campfire story showcasing the `checkbox` directive.
+ */
+export const Basic: StoryObj = {
+  render: () => (
+    <>
+      <tw-storydata startnode='1' options='debug'>
+        <tw-passagedata pid='1' name='Start'>
+          {`
+:checkbox[agree]
+`}
+        </tw-passagedata>
+      </tw-storydata>
+      <Campfire />
+    </>
+  )
+}

--- a/apps/storybook/src/MarkdownCheckbox.stories.tsx
+++ b/apps/storybook/src/MarkdownCheckbox.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/preact'
+import { h } from 'preact'
+import { Deck, Slide, renderDirectiveMarkdown } from '@campfire/components'
+
+const meta: Meta = {
+  title: 'Campfire/Markdown/Checkbox'
+}
+
+export default meta
+
+const markdown = `
+- [ ] Unchecked item
+- [x] Checked item
+`
+
+/**
+ * Demonstrates rendering Markdown checkboxes as styled buttons.
+ *
+ * @returns Deck with a slide showing the checkboxes.
+ */
+export const Basic: StoryObj = {
+  render: () => (
+    <Deck className='w-[800px] h-[600px]' hideNavigation>
+      <Slide
+        className={
+          'absolute bottom-0 !w-1/2 -translate-x-[50%] -translate-y-[10%] top-[50%] left-[50%]'
+        }
+      >
+        {renderDirectiveMarkdown(markdown, {})}
+      </Slide>
+    </Deck>
+  )
+}


### PR DESCRIPTION
## Summary
- render interactive checkbox directives using a button styled as a checkbox
- convert markdown checklist inputs into disabled checkbox buttons
- support new checkbox directive and add coverage
- showcase checkbox in component, directive, and markdown stories

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68b1cd69424083228528ae0f2fe361f4