### PR TITLE
fix: adjust scale easing for tall aspect ratios

### DIFF
--- a/apps/campfire/src/hooks/__tests__/useScale.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/useScale.test.tsx
@@ -34,6 +34,31 @@ describe('useScale', () => {
     expect(currentScale).toBe(2)
   })
 
+  it('skips easing when container is taller than wide', () => {
+    const trigger = setupResizeObserver()
+    let currentScale = 0
+
+    /**
+     * Test component that exposes the scale computed by the hook.
+     */
+    const TestComponent = () => {
+      const { ref, scale } = useScale({ width: 100, height: 100 })
+      currentScale = scale
+      return <div ref={ref} />
+    }
+
+    const { container } = render(<TestComponent />)
+    const el = container.firstElementChild as HTMLDivElement
+
+    Object.defineProperty(el, 'clientWidth', { value: 80, configurable: true })
+    Object.defineProperty(el, 'clientHeight', {
+      value: 200,
+      configurable: true
+    })
+    act(() => trigger())
+    expect(currentScale).toBe(0.8)
+  })
+
   it('prevents scale from dropping below the minimum', () => {
     const trigger = setupResizeObserver()
     let currentScale = 1

--- a/apps/campfire/src/hooks/useScale.ts
+++ b/apps/campfire/src/hooks/useScale.ts
@@ -38,7 +38,13 @@ export const useScale = (size: DeckSize) => {
       const sx = cw / size.width
       const sy = ch / size.height
       const sRaw = Math.min(sx, sy)
-      const s = Math.max(MIN_SCALE, sRaw < 1 ? Math.sqrt(sRaw) : sRaw)
+      /**
+       * Skip easing when the container is taller than it is wide to prevent
+       * excessive scaling and horizontal clipping. Otherwise, ease the scale
+       * using a square root to avoid overly shrinking content.
+       */
+      const eased = sRaw < 1 && sy <= sx ? Math.sqrt(sRaw) : sRaw
+      const s = Math.max(MIN_SCALE, eased)
       if (s !== scaleRef.current) {
         scaleRef.current = s
         setScale(s)


### PR DESCRIPTION
## Summary
- skip scale easing when container is taller than wide to avoid oversizing
- add regression test for tall container scaling

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68b3cda27b7483229db8c325f3acb68e