### PR TITLE
docs: use headings instead of lists for sections

### DIFF
--- a/docs/directives/asset-management.md
+++ b/docs/directives/asset-management.md
@@ -4,98 +4,110 @@ Manage image and audio assets. Position images within slides and preload them or
 
 ## Images
 
-- `image`: Position an image within a slide.
+### `image`
 
-  ```md
-  :::deck
-  :::slide
-  :image{src='https://example.com/cat.png' x=10 y=20}
-  :::
-  :::
-  ```
+Position an image within a slide.
 
-  Supports a `from` attribute to apply presets.
+```md
+:::deck
+:::slide
+:image{src='https://example.com/cat.png' x=10 y=20}
+:::
+:::
+```
 
-  | Input          | Description                              |
-  | -------------- | ---------------------------------------- |
-  | x              | Horizontal position in pixels            |
-  | y              | Vertical position in pixels              |
-  | w              | Width in pixels                          |
-  | h              | Height in pixels                         |
-  | z              | z-index value                            |
-  | rotate         | Rotation in degrees                      |
-  | scale          | Scale multiplier                         |
-  | anchor         | Transform origin (`top-left` by default) |
-  | src            | Image source URL                         |
-  | alt            | Alternate text description               |
-  | style          | Inline styles applied to the `<img>`     |
-  | className      | Classes applied to the `<img>`           |
-  | layerClassName | Classes applied to the Layer wrapper     |
-  | from           | Name of an image preset to apply         |
+Supports a `from` attribute to apply presets.
 
-- `preloadImage`: Preload an image for later use.
+| Input          | Description                              |
+| -------------- | ---------------------------------------- |
+| x              | Horizontal position in pixels            |
+| y              | Vertical position in pixels              |
+| w              | Width in pixels                          |
+| h              | Height in pixels                         |
+| z              | z-index value                            |
+| rotate         | Rotation in degrees                      |
+| scale          | Scale multiplier                         |
+| anchor         | Transform origin (`top-left` by default) |
+| src            | Image source URL                         |
+| alt            | Alternate text description               |
+| style          | Inline styles applied to the `<img>`     |
+| className      | Classes applied to the `<img>`           |
+| layerClassName | Classes applied to the Layer wrapper     |
+| from           | Name of an image preset to apply         |
 
-  ```md
-  :preloadImage[titleScreen]{src='images/title.png'}
-  ```
+### `preloadImage`
 
-  | Attribute | Description                     |
-  | --------- | ------------------------------- |
-  | `src`     | URL of the image file           |
-  | `id`      | Unique identifier for the image |
+Preload an image for later use.
+
+```md
+:preloadImage[titleScreen]{src='images/title.png'}
+```
+
+| Attribute | Description                     |
+| --------- | ------------------------------- |
+| `src`     | URL of the image file           |
+| `id`      | Unique identifier for the image |
 
 ## Audio
 
-- `preloadAudio`: Preload an audio file for later use.
+### `preloadAudio`
 
-  ```md
-  :preloadAudio[click]{src='audio/click.wav'}
-  ```
+Preload an audio file for later use.
 
-  | Attribute | Description                    |
-  | --------- | ------------------------------ |
-  | `src`     | URL of the audio file          |
-  | `id`      | Unique identifier for the clip |
+```md
+:preloadAudio[click]{src='audio/click.wav'}
+```
 
-- `sound`: Play a one-off sound effect.
+| Attribute | Description                    |
+| --------- | ------------------------------ |
+| `src`     | URL of the audio file          |
+| `id`      | Unique identifier for the clip |
 
-  ```md
-  :sound[click]{volume=0.5 delay=200}
-  ```
+### `sound`
 
-  | Attribute | Description                         |
-  | --------- | ----------------------------------- |
-  | `id`      | Name of a preloaded track           |
-  | `src`     | URL of the audio file               |
-  | `volume`  | Volume level from 0–1               |
-  | `delay`   | Milliseconds to wait before playing |
-  | `rate`    | Playback speed                      |
+Play a one-off sound effect.
 
-- `bgm`: Control background music. Use `stop=true` to stop.
+```md
+:sound[click]{volume=0.5 delay=200}
+```
 
-  ```md
-  :bgm[forest]{volume=0.4 loop=true fade=1000}
-  :bgm{stop=true fade=500}
-  ```
+| Attribute | Description                         |
+| --------- | ----------------------------------- |
+| `id`      | Name of a preloaded track           |
+| `src`     | URL of the audio file               |
+| `volume`  | Volume level from 0–1               |
+| `delay`   | Milliseconds to wait before playing |
+| `rate`    | Playback speed                      |
 
-  | Attribute | Description                                    |
-  | --------- | ---------------------------------------------- |
-  | `id`      | Name of a preloaded track                      |
-  | `src`     | URL of the audio file                          |
-  | `volume`  | Volume level from 0–1                          |
-  | `loop`    | Whether the track should loop (default `true`) |
-  | `fade`    | Milliseconds to cross-fade between tracks      |
-  | `stop`    | Stop the current background music when `true`  |
+### `bgm`
 
-- `volume`: Set global volume levels.
+Control background music. Use `stop=true` to stop.
 
-  ```md
-  :volume{bgm=0.2 sfx=0.8}
-  ```
+```md
+:bgm[forest]{volume=0.4 loop=true fade=1000}
+:bgm{stop=true fade=500}
+```
 
-  | Attribute | Description                      |
-  | --------- | -------------------------------- |
-  | `bgm`     | Background music volume from 0–1 |
-  | `sfx`     | Sound effects volume from 0–1    |
+| Attribute | Description                                    |
+| --------- | ---------------------------------------------- |
+| `id`      | Name of a preloaded track                      |
+| `src`     | URL of the audio file                          |
+| `volume`  | Volume level from 0–1                          |
+| `loop`    | Whether the track should loop (default `true`) |
+| `fade`    | Milliseconds to cross-fade between tracks      |
+| `stop`    | Stop the current background music when `true`  |
+
+### `volume`
+
+Set global volume levels.
+
+```md
+:volume{bgm=0.2 sfx=0.8}
+```
+
+| Attribute | Description                      |
+| --------- | -------------------------------- |
+| `bgm`     | Background music volume from 0–1 |
+| `sfx`     | Sound effects volume from 0–1    |
 
 Wrap string values in matching quotes or backticks. Unquoted values are treated as state keys when applicable.

--- a/docs/directives/conditional-logic-and-iteration.md
+++ b/docs/directives/conditional-logic-and-iteration.md
@@ -6,121 +6,125 @@ Control whether and how many times content renders.
 
 Run content only when conditions hold.
 
-- `if`: Render a block when a JavaScript expression against game data is truthy. Add an `else` container for fallback content.
+### `if`
 
-  Basic truthy check:
+Render a block when a JavaScript expression against game data is truthy. Add an `else` container for fallback content.
 
-  ```md
-  :::if[some_key]
+Basic truthy check:
 
-  CONTENT WHEN `some_key` IS TRUTHY
+```md
+:::if[some_key]
 
-  :::
-  ```
+CONTENT WHEN `some_key` IS TRUTHY
 
-  Negation check:
+:::
+```
 
-  ```md
-  :::if[!some_key]
+Negation check:
 
-  CONTENT WHEN `some_key` IS FALSY
+```md
+:::if[!some_key]
 
-  :::
-  ```
+CONTENT WHEN `some_key` IS FALSY
 
-  Double negation for boolean coercion:
+:::
+```
 
