### PR TITLE
feat: introduce useDirectiveEvents hook

### DIFF
--- a/apps/campfire/src/components/Passage/Checkbox.tsx
+++ b/apps/campfire/src/components/Passage/Checkbox.tsx
@@ -1,17 +1,12 @@
 import type { JSX } from 'preact'
 import { useEffect } from 'preact/hooks'
-import rfdc from 'rfdc'
-import type { RootContent } from 'mdast'
-import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
-import { runDirectiveBlock } from '@campfire/utils/directiveUtils'
+import { useDirectiveEvents } from '@campfire/hooks/useDirectiveEvents'
 import { mergeClasses } from '@campfire/utils/core'
 import { useGameStore } from '@campfire/state/useGameStore'
 import {
   checkboxStyles,
   checkboxIndicatorStyles
 } from '@campfire/utils/remarkStyles'
-
-const clone = rfdc()
 
 interface CheckboxProps
   extends Omit<
@@ -62,7 +57,7 @@ export const Checkbox = ({
     | boolean
     | string
     | undefined
-  const handlers = useDirectiveHandlers()
+  const directiveEvents = useDirectiveEvents(onHover, onFocus, onBlur)
   const setGameData = useGameStore(state => state.setGameData)
   useEffect(() => {
     if (value === undefined) {
@@ -83,30 +78,7 @@ export const Checkbox = ({
       aria-checked={checked}
       data-state={checked ? 'checked' : 'unchecked'}
       {...rest}
-      onMouseEnter={e => {
-        if (onHover) {
-          runDirectiveBlock(
-            clone(JSON.parse(onHover)) as RootContent[],
-            handlers
-          )
-        }
-      }}
-      onFocus={e => {
-        if (onFocus) {
-          runDirectiveBlock(
-            clone(JSON.parse(onFocus)) as RootContent[],
-            handlers
-          )
-        }
-      }}
-      onBlur={e => {
-        if (onBlur) {
-          runDirectiveBlock(
-            clone(JSON.parse(onBlur)) as RootContent[],
-            handlers
-          )
-        }
-      }}
+      {...directiveEvents}
       onClick={e => {
         onClick?.(e)
         if (e.defaultPrevented) return

--- a/apps/campfire/src/components/Passage/Input.tsx
+++ b/apps/campfire/src/components/Passage/Input.tsx
@@ -1,13 +1,8 @@
 import type { JSX } from 'preact'
 import { useEffect } from 'preact/hooks'
-import rfdc from 'rfdc'
-import type { RootContent } from 'mdast'
-import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
-import { runDirectiveBlock } from '@campfire/utils/directiveUtils'
+import { useDirectiveEvents } from '@campfire/hooks/useDirectiveEvents'
 import { mergeClasses } from '@campfire/utils/core'
 import { useGameStore } from '@campfire/state/useGameStore'
-
-const clone = rfdc()
 
 const inputStyles =
   'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive'
@@ -60,7 +55,7 @@ export const Input = ({
   const value = useGameStore(state => state.gameData[stateKey]) as
     | string
     | undefined
-  const handlers = useDirectiveHandlers()
+  const directiveEvents = useDirectiveEvents(onHover, onFocus, onBlur)
   const setGameData = useGameStore(state => state.setGameData)
   useEffect(() => {
     if (value === undefined) {
@@ -73,30 +68,7 @@ export const Input = ({
       className={mergeClasses('campfire-input', inputStyles, className)}
       value={value ?? ''}
       {...rest}
-      onMouseEnter={e => {
-        if (onHover) {
-          runDirectiveBlock(
-            clone(JSON.parse(onHover)) as RootContent[],
-            handlers
-          )
-        }
-      }}
-      onFocus={e => {
-        if (onFocus) {
-          runDirectiveBlock(
-            clone(JSON.parse(onFocus)) as RootContent[],
-            handlers
-          )
-        }
-      }}
-      onBlur={e => {
-        if (onBlur) {
-          runDirectiveBlock(
-            clone(JSON.parse(onBlur)) as RootContent[],
-            handlers
-          )
-        }
-      }}
+      {...directiveEvents}
       onInput={e => {
         onInput?.(e)
         if (e.defaultPrevented) return

--- a/apps/campfire/src/components/Passage/Radio.tsx
+++ b/apps/campfire/src/components/Passage/Radio.tsx
@@ -1,14 +1,9 @@
 import type { JSX } from 'preact'
 import { useEffect } from 'preact/hooks'
-import rfdc from 'rfdc'
-import type { RootContent } from 'mdast'
-import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
-import { runDirectiveBlock } from '@campfire/utils/directiveUtils'
+import { useDirectiveEvents } from '@campfire/hooks/useDirectiveEvents'
 import { mergeClasses } from '@campfire/utils/core'
 import { useGameStore } from '@campfire/state/useGameStore'
 import { radioStyles, radioIndicatorStyles } from '@campfire/utils/remarkStyles'
-
-const clone = rfdc()
 
 interface RadioProps
   extends Omit<
@@ -62,7 +57,7 @@ export const Radio = ({
   const value = useGameStore(state => state.gameData[stateKey]) as
     | string
     | undefined
-  const handlers = useDirectiveHandlers()
+  const directiveEvents = useDirectiveEvents(onHover, onFocus, onBlur)
   const setGameData = useGameStore(state => state.setGameData)
   useEffect(() => {
     if (value === undefined && initialValue !== undefined) {
@@ -79,30 +74,7 @@ export const Radio = ({
       aria-checked={checked}
       data-state={checked ? 'checked' : 'unchecked'}
       {...rest}
-      onMouseEnter={e => {
-        if (onHover) {
-          runDirectiveBlock(
-            clone(JSON.parse(onHover)) as RootContent[],
-            handlers
-          )
-        }
-      }}
-      onFocus={e => {
-        if (onFocus) {
-          runDirectiveBlock(
-            clone(JSON.parse(onFocus)) as RootContent[],
-            handlers
-          )
-        }
-      }}
-      onBlur={e => {
-        if (onBlur) {
-          runDirectiveBlock(
-            clone(JSON.parse(onBlur)) as RootContent[],
-            handlers
-          )
-        }
-      }}
+      {...directiveEvents}
       onClick={e => {
         onClick?.(e)
         if (e.defaultPrevented) return

--- a/apps/campfire/src/components/Passage/Select.tsx
+++ b/apps/campfire/src/components/Passage/Select.tsx
@@ -1,15 +1,10 @@
 import type { JSX, VNode } from 'preact'
 import { cloneElement, toChildArray } from 'preact'
 import { useEffect, useRef, useState } from 'preact/hooks'
-import rfdc from 'rfdc'
-import type { RootContent } from 'mdast'
-import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
-import { runDirectiveBlock } from '@campfire/utils/directiveUtils'
+import { useDirectiveEvents } from '@campfire/hooks/useDirectiveEvents'
 import { mergeClasses } from '@campfire/utils/core'
 import { useGameStore } from '@campfire/state/useGameStore'
 import type { OptionProps } from './Option'
-
-const clone = rfdc()
 const selectStyles =
   'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-2 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive'
 
@@ -66,7 +61,7 @@ export const Select = ({
     | string
     | undefined
   const setGameData = useGameStore(state => state.setGameData)
-  const handlers = useDirectiveHandlers()
+  const directiveEvents = useDirectiveEvents(onHover, onFocus, onBlur)
   const [open, setOpen] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
   useEffect(() => {
@@ -115,30 +110,7 @@ export const Select = ({
         style={style}
         value={value ?? ''}
         {...rest}
-        onMouseEnter={e => {
-          if (onHover) {
-            runDirectiveBlock(
-              clone(JSON.parse(onHover)) as RootContent[],
-              handlers
-            )
-          }
-        }}
-        onFocus={e => {
-          if (onFocus) {
-            runDirectiveBlock(
-              clone(JSON.parse(onFocus)) as RootContent[],
-              handlers
-            )
-          }
-        }}
-        onBlur={e => {
-          if (onBlur) {
-            runDirectiveBlock(
-              clone(JSON.parse(onBlur)) as RootContent[],
-              handlers
-            )
-          }
-        }}
+        {...directiveEvents}
         onClick={() => setOpen(prev => !prev)}
       >
         <span className='flex-1 truncate text-left pr-2'>

--- a/apps/campfire/src/components/Passage/Textarea.tsx
+++ b/apps/campfire/src/components/Passage/Textarea.tsx
@@ -1,13 +1,8 @@
 import type { JSX } from 'preact'
 import { useEffect } from 'preact/hooks'
-import rfdc from 'rfdc'
-import type { RootContent } from 'mdast'
-import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
-import { runDirectiveBlock } from '@campfire/utils/directiveUtils'
+import { useDirectiveEvents } from '@campfire/hooks/useDirectiveEvents'
 import { mergeClasses } from '@campfire/utils/core'
 import { useGameStore } from '@campfire/state/useGameStore'
-
-const clone = rfdc()
 
 const textareaStyles =
   'border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm'
@@ -60,7 +55,7 @@ export const Textarea = ({
   const value = useGameStore(state => state.gameData[stateKey]) as
     | string
     | undefined
-  const handlers = useDirectiveHandlers()
+  const directiveEvents = useDirectiveEvents(onHover, onFocus, onBlur)
   const setGameData = useGameStore(state => state.setGameData)
   useEffect(() => {
     if (value === undefined) {
@@ -73,30 +68,7 @@ export const Textarea = ({
       className={mergeClasses('campfire-textarea', textareaStyles, className)}
       value={value ?? ''}
       {...rest}
-      onMouseEnter={e => {
-        if (onHover) {
-          runDirectiveBlock(
-            clone(JSON.parse(onHover)) as RootContent[],
-            handlers
-          )
-        }
-      }}
-      onFocus={e => {
-        if (onFocus) {
-          runDirectiveBlock(
-            clone(JSON.parse(onFocus)) as RootContent[],
-            handlers
-          )
-        }
-      }}
-      onBlur={e => {
-        if (onBlur) {
-          runDirectiveBlock(
-            clone(JSON.parse(onBlur)) as RootContent[],
-            handlers
-          )
-        }
-      }}
+      {...directiveEvents}
       onInput={e => {
         onInput?.(e)
         if (e.defaultPrevented) return

--- a/apps/campfire/src/components/Passage/TriggerButton.tsx
+++ b/apps/campfire/src/components/Passage/TriggerButton.tsx
@@ -4,6 +4,7 @@ import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
 import { runDirectiveBlock } from '@campfire/utils/directiveUtils'
 import { mergeClasses } from '@campfire/utils/core'
 import type { JSX } from 'preact'
+import { useDirectiveEvents } from '@campfire/hooks/useDirectiveEvents'
 
 const clone = rfdc()
 
@@ -49,6 +50,7 @@ export const TriggerButton = ({
   ...rest
 }: TriggerButtonProps) => {
   const handlers = useDirectiveHandlers()
+  const directiveEvents = useDirectiveEvents(onHover, onFocus, onBlur)
   return (
     <button
       type='button'
@@ -61,30 +63,7 @@ export const TriggerButton = ({
       disabled={disabled}
       style={style}
       {...rest}
-      onMouseEnter={e => {
-        if (onHover) {
-          runDirectiveBlock(
-            clone(JSON.parse(onHover)) as RootContent[],
-            handlers
-          )
-        }
-      }}
-      onFocus={e => {
-        if (onFocus) {
-          runDirectiveBlock(
-            clone(JSON.parse(onFocus)) as RootContent[],
-            handlers
-          )
-        }
-      }}
-      onBlur={e => {
-        if (onBlur) {
-          runDirectiveBlock(
-            clone(JSON.parse(onBlur)) as RootContent[],
-            handlers
-          )
-        }
-      }}
+      {...directiveEvents}
       onClick={e => {
         e.stopPropagation()
         onClick?.(e)

--- a/apps/campfire/src/hooks/useDirectiveEvents.ts
+++ b/apps/campfire/src/hooks/useDirectiveEvents.ts
@@ -1,0 +1,41 @@
+import type { JSX } from 'preact'
+import type { RootContent } from 'mdast'
+import rfdc from 'rfdc'
+import { runDirectiveBlock } from '@campfire/utils/directiveUtils'
+import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
+
+const clone = rfdc()
+
+/**
+ * Generates directive event handlers from serialized directive strings.
+ *
+ * @param onHover - Serialized directives to run when hovered.
+ * @param onFocus - Serialized directives to run on focus.
+ * @param onBlur - Serialized directives to run on blur.
+ * @returns Object containing `onMouseEnter`, `onFocus`, and `onBlur` handlers.
+ */
+export const useDirectiveEvents = (
+  onHover?: string,
+  onFocus?: string,
+  onBlur?: string
+): Pick<
+  JSX.HTMLAttributes<HTMLElement>,
+  'onMouseEnter' | 'onFocus' | 'onBlur'
+> => {
+  const handlers = useDirectiveHandlers()
+
+  const createHandler = (content?: string) =>
+    content
+      ? () =>
+          runDirectiveBlock(
+            clone(JSON.parse(content)) as RootContent[],
+            handlers
+          )
+      : undefined
+
+  return {
+    onMouseEnter: createHandler(onHover),
+    onFocus: createHandler(onFocus),
+    onBlur: createHandler(onBlur)
+  }
+}


### PR DESCRIPTION
## Summary
- add `useDirectiveEvents` hook to parse serialized event directives and run them
- refactor Checkbox, Radio, Input, Textarea, Select, and TriggerButton to use `useDirectiveEvents`

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68b374a8988c8322a857eeec8e921221