### PR TITLE
refactor: centralize class name merging

### DIFF
--- a/apps/campfire/src/components/Deck/Deck.tsx
+++ b/apps/campfire/src/components/Deck/Deck.tsx
@@ -21,6 +21,7 @@ import {
   prefersReducedMotion,
   runAnimation
 } from '@campfire/components/transition'
+import { mergeClasses } from '@campfire/utils/core'
 import { getRevealMax } from './Slide/utils'
 import type { Transition, SlideTransition } from './Slide/types'
 
@@ -403,9 +404,10 @@ export const Deck = ({
   return (
     <div
       ref={hostRef}
-      className={`campfire-deck relative w-full h-full overflow-hidden ${
-        className ?? ''
-      }`}
+      className={mergeClasses(
+        'campfire-deck relative w-full h-full overflow-hidden',
+        className
+      )}
       style={{
         background:
           'var(--deck-bg,linear-gradient(to bottom,var(--color-gray-900),var(--color-gray-950)))',
@@ -419,12 +421,10 @@ export const Deck = ({
     >
       <div
         ref={slideRef}
-        className={[
+        className={mergeClasses(
           'campfire-deck-group absolute left-1/2 top-1/2 origin-center rounded-2xl overflow-hidden shadow-[0_10px_30px_oklch(0_0_0_/_0.35)] bg-[var(--slide-bg,var(--color-gray-50))] text-[var(--slide-fg,var(--color-gray-950))]',
           groupClassName
-        ]
-          .filter(c => c != null && c !== '')
-          .join(' ')}
+        )}
         style={{
           width: size.width,
           height: size.height,
@@ -443,19 +443,18 @@ export const Deck = ({
       </div>
       {showSlideCount && (
         <div
-          className={[
+          className={mergeClasses(
             'campfire-deck-hud absolute top-3 right-3 text-sm px-2 py-1 rounded bg-black/50 text-white/80 text-right',
             hudClassName
-          ]
-            .filter(c => c != null && c !== '')
-            .join(' ')}
+          )}
           aria-hidden='true'
           data-testid='deck-hud'
         >
           <div
-            className={['campfire-deck-slide-hud', slideHudClassName]
-              .filter(c => c != null && c !== '')
-              .join(' ')}
+            className={mergeClasses(
+              'campfire-deck-slide-hud',
+              slideHudClassName
+            )}
             data-testid='deck-slide-hud'
           >
             Slide {currentSlide + 1} / {slides.length}
@@ -464,23 +463,19 @@ export const Deck = ({
       )}
       {!hideNavigation && (
         <div
-          className={[
+          className={mergeClasses(
             'campfire-deck-nav absolute inset-x-0 bottom-2 flex items-center justify-center px-2 pointer-events-none gap-[8px]',
             navClassName
-          ]
-            .filter(c => c != null && c !== '')
-            .join(' ')}
+          )}
           data-testid='deck-nav'
         >
           <button
             type='button'
-            className={[
+            className={mergeClasses(
               'campfire-deck-prev campfire-deck-nav-button pointer-events-auto px-3 py-1 rounded bg-black/60 text-white/90 focus:outline-none focus:ring disabled:opacity-50',
               navButtonClassName,
               rewindButtonClassName
-            ]
-              .filter(c => c != null && c !== '')
-              .join(' ')}
+            )}
             aria-label={labels.prev}
             onClick={e => {
               e.stopPropagation()
@@ -493,13 +488,11 @@ export const Deck = ({
           </button>
           <button
             type='button'
-            className={[
+            className={mergeClasses(
               'campfire-deck-autoplay-toggle campfire-deck-nav-button pointer-events-auto px-3 py-1 rounded bg-black/60 text-white/90 focus:outline-none focus:ring disabled:opacity-50',
               navButtonClassName,
               playButtonClassName
-            ]
-              .filter(c => c != null && c !== '')
-              .join(' ')}
+            )}
             aria-label={paused ? labels.play : labels.pause}
             onClick={e => {
               e.stopPropagation()
@@ -512,13 +505,11 @@ export const Deck = ({
           </button>
           <button
             type='button'
-            className={[
+            className={mergeClasses(
               'campfire-deck-next campfire-deck-nav-button pointer-events-auto px-3 py-1 rounded bg-black/60 text-white/90 focus:outline-none focus:ring disabled:opacity-50',
               navButtonClassName,
               fastForwardButtonClassName
-            ]
-              .filter(c => c != null && c !== '')
-              .join(' ')}
+            )}
             aria-label={labels.next}
             onClick={e => {
               e.stopPropagation()

--- a/apps/campfire/src/components/Deck/Slide/Layer/index.tsx
+++ b/apps/campfire/src/components/Deck/Slide/Layer/index.tsx
@@ -1,4 +1,5 @@
 import { type ComponentChildren, type JSX } from 'preact'
+import { mergeClasses } from '@campfire/utils/core'
 
 export interface LayerProps {
   x?: number
@@ -72,9 +73,7 @@ export const Layer = ({
   }
   return (
     <div
-      className={['campfire-layer', className]
-        .filter(c => c != null && c !== '')
-        .join(' ')}
+      className={mergeClasses('campfire-layer', className)}
       style={style}
       {...rest}
     >

--- a/apps/campfire/src/components/Deck/Slide/SlideLayer/index.tsx
+++ b/apps/campfire/src/components/Deck/Slide/SlideLayer/index.tsx
@@ -1,6 +1,6 @@
 import { type ComponentChildren, type ComponentType, type JSX } from 'preact'
 import { Layer, type LayerProps } from '../Layer'
-import { parseInlineStyle } from '@campfire/utils/core'
+import { mergeClasses, parseInlineStyle } from '@campfire/utils/core'
 
 export interface SlideLayerProps
   extends Omit<LayerProps, 'children' | 'className'> {
@@ -44,9 +44,7 @@ export const SlideLayer = ({
   return (
     <Layer
       data-testid={testId}
-      className={['campfire-slide-layer', layerClassName]
-        .filter(c => c != null && c !== '')
-        .join(' ')}
+      className={mergeClasses('campfire-slide-layer', layerClassName)}
       {...layerProps}
     >
       <Tag className={className} style={finalStyle} {...elementProps}>

--- a/apps/campfire/src/components/Passage/Checkbox.tsx
+++ b/apps/campfire/src/components/Passage/Checkbox.tsx
@@ -4,6 +4,7 @@ import rfdc from 'rfdc'
 import type { RootContent } from 'mdast'
 import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
 import { runDirectiveBlock } from '@campfire/utils/directiveUtils'
+import { mergeClasses } from '@campfire/utils/core'
 import { useGameStore } from '@campfire/state/useGameStore'
 import {
   checkboxStyles,
@@ -72,20 +73,13 @@ export const Checkbox = ({
       setGameData({ [stateKey]: init })
     }
   }, [value, stateKey, initialValue, setGameData])
-  const classes = Array.isArray(className)
-    ? className
-    : className
-      ? [className]
-      : []
   const checked = typeof value === 'string' ? value === 'true' : Boolean(value)
   return (
     <button
       type='button'
       role='checkbox'
       data-testid='checkbox'
-      className={['campfire-checkbox', checkboxStyles, ...classes]
-        .filter((c, i, arr) => c && arr.indexOf(c) === i)
-        .join(' ')}
+      className={mergeClasses('campfire-checkbox', checkboxStyles, className)}
       aria-checked={checked}
       data-state={checked ? 'checked' : 'unchecked'}
       {...rest}

--- a/apps/campfire/src/components/Passage/Input.tsx
+++ b/apps/campfire/src/components/Passage/Input.tsx
@@ -4,6 +4,7 @@ import rfdc from 'rfdc'
 import type { RootContent } from 'mdast'
 import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
 import { runDirectiveBlock } from '@campfire/utils/directiveUtils'
+import { mergeClasses } from '@campfire/utils/core'
 import { useGameStore } from '@campfire/state/useGameStore'
 
 const clone = rfdc()
@@ -66,17 +67,10 @@ export const Input = ({
       setGameData({ [stateKey]: initialValue ?? '' })
     }
   }, [value, stateKey, initialValue, setGameData])
-  const classes = Array.isArray(className)
-    ? className
-    : className
-      ? [className]
-      : []
   return (
     <input
       data-testid='input'
-      className={['campfire-input', inputStyles, ...classes]
-        .filter((c, i, arr) => c && arr.indexOf(c) === i)
-        .join(' ')}
+      className={mergeClasses('campfire-input', inputStyles, className)}
       value={value ?? ''}
       {...rest}
       onMouseEnter={e => {

--- a/apps/campfire/src/components/Passage/LinkButton.tsx
+++ b/apps/campfire/src/components/Passage/LinkButton.tsx
@@ -3,11 +3,14 @@ import {
   useStoryDataStore,
   type StoryDataState
 } from '@campfire/state/useStoryDataStore'
+import { mergeClasses } from '@campfire/utils/core'
 
-interface LinkButtonProps extends JSX.HTMLAttributes<HTMLButtonElement> {
+interface LinkButtonProps
+  extends Omit<JSX.HTMLAttributes<HTMLButtonElement>, 'className'> {
   'data-pid'?: string
   'data-name'?: string
   disabled?: boolean
+  className?: string | string[]
 }
 
 /**
@@ -33,13 +36,11 @@ export const LinkButton = ({
     <button
       type='button'
       data-testid='link-button'
-      className={[
+      className={mergeClasses(
         'campfire-link',
         "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive bg-primary text-primary-foreground shadow-xs hover:bg-primary/90 h-9 px-4 py-2 has-[>svg]:px-3",
         className
-      ]
-        .filter((c, i, arr) => c && arr.indexOf(c) === i)
-        .join(' ')}
+      )}
       {...rest}
       onClick={e => {
         e.stopPropagation()

--- a/apps/campfire/src/components/Passage/Option.tsx
+++ b/apps/campfire/src/components/Passage/Option.tsx
@@ -1,4 +1,5 @@
 import type { JSX } from 'preact'
+import { mergeClasses } from '@campfire/utils/core'
 
 export interface OptionProps
   extends Omit<JSX.HTMLAttributes<HTMLButtonElement>, 'className'> {
@@ -28,11 +29,6 @@ export const Option = ({
   value,
   ...rest
 }: OptionProps) => {
-  const classes = Array.isArray(className)
-    ? className
-    : className
-      ? [className]
-      : []
   const mergedStyle =
     typeof style === 'string'
       ? `color:oklch(0 0 0);background:oklch(0.98 0 0);${style}`
@@ -45,11 +41,11 @@ export const Option = ({
     <button
       type='button'
       data-testid='option'
-      className={[
+      className={mergeClasses(
         'campfire-option',
         'w-full text-left px-2 py-2 transition-colors hover:bg-[oklch(0.9_0_0)]',
-        ...classes
-      ].join(' ')}
+        className
+      )}
       style={mergedStyle}
       onClick={() => onSelectOption?.(value)}
       {...rest}

--- a/apps/campfire/src/components/Passage/Radio.tsx
+++ b/apps/campfire/src/components/Passage/Radio.tsx
@@ -4,6 +4,7 @@ import rfdc from 'rfdc'
 import type { RootContent } from 'mdast'
 import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
 import { runDirectiveBlock } from '@campfire/utils/directiveUtils'
+import { mergeClasses } from '@campfire/utils/core'
 import { useGameStore } from '@campfire/state/useGameStore'
 import { radioStyles, radioIndicatorStyles } from '@campfire/utils/remarkStyles'
 
@@ -68,20 +69,13 @@ export const Radio = ({
       setGameData({ [stateKey]: initialValue })
     }
   }, [value, stateKey, initialValue, setGameData])
-  const classes = Array.isArray(className)
-    ? className
-    : className
-      ? [className]
-      : []
   const checked = value === optionValue
   return (
     <button
       type='button'
       role='radio'
       data-testid='radio'
-      className={['campfire-radio', radioStyles, ...classes]
-        .filter((c, i, arr) => c && arr.indexOf(c) === i)
-        .join(' ')}
+      className={mergeClasses('campfire-radio', radioStyles, className)}
       aria-checked={checked}
       data-state={checked ? 'checked' : 'unchecked'}
       {...rest}

--- a/apps/campfire/src/components/Passage/Select.tsx
+++ b/apps/campfire/src/components/Passage/Select.tsx
@@ -5,6 +5,7 @@ import rfdc from 'rfdc'
 import type { RootContent } from 'mdast'
 import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
 import { runDirectiveBlock } from '@campfire/utils/directiveUtils'
+import { mergeClasses } from '@campfire/utils/core'
 import { useGameStore } from '@campfire/state/useGameStore'
 import type { OptionProps } from './Option'
 
@@ -66,11 +67,6 @@ export const Select = ({
     | undefined
   const setGameData = useGameStore(state => state.setGameData)
   const handlers = useDirectiveHandlers()
-  const classes = Array.isArray(className)
-    ? className
-    : className
-      ? [className]
-      : []
   const [open, setOpen] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
   useEffect(() => {
@@ -110,12 +106,12 @@ export const Select = ({
     <div ref={containerRef} className='inline-block relative'>
       <button
         data-testid='select'
-        className={[
+        className={mergeClasses(
           'campfire-select',
           selectStyles,
           'items-center justify-between cursor-pointer',
-          ...classes
-        ].join(' ')}
+          className
+        )}
         style={style}
         value={value ?? ''}
         {...rest}

--- a/apps/campfire/src/components/Passage/Show.tsx
+++ b/apps/campfire/src/components/Passage/Show.tsx
@@ -1,7 +1,11 @@
 import type { JSX } from 'preact'
 import { useGameStore } from '@campfire/state/useGameStore'
 import { isRange } from '@campfire/utils/directiveUtils'
-import { evalExpression, interpolateString } from '@campfire/utils/core'
+import {
+  evalExpression,
+  interpolateString,
+  mergeClasses
+} from '@campfire/utils/core'
 
 interface ShowProps {
   /** Game data key to display */
@@ -23,11 +27,7 @@ export const Show = ({ className, style, ...props }: ShowProps) => {
   const addError = useGameStore(state => state.addError)
   const gameData = useGameStore(state => state.gameData)
   const expr = props['data-expr']
-  const classes = Array.isArray(className)
-    ? className
-    : className
-      ? [className]
-      : []
+
   const mergedStyle =
     typeof style === 'string' ? style : style ? { ...style } : undefined
   if (expr) {
@@ -42,7 +42,7 @@ export const Show = ({ className, style, ...props }: ShowProps) => {
       const display = isRange(result) ? result.value : result
       return (
         <span
-          className={['campfire-show', ...classes].join(' ')}
+          className={mergeClasses('campfire-show', className)}
           style={mergedStyle}
           data-testid='show'
         >
@@ -64,7 +64,7 @@ export const Show = ({ className, style, ...props }: ShowProps) => {
   const displayValue = isRange(value) ? value.value : value
   return (
     <span
-      className={['campfire-show', ...classes].join(' ')}
+      className={mergeClasses('campfire-show', className)}
       style={mergedStyle}
       data-testid='show'
     >

--- a/apps/campfire/src/components/Passage/Textarea.tsx
+++ b/apps/campfire/src/components/Passage/Textarea.tsx
@@ -4,6 +4,7 @@ import rfdc from 'rfdc'
 import type { RootContent } from 'mdast'
 import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
 import { runDirectiveBlock } from '@campfire/utils/directiveUtils'
+import { mergeClasses } from '@campfire/utils/core'
 import { useGameStore } from '@campfire/state/useGameStore'
 
 const clone = rfdc()
@@ -66,17 +67,10 @@ export const Textarea = ({
       setGameData({ [stateKey]: initialValue ?? '' })
     }
   }, [value, stateKey, initialValue, setGameData])
-  const classes = Array.isArray(className)
-    ? className
-    : className
-      ? [className]
-      : []
   return (
     <textarea
       data-testid='textarea'
-      className={['campfire-textarea', textareaStyles, ...classes]
-        .filter((c, i, arr) => c && arr.indexOf(c) === i)
-        .join(' ')}
+      className={mergeClasses('campfire-textarea', textareaStyles, className)}
       value={value ?? ''}
       {...rest}
       onMouseEnter={e => {

--- a/apps/campfire/src/components/Passage/Translate.tsx
+++ b/apps/campfire/src/components/Passage/Translate.tsx
@@ -2,7 +2,11 @@ import type { JSX } from 'preact'
 import { useTranslation } from 'react-i18next'
 import i18next from 'i18next'
 import { useGameStore } from '@campfire/state/useGameStore'
-import { evalExpression, getTranslationOptions } from '@campfire/utils/core'
+import {
+  evalExpression,
+  getTranslationOptions,
+  mergeClasses
+} from '@campfire/utils/core'
 
 interface TranslateProps {
   /** Translation key to display */
@@ -35,11 +39,6 @@ export const Translate = ({ className, style, ...props }: TranslateProps) => {
   let tKey = props['data-i18n-key']
   const expr = props['data-i18n-expr']
   const fallback = props['data-i18n-fallback']
-  const classes = Array.isArray(className)
-    ? className
-    : className
-      ? [className]
-      : []
   const mergedStyle =
     typeof style === 'string' ? style : style ? { ...style } : undefined
   if (!tKey && expr) {
@@ -60,7 +59,7 @@ export const Translate = ({ className, style, ...props }: TranslateProps) => {
       addError(msg)
       return fallback ? (
         <span
-          className={['campfire-translate', ...classes].join(' ')}
+          className={mergeClasses('campfire-translate', className)}
           style={mergedStyle}
           data-testid='translate'
         >
@@ -72,7 +71,7 @@ export const Translate = ({ className, style, ...props }: TranslateProps) => {
   if (!tKey)
     return fallback ? (
       <span
-        className={['campfire-translate', ...classes].join(' ')}
+        className={mergeClasses('campfire-translate', className)}
         style={mergedStyle}
         data-testid='translate'
       >
@@ -97,7 +96,7 @@ export const Translate = ({ className, style, ...props }: TranslateProps) => {
   }
   return (
     <span
-      className={['campfire-translate', ...classes].join(' ')}
+      className={mergeClasses('campfire-translate', className)}
       style={mergedStyle}
       data-testid='translate'
     >

--- a/apps/campfire/src/components/Passage/TriggerButton.tsx
+++ b/apps/campfire/src/components/Passage/TriggerButton.tsx
@@ -2,6 +2,7 @@ import type { RootContent } from 'mdast'
 import rfdc from 'rfdc'
 import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
 import { runDirectiveBlock } from '@campfire/utils/directiveUtils'
+import { mergeClasses } from '@campfire/utils/core'
 import type { JSX } from 'preact'
 
 const clone = rfdc()
@@ -48,20 +49,15 @@ export const TriggerButton = ({
   ...rest
 }: TriggerButtonProps) => {
   const handlers = useDirectiveHandlers()
-  const classes = Array.isArray(className)
-    ? className
-    : className
-      ? [className]
-      : []
   return (
     <button
       type='button'
       data-testid='trigger-button'
-      className={[
+      className={mergeClasses(
         'campfire-trigger',
         "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive bg-primary text-primary-foreground shadow-xs hover:bg-primary/90 h-9 px-4 py-2 has-[>svg]:px-3",
-        ...classes
-      ].join(' ')}
+        className
+      )}
       disabled={disabled}
       style={style}
       {...rest}

--- a/apps/campfire/src/utils/__tests__/core.test.ts
+++ b/apps/campfire/src/utils/__tests__/core.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'bun:test'
-import { extractQuoted, getBaseUrl } from '@campfire/utils/core'
+import { extractQuoted, getBaseUrl, mergeClasses } from '@campfire/utils/core'
 
 describe('extractQuoted', () => {
   it('unwraps single-quoted strings', () => {
@@ -18,6 +18,18 @@ describe('extractQuoted', () => {
     expect(extractQuoted('\'He said "hi"\'')).toBe('He said "hi"')
     expect(extractQuoted('"It\'s fine"')).toBe("It's fine")
     expect(extractQuoted('`mix "and" \'match\'`')).toBe('mix "and" \'match\'')
+  })
+})
+
+describe('mergeClasses', () => {
+  it('combines strings and arrays', () => {
+    expect(mergeClasses('a', ['b', 'c'], 'd')).toBe('a b c d')
+  })
+
+  it('deduplicates and filters falsy values', () => {
+    expect(mergeClasses('a', undefined, 'a', ['b', '', 'c'], false)).toBe(
+      'a b c'
+    )
   })
 })
 

--- a/apps/campfire/src/utils/core.ts
+++ b/apps/campfire/src/utils/core.ts
@@ -107,6 +107,23 @@ export const parseInlineStyle = (
     : { ...style }
 
 /**
+ * Merges multiple class name inputs into a deduplicated string.
+ *
+ * Accepts strings or arrays of strings and filters out falsy values and
+ * duplicates.
+ *
+ * @param classes - Class name values to merge.
+ * @returns A space-separated string of unique class names.
+ */
+export const mergeClasses = (
+  ...classes: Array<string | string[] | undefined | null | false>
+): string =>
+  classes
+    .flatMap(cls => (Array.isArray(cls) ? cls : cls ? [cls] : []))
+    .filter((c, i, arr) => c && arr.indexOf(c) === i)
+    .join(' ')
+
+/**
  * Extracts translation options from directive attributes or component props.
  *
  * @param src - Source object that may contain `ns` and `count` values.

--- a/apps/storybook/src/Input.stories.tsx
+++ b/apps/storybook/src/Input.stories.tsx
@@ -15,7 +15,9 @@ export default meta
  * @returns An Input example.
  */
 export const Basic: StoryObj<typeof Input> = {
-  render: () => <Input stateKey='name' placeholder='Your name' /> // simple example
+  render: () => (
+    <Input stateKey='name' className={['p-2']} placeholder='Your name' />
+  ) // simple example
 }
 
 /**

--- a/apps/storybook/src/Textarea.stories.tsx
+++ b/apps/storybook/src/Textarea.stories.tsx
@@ -15,7 +15,9 @@ export default meta
  * @returns A Textarea example.
  */
 export const Basic: StoryObj<typeof Textarea> = {
-  render: () => <Textarea stateKey='bio' placeholder='Your bio' />
+  render: () => (
+    <Textarea stateKey='bio' className={['p-2']} placeholder='Your bio' />
+  )
 }
 
 /**


### PR DESCRIPTION
## Summary
- add `mergeClasses` utility to deduplicate class names
- refactor UI components to use `mergeClasses`
- document array `className` usage in Input and Textarea stories

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68b36ca3af24832291270109949d8819