-  ```md
-  :::if[!!some_key]
+Double negation for boolean coercion:
 
-  CONTENT WHEN `some_key` COERCES TO TRUE
+```md
+:::if[!!some_key]
 
-  :::
-  ```
+CONTENT WHEN `some_key` COERCES TO TRUE
 
-  Comparison operators:
+:::
+```
 
-  ```md
-  :::if[key_a < key_b]
+Comparison operators:
 
-  CONTENT WHEN `key_a` IS LESS THAN `key_b`
+```md
+:::if[key_a < key_b]
 
-  :::
-  ```
+CONTENT WHEN `key_a` IS LESS THAN `key_b`
 
-  Type checking:
+:::
+```
 
-  ```md
-  :::if[typeof key_a !== "string"]
+Type checking:
 
-  CONTENT WHEN `key_a` IS NOT A STRING
+```md
+:::if[typeof key_a !== "string"]
 
-  :::
-  ```
+CONTENT WHEN `key_a` IS NOT A STRING
 
-  Using with else block:
+:::
+```
 
-  ```md
-  :::if[some_key]
+Using with else block:
 
-  TRUTHY CONTENT
+```md
+:::if[some_key]
 
-  :::else
+TRUTHY CONTENT
 
-  FALLBACK CONTENT
+:::else
 
-  :::
-  ```
+FALLBACK CONTENT
 
-  Combining with other directives and links:
+:::
+```
 
-  ```md
-  :::if[has_key]
+Combining with other directives and links:
 
-  You unlock the door.
+```md
+:::if[has_key]
 
-  :set[door_opened=true]
+You unlock the door.
 
-  [[Enter->Hallway]]
+:set[door_opened=true]
 
-  :::
-  ```
+[[Enter->Hallway]]
 
-  Replace the keys with those from your game data.
+:::
+```
 
-  | Input      | Description                                  |
-  | ---------- | -------------------------------------------- |
-  | expression | JavaScript condition evaluated against state |
+Replace the keys with those from your game data.
+
+| Input      | Description                                  |
+| ---------- | -------------------------------------------- |
+| expression | JavaScript condition evaluated against state |
 
 ## Iteration
 
 Repeat blocks for each item in a collection.
 
-- `for`: Render content for every element in an array or range.
+### `for`
 
-  ```md
-  :::for[item in [1,2,3]]
+Render content for every element in an array or range.
 
-  Item: :show[item]
+```md
+:::for[item in [1,2,3]]
 
-  :::
-  ```
+Item: :show[item]
 
-  With ranges:
+:::
+```
 
-  ```md
-  :createRange[r=0]{min=1 max=3}
+With ranges:
 
-  :::for[x in r]
+```md
+:createRange[r=0]{min=1 max=3}
 
-  Number: :show[x]
+:::for[x in r]
 
-  :::
-  ```
+Number: :show[x]
 
-  Renders nothing for empty iterables.
+:::
+```
 
-  | Input      | Description                            |
-  | ---------- | -------------------------------------- |
-  | variable   | Name assigned to each item             |
-  | expression | Array or range evaluated against state |
+Renders nothing for empty iterables.
+
+| Input      | Description                            |
+| ---------- | -------------------------------------- |
+| variable   | Name assigned to each item             |
+| expression | Array or range evaluated against state |

--- a/docs/directives/data-retrieval.md
+++ b/docs/directives/data-retrieval.md
@@ -2,33 +2,32 @@
 
 Read or compute data without mutating state.
 
-- `show`: Display a key's value, the result of an expression, or an
-  interpolated string.
+### `show`
 
-  ```md
-  :show[hp]
-  :show[`Hello ${name}`]
-  :show[some_key > 1 ? "X" : " "]
-  ```
+Display a key's value, the result of an expression, or an interpolated string.
 
-  Replace the content with a key, template string, or JavaScript expression to
-  display.
+```md
+:show[hp]
+:show[`Hello ${name}`]
+:show[some_key > 1 ? "X" : " "]
+```
 
-  | Input     | Description                            |
-  | --------- | -------------------------------------- |
-  | key       | State key to display                   |
-  | className | Additional classes applied to the span |
-  | style     | Inline styles applied to the span      |
+Replace the content with a key, template string, or JavaScript expression to display.
 
-  The directive also supports `className` and `style` attributes for styling
-  the rendered span.
+| Input     | Description                            |
+| --------- | -------------------------------------- |
+| key       | State key to display                   |
+| className | Additional classes applied to the span |
+| style     | Inline styles applied to the span      |
 
-  To read range data, access the range's properties with dot notation:
+The directive also supports `className` and `style` attributes for styling the rendered span.
 
-  ```md
-  :show[score.value]
-  :show[score.min]
-  :show[score.max]
-  ```
+To read range data, access the range's properties with dot notation:
 
-  Range objects expose `value`, `min`, and `max` fields.
+```md
+:show[score.value]
+:show[score.min]
+:show[score.max]
+```
+
+Range objects expose `value`, `min`, and `max` fields.

--- a/docs/directives/inputs-and-events.md
+++ b/docs/directives/inputs-and-events.md
@@ -6,7 +6,9 @@ Collect data from players or run directives on demand with interactive elements,
 
 Collect data or trigger actions directly in the passage.
 
-- `input`: Render a text input bound to a game state key. Use as a leaf or container. The container form can include event directives. If the key already exists in game state, its value is used; otherwise, the optional `value` attribute sets the starting value.
+### `input`
+
+Render a text input bound to a game state key. Use as a leaf or container. The container form can include event directives. If the key already exists in game state, its value is used; otherwise, the optional `value` attribute sets the starting value.
 
 Leaf form:
 
@@ -33,7 +35,9 @@ Container form:
 | className   | Optional space-separated classes           |
 | style       | Optional inline style declarations         |
 
-- `textarea`: Render a multi-line text area bound to a game state key. Use as a leaf or container. The container form can include event directives. If the key already exists in game state, its value is used; otherwise, the optional `value` attribute sets the starting value.
+### `textarea`
+
+Render a multi-line text area bound to a game state key. Use as a leaf or container. The container form can include event directives. If the key already exists in game state, its value is used; otherwise, the optional `value` attribute sets the starting value.
 
 Leaf form:
 
@@ -60,7 +64,9 @@ Container form:
 | className   | Optional space-separated classes              |
 | style       | Optional inline style declarations            |
 
