### PR TITLE
fix: group nested directives within layer

### DIFF
--- a/apps/campfire/src/hooks/__tests__/layerDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/layerDirective.test.tsx
@@ -60,4 +60,17 @@ describe('layer directive', () => {
     render(<MarkdownRunner markdown={md} />)
     expect(document.body.textContent).not.toContain(':::')
   })
+
+  it('allows layers to be nested', () => {
+    const md =
+      ':::layer{className="outer"}\nOuter\n:::layer{className="inner"}\nInner\n:::\n:::\n'
+    render(<MarkdownRunner markdown={md} />)
+    const layers = document.querySelectorAll('[data-testid="layer"]')
+    expect(layers.length).toBe(2)
+    const [outer, inner] = Array.from(layers) as HTMLElement[]
+    expect(outer.className).toContain('outer')
+    expect(inner.className).toContain('inner')
+    expect(outer.contains(inner)).toBe(true)
+    expect(document.body.textContent).not.toContain(':::')
+  })
 })

--- a/apps/campfire/src/hooks/__tests__/layerDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/layerDirective.test.tsx
@@ -53,4 +53,11 @@ describe('layer directive', () => {
     expect(el.style.top).toBe('10px')
     expect(el.style.zIndex).toBe('2')
   })
+
+  it('removes stray markers from nested directives', () => {
+    const md =
+      ':::layer{className="wrapper"}\n:::text{x=0 y=0}\nOne\n:::\n:::text{x=0 y=0}\nTwo\n:::\n:::'
+    render(<MarkdownRunner markdown={md} />)
+    expect(document.body.textContent).not.toContain(':::')
+  })
 })

--- a/apps/campfire/src/hooks/__tests__/layerDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/layerDirective.test.tsx
@@ -68,9 +68,11 @@ describe('layer directive', () => {
     const layers = document.querySelectorAll('[data-testid="layer"]')
     expect(layers.length).toBe(2)
     const [outer, inner] = Array.from(layers) as HTMLElement[]
+    expect(outer.tagName).toBe('DIV')
+    expect(inner.tagName).toBe('DIV')
+    expect(inner.parentElement).toBe(outer)
     expect(outer.className).toContain('outer')
     expect(inner.className).toContain('inner')
-    expect(outer.contains(inner)).toBe(true)
     expect(document.body.textContent).not.toContain(':::')
   })
 })

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -3013,11 +3013,18 @@ export const useDirectiveHandlers = () => {
     const container = directive as ContainerDirective
     const extra: RootContent[] = []
     let markerPos = index + 1
-    while (
-      markerPos < parent.children.length &&
-      !isMarkerParagraph(parent.children[markerPos] as RootContent)
-    ) {
-      extra.push(parent.children[markerPos] as RootContent)
+    let depth = 0
+    while (markerPos < parent.children.length) {
+      const node = parent.children[markerPos] as RootContent
+      if (isMarkerParagraph(node)) {
+        if (depth === 0) break
+        depth--
+        extra.push(node)
+        markerPos++
+        continue
+      }
+      extra.push(node)
+      if ((node as DirectiveNode).type === 'containerDirective') depth++
       markerPos++
     }
     if (extra.length > 0) parent.children.splice(index + 1, extra.length)


### PR DESCRIPTION
## Summary
- ensure layer directive collects nested container directives and filters whitespace to avoid stray markers
- test layering with multiple nested directives

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68b20ebb16fc83229426df9a18cf944a