### PR TITLE
refactor: centralize asset management for media

### DIFF
--- a/apps/campfire/src/audio/AudioManager.ts
+++ b/apps/campfire/src/audio/AudioManager.ts
@@ -1,23 +1,14 @@
-import { getBaseUrl } from '@campfire/utils/core'
+import { AssetManager } from '@campfire/utils/AssetManager'
 
-export class AudioManager {
-  private static instance: AudioManager
+/**
+ * Manages loading and playback of audio assets.
+ */
+export class AudioManager extends AssetManager<HTMLAudioElement> {
   private bgm?: HTMLAudioElement
   private bgmName?: string
-  private sfxMap: Map<string, HTMLAudioElement> = new Map()
   private globalSfxVolume = 1
   private globalBgmVolume = 1
   private bgmBaseVolume = 1
-
-  /**
-   * Retrieves the singleton instance of the AudioManager.
-   *
-   * @returns The AudioManager instance.
-   */
-  static getInstance(): AudioManager {
-    if (!this.instance) this.instance = new AudioManager()
-    return this.instance
-  }
 
   /**
    * Retrieves a cached audio element or creates one from the given source.
@@ -30,21 +21,11 @@ export class AudioManager {
     id: string,
     source?: string
   ): HTMLAudioElement | undefined {
-    if (this.sfxMap.has(id)) return this.sfxMap.get(id)!
-    const src = source ?? id
-    if (!src) return undefined
-    let href: string
-    try {
-      // Resolve and validate the URL to avoid creating elements with invalid sources
-      href = new URL(src, getBaseUrl()).href
-    } catch {
-      console.error(`Invalid audio source: ${src}`)
-      return undefined
-    }
-    const audio = new Audio(href)
-    audio.preload = 'auto'
-    this.sfxMap.set(id, audio)
-    return audio
+    return this.getOrCreate(id, source, href => {
+      const audio = new Audio(href)
+      audio.preload = 'auto'
+      return audio
+    })
   }
 
   /**

--- a/apps/campfire/src/image/ImageManager.ts
+++ b/apps/campfire/src/image/ImageManager.ts
@@ -1,19 +1,9 @@
-import { getBaseUrl } from '@campfire/utils/core'
+import { AssetManager } from '@campfire/utils/AssetManager'
 
-export class ImageManager {
-  private static instance: ImageManager
-  private cache: Map<string, HTMLImageElement> = new Map()
-
-  /**
-   * Retrieves the singleton instance of the ImageManager.
-   *
-   * @returns The ImageManager instance.
-   */
-  static getInstance(): ImageManager {
-    if (!this.instance) this.instance = new ImageManager()
-    return this.instance
-  }
-
+/**
+ * Manages image asset loading and caching.
+ */
+export class ImageManager extends AssetManager<HTMLImageElement> {
   /**
    * Preloads an image and caches it by id.
    *
@@ -39,7 +29,7 @@ export class ImageManager {
         reject(err)
       }
       try {
-        img.src = new URL(src, getBaseUrl()).href
+        img.src = this.resolve(src)
       } catch (err) {
         cleanup()
         console.error(`Invalid image source: ${src}`, err)

--- a/apps/campfire/src/utils/AssetManager.ts
+++ b/apps/campfire/src/utils/AssetManager.ts
@@ -1,0 +1,68 @@
+import { getBaseUrl } from '@campfire/utils/core'
+
+/**
+ * Generic asset manager providing singleton access, caching, and URL resolution.
+ *
+ * @typeParam T - Type of asset handled by the manager.
+ */
+export abstract class AssetManager<T> {
+  private static instances = new Map<Function, AssetManager<any>>()
+
+  /** Cache of loaded assets keyed by identifier. */
+  protected cache: Map<string, T> = new Map()
+
+  /**
+   * Retrieves the singleton instance for the derived manager.
+   *
+   * @returns The singleton instance of the manager.
+   */
+  static getInstance<TManager extends AssetManager<any>>(
+    this: new () => TManager
+  ): TManager {
+    let instance = AssetManager.instances.get(this) as TManager | undefined
+    if (!instance) {
+      instance = new this()
+      AssetManager.instances.set(this, instance)
+    }
+    return instance
+  }
+
+  /**
+   * Resolves an asset source against the application base URL.
+   *
+   * @param src - Source string to resolve.
+   * @returns Resolved absolute URL string.
+   */
+  protected resolve = (src: string): string => new URL(src, getBaseUrl()).href
+
+  /**
+   * Retrieves a cached asset or creates one using the provided factory.
+   *
+   * @param id - Cache key for the asset.
+   * @param src - Optional source string for the asset.
+   * @param factory - Factory creating the asset from a resolved URL.
+   * @returns The cached or newly created asset, or undefined if resolution fails.
+   */
+  protected getOrCreate = (
+    id: string,
+    src: string | undefined,
+    factory: (href: string) => T
+  ): T | undefined => {
+    let asset = this.cache.get(id)
+    if (asset) return asset
+    const ref = src ?? id
+    if (!ref) return undefined
+    let href: string
+    try {
+      href = this.resolve(ref)
+    } catch {
+      console.error(`Invalid asset source: ${ref}`)
+      return undefined
+    }
+    asset = factory(href)
+    this.cache.set(id, asset)
+    return asset
+  }
+}
+
+export default AssetManager


### PR DESCRIPTION
## Summary
- introduce generic `AssetManager` for singleton caching and URL resolution
- refactor `AudioManager` to reuse `AssetManager`
- refactor `ImageManager` to reuse `AssetManager`

## Testing
- `bun x prettier --write apps/campfire/src/utils/AssetManager.ts apps/campfire/src/audio/AudioManager.ts apps/campfire/src/image/ImageManager.ts`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68b37e166e748322af7a172a071fe8f5