-- `select`: Render a dropdown bound to a game state key. Must be used as a container with nested `option` directives. The container form can include event directives. If the key already exists in game state, its value is used; otherwise, the optional `value` attribute sets the initial selection. The optional `label` attribute provides placeholder text when no option is chosen.
+### `select`
+
+Render a dropdown bound to a game state key. Must be used as a container with nested `option` directives. The container form can include event directives. If the key already exists in game state, its value is used; otherwise, the optional `value` attribute sets the initial selection. The optional `label` attribute provides placeholder text when no option is chosen.
 
 ```md
 :::select[color]{label="Choose a color"}
@@ -88,25 +94,27 @@ The select button uses the same default styling as trigger and link buttons and 
 | className | Optional space-separated classes   |
 | style     | Optional inline style declarations |
 
-- `trigger`: Render a button that runs directives when clicked. Supports event directives inside the block.
+### `trigger`
 
-  ```md
-  :::trigger{label="Do it" className="primary"}
-  :::onHover
-  :set[hovered=true]
-  :::
-  :set[key=value]
-  :::
-  ```
+Render a button that runs directives when clicked. Supports event directives inside the block.
 
-  The `label` attribute must be a quoted string using matching single-, double-, or backtick quotes. Replace the label, class name, disabled state, and directives as needed.
+```md
+:::trigger{label="Do it" className="primary"}
+:::onHover
+:set[hovered=true]
+:::
+:set[key=value]
+:::
+```
 
-  | Input     | Description                            |
-  | --------- | -------------------------------------- |
-  | label     | Text displayed on the button           |
-  | className | Optional space-separated classes       |
-  | disabled  | Optional boolean to disable the button |
-  | style     | Optional inline style declarations     |
+The `label` attribute must be a quoted string using matching single-, double-, or backtick quotes. Replace the label, class name, disabled state, and directives as needed.
+
+| Input     | Description                            |
+| --------- | -------------------------------------- |
+| label     | Text displayed on the button           |
+| className | Optional space-separated classes       |
+| disabled  | Optional boolean to disable the button |
+| style     | Optional inline style declarations     |
 
 ### Event directives
 
@@ -122,32 +130,36 @@ Use event directives inside `input`, `select`, or `trigger` blocks to run direct
 
 Run directives on specific passage events or group actions.
 
-- `batch`: Apply multiple directives as a single update.
+### `batch`
 
-  ```md
-  :::batch
-  :set[hp=value]
-  :push{key=items value=sword}
-  :unset{key=old}
-  :::
-  ```
+Apply multiple directives as a single update.
 
-  Supports only the following directives: `if`, `set`, `setOnce`, `array`, `arrayOnce`, `unset`, `random`, and `randomOnce`. Nested `batch` directives are not allowed.
+```md
+:::batch
+:set[hp=value]
+:push{key=items value=sword}
+:unset{key=old}
+:::
+```
 
-  | Input    | Description                  |
-  | -------- | ---------------------------- |
-  | _(none)_ | This directive has no inputs |
+Supports only the following directives: `if`, `set`, `setOnce`, `array`, `arrayOnce`, `unset`, `random`, and `randomOnce`. Nested `batch` directives are not allowed.
 
-- `onExit`: Run data directives once when leaving the passage.
+| Input    | Description                  |
+| -------- | ---------------------------- |
+| _(none)_ | This directive has no inputs |
 
-  ```md
-  :::onExit
-  :set[key=value]
-  :::
-  ```
+### `onExit`
 
-  Only one `onExit` block is allowed per passage. Its contents are hidden, and it supports only the following directives: `if`, `set`, `setOnce`, `array`, `arrayOnce`, `unset`, `random`, `randomOnce`, and `batch`.
+Run data directives once when leaving the passage.
 
-  | Input    | Description                  |
-  | -------- | ---------------------------- |
-  | _(none)_ | This directive has no inputs |
+```md
+:::onExit
+:set[key=value]
+:::
+```
+
+Only one `onExit` block is allowed per passage. Its contents are hidden, and it supports only the following directives: `if`, `set`, `setOnce`, `array`, `arrayOnce`, `unset`, `random`, `randomOnce`, and `batch`.
+
+| Input    | Description                  |
+| -------- | ---------------------------- |
+| _(none)_ | This directive has no inputs |

--- a/docs/directives/localization.md
+++ b/docs/directives/localization.md
@@ -2,68 +2,72 @@
 
 Change language and handle translations.
 
-- `lang`: Switch the active locale.
+### `lang`
 
-  ```md
-  :lang[lang]
-  ```
+Switch the active locale.
 
-  Replace `lang` with a locale like `fr`.
+```md
+:lang[lang]
+```
 
-  | Input  | Description             |
-  | ------ | ----------------------- |
-  | locale | Locale code to activate |
+Replace `lang` with a locale like `fr`.
 
-- `t`: Output a translated string or expression. Use the optional `count`
-  attribute for pluralization and `fallback` for default text when the
-  translation is missing.
+| Input  | Description             |
+| ------ | ----------------------- |
+| locale | Locale code to activate |
 
-  ```md
-  :t[ui:apple]{count=2}
-  :t[apple]{ns="ui"}
-  :t[favoriteFruit]
-  :t[missing]{fallback=`Hello ${player}`}
-  ```
+### `t`
 
-  Replace `apple` and `ui` with your key and namespace. You can also provide the
-  namespace via the `ns` attribute or supply a JavaScript expression that
-  resolves to the key. The `fallback` attribute accepts either a
-  quoted string or a template literal. For interpolation, use backticks without
-  wrapping the value in quotes.
+Output a translated string or expression. Use the optional `count` attribute for pluralization and `fallback` for default text when the translation is missing.
 
-  The directive also accepts `className` and `style` attributes for styling the
-  output.
+```md
+:t[ui:apple]{count=2}
+:t[apple]{ns="ui"}
+:t[favoriteFruit]
+:t[missing]{fallback=`Hello ${player}`}
+```
 
-  | Input     | Description                            |
-  | --------- | -------------------------------------- |
-  | ns:key    | Namespace and key of the translation   |
-  | ns        | Optional namespace for the translation |
-  | count     | Optional count for pluralization       |
-  | fallback  | Fallback text when key is missing      |
-  | className | Additional classes applied to the span |
-  | style     | Inline styles applied to the span      |
+Replace `apple` and `ui` with your key and namespace. You can also provide the
+namespace via the `ns` attribute or supply a JavaScript expression that
+resolves to the key. The `fallback` attribute accepts either a
+quoted string or a template literal. For interpolation, use backticks without
+wrapping the value in quotes.
 
-- `translations`: Add a translation.
+The directive also accepts `className` and `style` attributes for styling the
+output.
 
-  ```md
-  :translations[lang]{ui:hello="BONJOUR"}
-  ```
+| Input     | Description                            |
+| --------- | -------------------------------------- |
+| ns:key    | Namespace and key of the translation   |
+| ns        | Optional namespace for the translation |
+| count     | Optional count for pluralization       |
+| fallback  | Fallback text when key is missing      |
+| className | Additional classes applied to the span |
+| style     | Inline styles applied to the span      |
 
-  Replace `lang` with the locale and `ui` with the namespace. Only one
-  `namespace:key="value"` pair is allowed per directive. Repeat the directive
-  for additional translations.
+### `translations`
 
-  ```md
-  :translations[en]{ui:greeting="Hello, {{name}}!"}
-  :t[greeting]{ns="ui" name="Aiden"}
-  ```
+Add a translation.
 
-  Attributes on `:t` become interpolation variables for i18next.
+```md
+:translations[lang]{ui:hello="BONJOUR"}
+```
 
-  | Input  | Description                     |
-  | ------ | ------------------------------- |
-  | locale | Locale code for the translation |
-  | ns:key | Namespace and key to translate  |
-  | value  | Translated string               |
+Replace `lang` with the locale and `ui` with the namespace. Only one
+`namespace:key="value"` pair is allowed per directive. Repeat the directive
+for additional translations.
+
+```md
+:translations[en]{ui:greeting="Hello, {{name}}!"}
+:t[greeting]{ns="ui" name="Aiden"}
+```
+
+Attributes on `:t` become interpolation variables for i18next.
+
+| Input  | Description                     |
+| ------ | ------------------------------- |
+| locale | Locale code for the translation |
+| ns:key | Namespace and key to translate  |
+| value  | Translated string               |
 
 Campfire prints descriptive error messages to the browser console when it encounters invalid markup.

--- a/docs/directives/navigation-composition.md
+++ b/docs/directives/navigation-composition.md
@@ -2,277 +2,300 @@
 
 Control the flow between passages or how they reveal.
 
-- `goto`: Jump to another passage.
+### `goto`
 
-  ```md
-  :goto["PASSAGE-NAME"]
-  ```
+Jump to another passage.
 
-  Use quotes or backticks for passage names. Unquoted numbers navigate by pid.
-  When using the `passage` attribute, unquoted strings are treated as keys in the
-  game state.
+```md
+:goto["PASSAGE-NAME"]
+```
 
-  | Input   | Description                            |
-  | ------- | -------------------------------------- |
-  | passage | Target passage name, pid, or state key |
+Use quotes or backticks for passage names. Unquoted numbers navigate by pid.
+When using the `passage` attribute, unquoted strings are treated as keys in the
+game state.
 
-- `include`: Embed another passage's content.
+| Input   | Description                            |
+| ------- | -------------------------------------- |
+| passage | Target passage name, pid, or state key |
 
-  ```md
-  :include["PASSAGE-NAME"]
-  ```
+### `include`
 
-  Use quotes or backticks for passage names. Unquoted numbers include by pid.
-  When using the `passage` attribute, unquoted strings are treated as keys in the
-  game state. Nested includes are limited to 10 levels to prevent infinite loops.
+Embed another passage's content.
 
-  | Input   | Description                                |
-  | ------- | ------------------------------------------ |
-  | passage | Passage name, pid, or state key to include |
+```md
+:include["PASSAGE-NAME"]
+```
 
-- `title`: Set the document title.
+Use quotes or backticks for passage names. Unquoted numbers include by pid.
+When using the `passage` attribute, unquoted strings are treated as keys in the
+game state. Nested includes are limited to 10 levels to prevent infinite loops.
 
-  ```md
-  :title["GAME-TITLE"]
-  ```
+| Input   | Description                                |
+| ------- | ------------------------------------------ |
+| passage | Passage name, pid, or state key to include |
 
-  Replace `GAME-TITLE` with the text to display, wrapped in matching quotes or backticks.
+### `title`
 
-  By default, the browser tab displays the story name and current passage name
-  separated by a colon. Customize this behavior by adding attributes to the
-  `<tw-storydata>` element:
-  - `title-separator`: String placed between the story and passage names.
-  - `title-show-passage="false"`: Hide the passage name and show only the
-    story name.
+Set the document title.
 
-  | Input | Description                         |
-  | ----- | ----------------------------------- |
-  | text  | Title text displayed in the browser |
+```md
+:title["GAME-TITLE"]
+```
 
-- `deck`: Present content as a series of slides.
+Replace `GAME-TITLE` with the text to display, wrapped in matching quotes or backticks.
 
-  ```md
-  :::deck{size='16x9' transition='slide'}
-  :::slide{transition='fade'}
+By default, the browser tab displays the story name and current passage name
+separated by a colon. Customize this behavior by adding attributes to the
+`<tw-storydata>` element:
 
