### PR TITLE
feat: add wrapper directive

### DIFF
--- a/apps/campfire/src/hooks/__tests__/wrapperDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/wrapperDirective.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach } from 'bun:test'
+import { render } from '@testing-library/preact'
+import type { ComponentChild } from 'preact'
+import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
+import { renderDirectiveMarkdown } from '@campfire/components/Deck/Slide'
+
+/** Wrapper directive test utilities. */
+
+let output: ComponentChild | null = null
+
+/**
+ * Component used in tests to render markdown with directive handlers.
+ *
+ * @param markdown - Markdown string that may include wrapper directives.
+ * @returns Nothing; sets `output` with rendered content.
+ */
+const MarkdownRunner = ({ markdown }: { markdown: string }) => {
+  const handlers = useDirectiveHandlers()
+  output = renderDirectiveMarkdown(markdown, handlers)
+  return <>{output}</>
+}
+
+beforeEach(() => {
+  output = null
+  document.body.innerHTML = ''
+})
+
+describe('wrapper directive', () => {
+  it('renders the specified element with props', () => {
+    const md =
+      ':::wrapper{as="section" className="box" data-test="ok"}\nContent\n:::'
+    render(<MarkdownRunner markdown={md} />)
+    const el = document.querySelector('[data-testid="wrapper"]') as HTMLElement
+    expect(el).toBeTruthy()
+    expect(el.tagName).toBe('SECTION')
+    expect(el.className).toContain('campfire-wrapper')
+    expect(el.className).toContain('box')
+    expect(el.getAttribute('data-test')).toBe('ok')
+    expect(el.textContent).toContain('Content')
+  })
+
+  it('defaults to div when an unsupported tag is provided', () => {
+    const md = ':::wrapper{as="article"}\nHi\n:::'
+    render(<MarkdownRunner markdown={md} />)
+    const el = document.querySelector('[data-testid="wrapper"]') as HTMLElement
+    expect(el.tagName).toBe('DIV')
+  })
+
+  it('does not leave stray markers inside layer', () => {
+    const md = ':::layer\n:::wrapper{as="p"}\nHi\n:::\n:::\n'
+    render(<MarkdownRunner markdown={md} />)
+    const layer = document.querySelector('[data-testid="layer"]') as HTMLElement
+    expect(layer.innerHTML).not.toContain(':::')
+    expect(layer.textContent).toBe('Hi')
+  })
+})

--- a/docs/directives/navigation-composition.md
+++ b/docs/directives/navigation-composition.md
@@ -241,6 +241,25 @@ Control the flow between passages or how they reveal.
   | style          | Inline styles applied to the `<svg>` element      |
   | from           | Name of a shape preset to apply                   |
 
+- `wrapper`: Wrap content in a basic HTML element.
+
+  ```md
+  :::deck
+  :::slide
+  :::layer{x=10 y=20}
+  :::wrapper{as="p" className="note"}
+  Text
+  :::
+  :::
+  :::
+  :::
+  ```
+
+  | Input     | Description                                                       |
+  | --------- | ----------------------------------------------------------------- |
+  | as        | Element tag (`div`, `span`, `p`, or `section`, defaults to `div`) |
+  | className | Additional classes applied to the element                         |
+
 - `preset`: Define reusable attribute sets that can be applied via the `from` attribute on `deck`, `reveal`, `image`, `shape`, and `text` directives.
 
   ```md


### PR DESCRIPTION
## Summary
- add wrapper directive for basic HTML wrapping
- clean up layer directive markers when nested
- document wrapper usage

## Testing
- `bun x prettier --write apps/campfire/src/hooks/useDirectiveHandlers.ts apps/campfire/src/hooks/__tests__/wrapperDirective.test.tsx docs/directives/navigation-composition.md`
- `bun tsc`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_68b24bda764c83229486acace170a646