-  # One
+- `title-separator`: String placed between the story and passage names.
+- `title-show-passage="false"`: Hide the passage name and show only the
+  story name.
 
-  :::
-  :::slide
+| Input | Description                         |
+| ----- | ----------------------------------- |
+| text  | Title text displayed in the browser |
 
-  ## Two
+### `deck`
 
-  :::
-  :::
-  ```
+Present content as a series of slides.
 
-  Each `:::slide` starts a new slide. Plain Markdown inside the deck becomes
-  its own slide if not preceded by a slide directive.
+```md
+:::deck{size='16x9' transition='slide'}
+:::slide{transition='fade'}
 
-  | Input                      | Description                                                                |
-  | -------------------------- | -------------------------------------------------------------------------- |
-  | size                       | Slide size as `WIDTHxHEIGHT` in pixels or aspect ratio like `16x9`         |
-  | theme                      | Optional JSON object or string of CSS properties applied to the deck theme |
-  | from                       | Name of a deck preset to apply before other attributes                     |
-  | autoplay                   | Whether to automatically advance through slides                            |
-  | autoplayDelay              | Milliseconds between automatic slide advances (defaults to 3000)           |
-  | pause                      | Start autoplay paused and display a play button                            |
-  | groupClassName             | Additional classes applied to the slide group wrapper                      |
-  | navClassName               | Additional classes applied to the navigation wrapper                       |
-  | hudClassName               | Additional classes applied to the slide counter HUD wrapper                |
-  | navButtonClassName         | Additional classes applied to each navigation button                       |
-  | rewindButtonClassName      | Additional classes applied to the rewind navigation button                 |
-  | playButtonClassName        | Additional classes applied to the autoplay toggle button                   |
-  | fastForwardButtonClassName | Additional classes applied to the fast-forward navigation button           |
-  | slideHudClassName          | Additional classes applied to the slide count element within the HUD       |
+# One
 
-  The autoplay toggle button also exposes a `data-state` attribute set to
-  `playing` or `paused` for targeting styles based on the current autoplay
-  state.
+:::
+:::slide
 
-- `slide`: Customize an individual slide.
+## Two
 
-  ```md
-  :::deck
-  :::slide{enter="slide" exit="fade"}
-  Content
-  :::
-  :::
-  ```
+:::
+:::
+```
 
-  | Input         | Description                         |
-  | ------------- | ----------------------------------- |
-  | enter         | Enter transition type               |
-  | exit          | Exit transition type                |
-  | enterDir      | Enter transition direction          |
-  | exitDir       | Exit transition direction           |
-  | enterDuration | Enter transition duration in ms     |
-  | exitDuration  | Exit transition duration in ms      |
-  | enterDelay    | Enter transition delay in ms        |
-  | exitDelay     | Exit transition delay in ms         |
-  | enterEasing   | Enter transition easing             |
-  | exitEasing    | Exit transition easing              |
-  | steps         | Number of build steps on this slide |
-  | onEnter       | Directive block to run on enter     |
-  | onExit        | Directive block to run on exit      |
-  | from          | Name of a slide preset to apply     |
+Each `:::slide` starts a new slide. Plain Markdown inside the deck becomes
+its own slide if not preceded by a slide directive.
 
-- `reveal`: Reveal slide content step-by-step.
+| Input                      | Description                                                                |
+| -------------------------- | -------------------------------------------------------------------------- |
+| size                       | Slide size as `WIDTHxHEIGHT` in pixels or aspect ratio like `16x9`         |
+| theme                      | Optional JSON object or string of CSS properties applied to the deck theme |
+| from                       | Name of a deck preset to apply before other attributes                     |
+| autoplay                   | Whether to automatically advance through slides                            |
+| autoplayDelay              | Milliseconds between automatic slide advances (defaults to 3000)           |
+| pause                      | Start autoplay paused and display a play button                            |
+| groupClassName             | Additional classes applied to the slide group wrapper                      |
+| navClassName               | Additional classes applied to the navigation wrapper                       |
+| hudClassName               | Additional classes applied to the slide counter HUD wrapper                |
+| navButtonClassName         | Additional classes applied to each navigation button                       |
+| rewindButtonClassName      | Additional classes applied to the rewind navigation button                 |
+| playButtonClassName        | Additional classes applied to the autoplay toggle button                   |
+| fastForwardButtonClassName | Additional classes applied to the fast-forward navigation button           |
+| slideHudClassName          | Additional classes applied to the slide count element within the HUD       |
 
-  ```md
-  :::deck
-  :::slide
-  :::reveal{at=0}
-  :::text{x=80 y=80}
-  First
-  :::
-  :::
-  :::reveal{at=1}
-  :::text{x=80 y=120}
-  Second
-  :::
-  :::
-  :::
-  ```
+The autoplay toggle button also exposes a `data-state` attribute set to
+`playing` or `paused` for targeting styles based on the current autoplay
+state.
 
-  | Input             | Description                          |
-  | ----------------- | ------------------------------------ |
-  | at                | Deck step when content reveals       |
-  | exitAt            | Deck step when content hides         |
-  | enter             | Enter transition type                |
-  | exit              | Exit transition type                 |
-  | enterDir          | Enter transition direction           |
-  | exitDir           | Exit transition direction            |
-  | enterDuration     | Enter transition duration in ms      |
-  | exitDuration      | Exit transition duration in ms       |
-  | interruptBehavior | How to handle interrupted animations |
-  | from              | Name of a reveal preset to apply     |
+### `slide`
 
-- `layer`: Absolutely position arbitrary content within a slide.
+Customize an individual slide.
 
-  ```md
-  :::deck
-  :::slide
-  :::layer{x=10 y=20 w=100 h=50 className="bg-[var(--color-primary-500)]"}
-  Content
-  :::
-  :::
-  ```
+```md
+:::deck
+:::slide{enter="slide" exit="fade"}
+Content
+:::
+:::
+```
 
-  | Input     | Description                              |
-  | --------- | ---------------------------------------- |
-  | x         | Horizontal position in pixels            |
-  | y         | Vertical position in pixels              |
-  | w         | Width in pixels                          |
-  | h         | Height in pixels                         |
-  | z         | z-index value                            |
-  | rotate    | Rotation in degrees                      |
-  | scale     | Scale multiplier                         |
-  | anchor    | Transform origin (`top-left` by default) |
-  | className | Additional classes applied to the Layer  |
-  | from      | Name of a layer preset to apply          |
+| Input         | Description                         |
+| ------------- | ----------------------------------- |
+| enter         | Enter transition type               |
+| exit          | Exit transition type                |
+| enterDir      | Enter transition direction          |
+| exitDir       | Exit transition direction           |
+| enterDuration | Enter transition duration in ms     |
+| exitDuration  | Exit transition duration in ms      |
+| enterDelay    | Enter transition delay in ms        |
+| exitDelay     | Exit transition delay in ms         |
+| enterEasing   | Enter transition easing             |
+| exitEasing    | Exit transition easing              |
+| steps         | Number of build steps on this slide |
+| onEnter       | Directive block to run on enter     |
+| onExit        | Directive block to run on exit      |
+| from          | Name of a slide preset to apply     |
 
-- `text`: Position typographic content within a slide.
+### `reveal`
 
-  ```md
-  :::deck
-  :::slide
-  :::text{x=100 y=50 align=center size=32 style="color: var(--color-primary-500)"}
-  Hello
-  :::
-  :::
-  ```
+Reveal slide content step-by-step.
 
-  Supports a `from` attribute to apply presets and uses `layerClassName` to add classes to the Layer wrapper.
+```md
+:::deck
+:::slide
+:::reveal{at=0}
+:::text{x=80 y=80}
+First
+:::
+:::
+:::reveal{at=1}
+:::text{x=80 y=120}
+Second
+:::
+:::
+:::
+```
 
-  | Input          | Description                              |
-  | -------------- | ---------------------------------------- |
-  | x              | Horizontal position in pixels            |
-  | y              | Vertical position in pixels              |
-  | w              | Width in pixels                          |
-  | h              | Height in pixels                         |
-  | z              | z-index value                            |
-  | rotate         | Rotation in degrees                      |
-  | scale          | Scale multiplier                         |
-  | anchor         | Transform origin (`top-left` by default) |
-  | align          | Horizontal text alignment                |
-  | size           | Font size in pixels                      |
-  | weight         | Font weight                              |
-  | lineHeight     | Line height multiplier                   |
-  | color          | Text color                               |
-  | style          | Inline styles applied to the text node   |
-  | className      | Classes applied to the text node         |
-  | layerClassName | Classes applied to the Layer wrapper     |
-  | from           | Name of a text preset to apply           |
+| Input             | Description                          |
+| ----------------- | ------------------------------------ |
+| at                | Deck step when content reveals       |
+| exitAt            | Deck step when content hides         |
+| enter             | Enter transition type                |
+| exit              | Exit transition type                 |
+| enterDir          | Enter transition direction           |
+| exitDir           | Exit transition direction            |
+| enterDuration     | Enter transition duration in ms      |
+| exitDuration      | Exit transition duration in ms       |
+| interruptBehavior | How to handle interrupted animations |
+| from              | Name of a reveal preset to apply     |
 
-- `shape`: Draw basic shapes within a slide.
+### `layer`
 
-  ```md
-  :::deck
-  :::slide
-  :shape{type='rect' x=10 y=20 w=100 h=50}
-  :::
-  :::
-  ```
+Absolutely position arbitrary content within a slide.
 
-  | Input          | Description                                       |
-  | -------------- | ------------------------------------------------- |
-  | x              | Horizontal position in pixels                     |
-  | y              | Vertical position in pixels                       |
-  | w              | Width in pixels                                   |
-  | h              | Height in pixels                                  |
-  | z              | z-index value                                     |
-  | rotate         | Rotation in degrees                               |
-  | scale          | Scale multiplier                                  |
-  | anchor         | Transform origin (`top-left` by default)          |
-  | type           | Shape type (`rect`, `ellipse`, `line`, `polygon`) |
-  | points         | Points for polygon shapes                         |
-  | x1             | Starting x-coordinate for line shapes             |
-  | y1             | Starting y-coordinate for line shapes             |
-  | x2             | Ending x-coordinate for line shapes               |
-  | y2             | Ending y-coordinate for line shapes               |
-  | stroke         | Stroke color                                      |
-  | strokeWidth    | Stroke width in pixels                            |
-  | fill           | Fill color (`none` by default)                    |
-  | radius         | Corner radius for rectangles                      |
-  | shadow         | Adds a drop shadow when true                      |
-  | className      | Classes applied to the `<svg>` element            |
-  | layerClassName | Classes applied to the Layer wrapper              |
-  | style          | Inline styles applied to the `<svg>` element      |
-  | from           | Name of a shape preset to apply                   |
+```md
+:::deck
+:::slide
+:::layer{x=10 y=20 w=100 h=50 className="bg-[var(--color-primary-500)]"}
+Content
+:::
+:::
+```
 
-- `wrapper`: Wrap content in a basic HTML element.
+| Input     | Description                              |
+| --------- | ---------------------------------------- |
+| x         | Horizontal position in pixels            |
+| y         | Vertical position in pixels              |
+| w         | Width in pixels                          |
+| h         | Height in pixels                         |
+| z         | z-index value                            |
+| rotate    | Rotation in degrees                      |
+| scale     | Scale multiplier                         |
+| anchor    | Transform origin (`top-left` by default) |
+| className | Additional classes applied to the Layer  |
+| from      | Name of a layer preset to apply          |
 
-  ```md
-  :::deck
-  :::slide
-  :::layer{x=10 y=20}
-  :::wrapper{as="p" className="note"}
-  Text
-  :::
-  :::
-  :::
-  :::
-  ```
+### `text`
 
-  | Input     | Description                                                       |
-  | --------- | ----------------------------------------------------------------- |
-  | as        | Element tag (`div`, `span`, `p`, or `section`, defaults to `div`) |
-  | className | Additional classes applied to the element                         |
-  | from      | Name of a wrapper preset to apply                                 |
+Position typographic content within a slide.
 
-- `preset`: Define reusable attribute sets that can be applied via the `from` attribute on `deck`, `reveal`, `image`, `shape`, `text`, and `wrapper` directives.
+```md
+:::deck
+:::slide
+:::text{x=100 y=50 align=center size=32 style="color: var(--color-primary-500)"}
+Hello
+:::
+:::
+```
 
-  ```md
-  :preset{type="deck" name="wide" size="16x9"}
-  :preset{type="text" name="title" x=100 y=50 size=32 color="var(--color-gray-200)"}
+Supports a `from` attribute to apply presets and uses `layerClassName` to add classes to the Layer wrapper.
 
-  :::deck{from="wide"}
-  :::slide
-  :::text{from="title"}
-  Welcome
-  :::
-  :::
-  ```
+| Input          | Description                              |
+| -------------- | ---------------------------------------- |
+| x              | Horizontal position in pixels            |
+| y              | Vertical position in pixels              |
+| w              | Width in pixels                          |
+| h              | Height in pixels                         |
+| z              | z-index value                            |
+| rotate         | Rotation in degrees                      |
+| scale          | Scale multiplier                         |
+| anchor         | Transform origin (`top-left` by default) |
+| align          | Horizontal text alignment                |
+| size           | Font size in pixels                      |
+| weight         | Font weight                              |
+| lineHeight     | Line height multiplier                   |
+| color          | Text color                               |
+| style          | Inline styles applied to the text node   |
+| className      | Classes applied to the text node         |
+| layerClassName | Classes applied to the Layer wrapper     |
+| from           | Name of a text preset to apply           |
 
-  Presets allow authors to reuse common configurations across multiple directives.
+### `shape`
+
+Draw basic shapes within a slide.
+
+```md
+:::deck
+:::slide
+:shape{type='rect' x=10 y=20 w=100 h=50}
+:::
+:::
+```
+
+| Input          | Description                                       |
+| -------------- | ------------------------------------------------- |
+| x              | Horizontal position in pixels                     |
+| y              | Vertical position in pixels                       |
+| w              | Width in pixels                                   |
+| h              | Height in pixels                                  |
+| z              | z-index value                                     |
+| rotate         | Rotation in degrees                               |
+| scale          | Scale multiplier                                  |
+| anchor         | Transform origin (`top-left` by default)          |
+| type           | Shape type (`rect`, `ellipse`, `line`, `polygon`) |
+| points         | Points for polygon shapes                         |
+| x1             | Starting x-coordinate for line shapes             |
+| y1             | Starting y-coordinate for line shapes             |
+| x2             | Ending x-coordinate for line shapes               |
+| y2             | Ending y-coordinate for line shapes               |
+| stroke         | Stroke color                                      |
+| strokeWidth    | Stroke width in pixels                            |
+| fill           | Fill color (`none` by default)                    |
+| radius         | Corner radius for rectangles                      |
+| shadow         | Adds a drop shadow when true                      |
+| className      | Classes applied to the `<svg>` element            |
+| layerClassName | Classes applied to the Layer wrapper              |
+| style          | Inline styles applied to the `<svg>` element      |
+| from           | Name of a shape preset to apply                   |
+
+### `wrapper`
+
+Wrap content in a basic HTML element.
+
+```md
+:::deck
+:::slide
+:::layer{x=10 y=20}
+:::wrapper{as="p" className="note"}
+Text
+:::
+:::
+:::
+:::
+```
+
+| Input     | Description                                                       |
+| --------- | ----------------------------------------------------------------- |
+| as        | Element tag (`div`, `span`, `p`, or `section`, defaults to `div`) |
+| className | Additional classes applied to the element                         |
+| from      | Name of a wrapper preset to apply                                 |
+
+### `preset`
+
+Define reusable attribute sets that can be applied via the `from` attribute on `deck`, `reveal`, `image`, `shape`, `text`, and `wrapper` directives.
+
+```md
+:preset{type="deck" name="wide" size="16x9"}
+:preset{type="text" name="title" x=100 y=50 size=32 color="var(--color-gray-200)"}
+
+:::deck{from="wide"}
+:::slide
+:::text{from="title"}
+Welcome
+:::
+:::
+```
+
+Presets allow authors to reuse common configurations across multiple directives.

--- a/docs/directives/persistence.md
+++ b/docs/directives/persistence.md
@@ -4,84 +4,96 @@ Save and load progress or store data in the browser.
 
 ## Checkpoints
 
-- `checkpoint`: Save the current game state.
+### `checkpoint`
 
-  ```md
-  :checkpoint{id="SAVE-ID" label="LABEL"}
-  ```
+Save the current game state.
 
-  Replace `SAVE-ID` with a key and `LABEL` with a description. Wrap the `id`
-  value in quotes or backticks unless referencing a state key. Saving a new
-  checkpoint replaces any existing checkpoint.
+```md
+:checkpoint{id="SAVE-ID" label="LABEL"}
+```
 
-  | Input | Description                          |
-  | ----- | ------------------------------------ |
-  | id    | Key used to store the checkpoint     |
-  | label | Description shown for the checkpoint |
+Replace `SAVE-ID` with a key and `LABEL` with a description. Wrap the `id`
+value in quotes or backticks unless referencing a state key. Saving a new
+checkpoint replaces any existing checkpoint.
 
-- `clearCheckpoint`: Remove the saved checkpoint.
+| Input | Description                          |
+| ----- | ------------------------------------ |
+| id    | Key used to store the checkpoint     |
+| label | Description shown for the checkpoint |
 
-  ```md
-  :clearCheckpoint
-  ```
+### `clearCheckpoint`
 
-  Removes the currently stored checkpoint. Only one checkpoint can exist at a
-  time, so this directive has no attributes.
+Remove the saved checkpoint.
 
-  | Input    | Description                  |
-  | -------- | ---------------------------- |
-  | _(none)_ | This directive has no inputs |
+```md
+:clearCheckpoint
+```
 
-- `loadCheckpoint`: Load a saved checkpoint.
+Removes the currently stored checkpoint. Only one checkpoint can exist at a
+time, so this directive has no attributes.
 
-  ```md
-  :loadCheckpoint
-  ```
+| Input    | Description                  |
+| -------- | ---------------------------- |
+| _(none)_ | This directive has no inputs |
 
-  Loads the currently stored checkpoint. Only one checkpoint can exist at a
-  time, so this directive has no attributes.
+### `loadCheckpoint`
 
-  | Input    | Description                  |
-  | -------- | ---------------------------- |
-  | _(none)_ | This directive has no inputs |
+Load a saved checkpoint.
+
+```md
+:loadCheckpoint
+```
+
+Loads the currently stored checkpoint. Only one checkpoint can exist at a
+time, so this directive has no attributes.
+
+| Input    | Description                  |
+| -------- | ---------------------------- |
+| _(none)_ | This directive has no inputs |
 
 ## Saves
 
-- `save`: Write the current state to local storage.
+### `save`
 
-  ```md
-  :save{id="SLOT"}
-  ```
+Write the current state to local storage.
 
-  Replace `SLOT` with the storage id. Wrap the `id` value in quotes or
-  backticks unless referencing a state key.
+```md
+:save{id="SLOT"}
+```
 
-  | Input | Description                   |
-  | ----- | ----------------------------- |
-  | id    | Storage key for the save slot |
+Replace `SLOT` with the storage id. Wrap the `id` value in quotes or
+backticks unless referencing a state key.
 
-- `load`: Load state from local storage.
+| Input | Description                   |
+| ----- | ----------------------------- |
+| id    | Storage key for the save slot |
 
-  ```md
-  :load{id="SLOT"}
-  ```
+### `load`
 
-  Replace `SLOT` with the storage id. Wrap the `id` value in quotes or
-  backticks unless referencing a state key.
+Load state from local storage.
 
-  | Input | Description              |
-  | ----- | ------------------------ |
-  | id    | Storage key to load from |
+```md
+:load{id="SLOT"}
+```
 
-- `clearSave`: Remove a stored game state.
+Replace `SLOT` with the storage id. Wrap the `id` value in quotes or
+backticks unless referencing a state key.
 
-  ```md
-  :clearSave{id="SLOT"}
-  ```
+| Input | Description              |
+| ----- | ------------------------ |
+| id    | Storage key to load from |
 
-  Replace `SLOT` with the storage id. Wrap the `id` value in quotes or
-  backticks unless referencing a state key.
+### `clearSave`
 
-  | Input | Description           |
-  | ----- | --------------------- |
-  | id    | Storage key to remove |
+Remove a stored game state.
+
+```md
+:clearSave{id="SLOT"}
+```
+
+Replace `SLOT` with the storage id. Wrap the `id` value in quotes or
+backticks unless referencing a state key.
+
+| Input | Description           |
+| ----- | --------------------- |
+| id    | Storage key to remove |

--- a/docs/directives/variables-and-state.md
+++ b/docs/directives/variables-and-state.md
@@ -2,95 +2,96 @@
 
 Operations that set, update, or remove scalar values, manage numeric ranges, and manipulate arrays.
 
-- `set`: Assign a value to a key. This directive is leaf-only and cannot wrap
-  content.
+### `set`
 
-  ```md
-  :set[key=value]
-  ```
+Assign a value to a key. This directive is leaf-only and cannot wrap content.
 
-  Replace `key` with the key name and `value` with the number, string, or
-  expression to store. Quoted values are treated as strings, `true`/`false` as
-  booleans, values wrapped in `{}` as objects, purely numeric values as numbers
-  and any other value is evaluated as an expression or state reference.
+```md
+:set[key=value]
+```
 
-  | Input | Description                  |
-  | ----- | ---------------------------- |
-  | key   | State key to assign          |
-  | value | Value or expression to store |
+Replace `key` with the key name and `value` with the number, string, or expression to store. Quoted values are treated as strings, `true`/`false` as booleans, values wrapped in `{}` as objects, purely numeric values as numbers and any other value is evaluated as an expression or state reference.
 
-  ```md
-  :set[health=100]
-  :set[playerName="John"]
-  :set[isActive=true]
-  ```
+| Input | Description                  |
+| ----- | ---------------------------- |
+| key   | State key to assign          |
+| value | Value or expression to store |
 
-- `setOnce`: Set a key only if it has not been set. This directive is leaf-only
-  and cannot wrap content.
+```md
+:set[health=100]
+:set[playerName="John"]
+:set[isActive=true]
+```
 
-  ```md
-  :setOnce[visited=true]
-  ```
+### `setOnce`
 
-  | Input | Description                  |
-  | ----- | ---------------------------- |
-  | key   | State key to set once        |
-  | value | Value to assign on first use |
+Set a key only if it has not been set. This directive is leaf-only and cannot wrap content.
 
-  Replace `visited` with the key to lock on first use.
+```md
+:setOnce[visited=true]
+```
 
-- `random`: Assign a random value. This directive is leaf-only and cannot wrap
-  content.
+| Input | Description                  |
+| ----- | ---------------------------- |
+| key   | State key to set once        |
+| value | Value to assign on first use |
 
-  ```md
-  :random[hp]{min=min_val max=max_val}
-  ```
+Replace `visited` with the key to lock on first use.
 
-  Replace `hp` with the key and `min_val`/`max_val` with bounds. You can also pick a random item from an array:
+### `random`
 
-  ```md
-  :random[pick]{from=['a string',some_key,true,42]}
-  :random[pick]{from=items}
-  ```
+Assign a random value. This directive is leaf-only and cannot wrap content.
 
-  Replace `pick` with the key to store the result and supply either a literal
-  array or a state key after `from`. Use either `min`/`max` _or_ `from`, but not
-  both. When using a numeric range, both `min` and `max` are required.
+```md
+:random[hp]{min=min_val max=max_val}
+```
 
-  | Input | Description                                     |
-  | ----- | ----------------------------------------------- |
-  | key   | State key to assign                             |
-  | min   | Minimum value for numeric range                 |
-  | max   | Maximum value for numeric range                 |
-  | from  | Array or state key to select a random item from |
+Replace `hp` with the key and `min_val`/`max_val` with bounds. You can also pick a random item from an array:
 
-- `randomOnce`: Assign a random value once and lock the key.
+```md
+:random[pick]{from=['a string',some_key,true,42]}
+:random[pick]{from=items}
+```
 
-  ```md
-  :randomOnce[roll]{min=1 max=6}
-  ```
+Replace `pick` with the key to store the result and supply either a literal array or a state key after `from`. Use either `min`/`max` _or_ `from`, but not both. When using a numeric range, both `min` and `max` are required.
 
-  | Input | Description                                     |
-  | ----- | ----------------------------------------------- |
-  | key   | State key to assign                             |
-  | min   | Minimum value for numeric range                 |
-  | max   | Maximum value for numeric range                 |
-  | from  | Array or state key to select a random item from |
+| Input | Description                                     |
+| ----- | ----------------------------------------------- |
+| key   | State key to assign                             |
+| min   | Minimum value for numeric range                 |
+| max   | Maximum value for numeric range                 |
+| from  | Array or state key to select a random item from |
 
-  **For both `random` and `randomOnce`, provide either `min`/`max` or `from`.**
+### `randomOnce`
 
-  Use this to store a random value that should not change on subsequent runs.
+Assign a random value once and lock the key.
 
-- `unset`: Remove a key from state. This directive is leaf-only and cannot wrap
-  content.
+```md
+:randomOnce[roll]{min=1 max=6}
+```
 
-  ```md
-  :unset{key=visited}
-  ```
+| Input | Description                                     |
+| ----- | ----------------------------------------------- |
+| key   | State key to assign                             |
+| min   | Minimum value for numeric range                 |
+| max   | Maximum value for numeric range                 |
+| from  | Array or state key to select a random item from |
 
-  | Input | Description         |
-  | ----- | ------------------- |
-  | key   | State key to remove |
+**For both `random` and `randomOnce`, provide either `min`/`max` or `from`.**
+
+Use this to store a random value that should not change on subsequent runs.
+
+### `unset`
+
+Remove a key from state. This directive is leaf-only and cannot wrap content.
+
+```md
+:unset{key=visited}
+```
+
+| Input | Description         |
+| ----- | ------------------- |
+| key   | State key to remove |
 
 Replace `visited` with the key to remove.
 
@@ -108,33 +109,37 @@ dot or bracket notation.
 
 Create and update numeric ranges.
 
-- `createRange`: Create a new numeric range.
+### `createRange`
 
-  ```md
-  :createRange[score=0]{min=0 max=10}
-  ```
+Create a new numeric range.
 
-  Replace `score` with the range key and `0` with the starting value. `min` and `max` define the bounds.
+```md
+:createRange[score=0]{min=0 max=10}
+```
 
-  | Input | Description                  |
-  | ----- | ---------------------------- |
-  | key   | State key to store the range |
-  | value | Initial value for the range  |
-  | min   | Minimum allowed value        |
-  | max   | Maximum allowed value        |
+Replace `score` with the range key and `0` with the starting value. `min` and `max` define the bounds.
 
-- `setRange`: Update the value of an existing range.
+| Input | Description                  |
+| ----- | ---------------------------- |
+| key   | State key to store the range |
+| value | Initial value for the range  |
+| min   | Minimum allowed value        |
+| max   | Maximum allowed value        |
 
-  ```md
-  :setRange[score=(score.value+1)]
-  ```
+### `setRange`
 
-  Replace `score` with the range key and provide a new value or expression.
+Update the value of an existing range.
 
-  | Input | Description                   |
-  | ----- | ----------------------------- |
-  | key   | Range key to update           |
-  | value | Value or expression to assign |
+```md
+:setRange[score=(score.value+1)]
+```
+
+Replace `score` with the range key and provide a new value or expression.
+
+| Input | Description                   |
+| ----- | ----------------------------- |
+| key   | Range key to update           |
+| value | Value or expression to assign |
 
 Range values are objects with `value`, `min`, and `max` properties. Access them using dot notation such as `score.value`, `score.min`, and `score.max`.
 
@@ -145,114 +150,129 @@ Create or modify lists of values.
 > Only use these directives for arrays—JavaScript's built-in methods can lead
 > to unpredictable behavior.
 
-- `array`: Create an array.
+### `array`
 
-  ```md
-  :array[items=[1,2,'three',"four"]]
-  ```
+Create an array.
 
-  Replace `items` with the array name. The directive accepts a single
-  `key=[...]` pair where the value is in array notation. Items are
-  automatically converted to strings, numbers, or booleans and may include
-  expressions evaluated against the current state.
+```md
+:array[items=[1,2,'three',"four"]]
+```
 
-  | Input | Description                      |
-  | ----- | -------------------------------- |
-  | key   | Name of the array to create      |
-  | [...] | Initial values in array notation |
+Replace `items` with the array name. The directive accepts a single
+`key=[...]` pair where the value is in array notation. Items are
+automatically converted to strings, numbers, or booleans and may include
+expressions evaluated against the current state.
 
-- `arrayOnce`: Create an array only if it has not been set.
+| Input | Description                      |
+| ----- | -------------------------------- |
+| key   | Name of the array to create      |
+| [...] | Initial values in array notation |
 
-  ```md
-  :arrayOnce[visited=['FOREST',"CAVE"]]
-  ```
+### `arrayOnce`
 
-  This behaves like `array` but locks the key after execution, preventing
-  further changes.
+Create an array only if it has not been set.
 
-  | Input | Description                      |
-  | ----- | -------------------------------- |
-  | key   | Name of the array to create      |
-  | [...] | Initial values in array notation |
+```md
+:arrayOnce[visited=['FOREST',"CAVE"]]
+```
 
-- `concat`: Combine arrays.
+This behaves like `array` but locks the key after execution, preventing
+further changes.
 
-  ```md
-  :concat{key=items value=moreItems}
-  ```
+| Input | Description                      |
+| ----- | -------------------------------- |
+| key   | Name of the array to create      |
+| [...] | Initial values in array notation |
 
-  Replace `items` with the target array and `moreItems` with the source.
+### `concat`
 
-  | Input | Description                    |
-  | ----- | ------------------------------ |
-  | key   | Target array to modify         |
-  | value | Array whose items are appended |
+Combine arrays.
 
-- `pop`: Remove the last item. Use `into` to store it.
+```md
+:concat{key=items value=moreItems}
+```
 
-  ```md
-  :pop{key=items into=lastItem}
-  ```
+Replace `items` with the target array and `moreItems` with the source.
 
-  Replace `items` with the array and `lastItem` with the storage key.
+| Input | Description                    |
+| ----- | ------------------------------ |
+| key   | Target array to modify         |
+| value | Array whose items are appended |
 
-  | Input | Description                            |
-  | ----- | -------------------------------------- |
-  | key   | Array to modify                        |
-  | into  | Optional key to store the removed item |
+### `pop`
 
-- `push`: Add items to the end of an array.
+Remove the last item. Use `into` to store it.
 
-  ```md
-  :push{key=items value=newItem}
-  ```
+```md
+:pop{key=items into=lastItem}
+```
 
-  Replace `items` with the array and `newItem` with items to add.
+Replace `items` with the array and `lastItem` with the storage key.
 
-  | Input | Description     |
-  | ----- | --------------- |
-  | key   | Array to modify |
-  | value | Items to append |
+| Input | Description                            |
+| ----- | -------------------------------------- |
+| key   | Array to modify                        |
+| into  | Optional key to store the removed item |
 
-- `shift`: Remove the first item. Use `into` to store it.
+### `push`
 
-  ```md
-  :shift{key=items into=firstItem}
-  ```
+Add items to the end of an array.
 
-  Replace `items` with the array and `firstItem` with the storage key.
+```md
+:push{key=items value=newItem}
+```
 
-  | Input | Description                            |
-  | ----- | -------------------------------------- |
-  | key   | Array to modify                        |
-  | into  | Optional key to store the removed item |
+Replace `items` with the array and `newItem` with items to add.
 
-- `splice`: Remove items at an index and optionally insert new ones. Use `into`
-  to store removed items.
+| Input | Description     |
+| ----- | --------------- |
+| key   | Array to modify |
+| value | Items to append |
 
-  ```md
-  :splice{key=items index=value count=value into=removedItems}
-  ```
+### `shift`
 
-  Replace `items` with the array and adjust attributes as needed.
+Remove the first item. Use `into` to store it.
 
-  | Input | Description                         |
-  | ----- | ----------------------------------- |
-  | key   | Array to modify                     |
-  | index | Starting index for removal          |
-  | count | Number of items to remove           |
-  | value | Items to insert                     |
-  | into  | Optional key to store removed items |
+```md
+:shift{key=items into=firstItem}
+```
 
-- `unshift`: Add items to the start of an array.
+Replace `items` with the array and `firstItem` with the storage key.
 
-  ```md
-  :unshift{key=items value=newItem}
-  ```
+| Input | Description                            |
+| ----- | -------------------------------------- |
+| key   | Array to modify                        |
+| into  | Optional key to store the removed item |
 
-  Replace `items` with the array and `newItem` with items to add.
+### `splice`
 
-  | Input | Description      |
-  | ----- | ---------------- |
-  | key   | Array to modify  |
-  | value | Items to prepend |
+Remove items at an index and optionally insert new ones. Use `into` to store removed items.
+
+```md
+:splice{key=items index=value count=value into=removedItems}
+```
+
+Replace `items` with the array and adjust attributes as needed.
+
+| Input | Description                         |
+| ----- | ----------------------------------- |
+| key   | Array to modify                     |
+| index | Starting index for removal          |
+| count | Number of items to remove           |
+| value | Items to insert                     |
+| into  | Optional key to store removed items |
+
+### `unshift`
+
+Add items to the start of an array.
+
+```md
+:unshift{key=items value=newItem}
+```
+
+Replace `items` with the array and `newItem` with items to add.
+
+| Input | Description      |
+| ----- | ---------------- |
+| key   | Array to modify  |
+| value | Items to prepend |


### PR DESCRIPTION
## Summary
- replace list-based directive sections with `###` headings for clarity

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68b416974f3c8322b3dd8003b80020c4