### PR TITLE
feat(trigger): require explicit click event directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ Here's a practical example showing how directives can be combined to create inte
 The value is currently :show[testRange]
 
 :::trigger{label="add"}
+:::onClick
 :setRange[testRange=(testRange.value+1)]
+:::
 :::
 
 :::if[testRange.value === testRange.max]

--- a/apps/campfire/src/components/Campfire/__tests__/Campfire.test.tsx
+++ b/apps/campfire/src/components/Campfire/__tests__/Campfire.test.tsx
@@ -93,7 +93,9 @@ describe('Story', () => {
 :::
 
 :::trigger{label="open"}
-:::set[open=false]
+:::onClick
+:set[open=false]
+:::
 :::
 
 :::if[!open]
@@ -124,7 +126,8 @@ is open!
 
 :::if[open]
 :::trigger{label="open"}
-:::set[clicked=true]
+:::onClick
+:set[clicked=true]
 :::
 :::
 :::

--- a/apps/campfire/src/components/Deck/Slide/__tests__/SlideDirective.test.tsx
+++ b/apps/campfire/src/components/Deck/Slide/__tests__/SlideDirective.test.tsx
@@ -50,7 +50,7 @@ describe('Slide directive hooks', () => {
     const { getByRole } = render(
       <Deck>
         <Slide>
-          <TriggerButton content={btnContent}>Click</TriggerButton>
+          <TriggerButton onClick={btnContent}>Click</TriggerButton>
         </Slide>
       </Deck>
     )

--- a/apps/campfire/src/components/Passage/TriggerButton.tsx
+++ b/apps/campfire/src/components/Passage/TriggerButton.tsx
@@ -11,11 +11,23 @@ const clone = rfdc()
 interface TriggerButtonProps
   extends Omit<
     JSX.HTMLAttributes<HTMLButtonElement>,
-    'className' | 'onMouseEnter' | 'onMouseLeave' | 'onFocus' | 'onBlur'
+    | 'className'
+    | 'onClick'
+    | 'onMouseDown'
+    | 'onMouseUp'
+    | 'onMouseEnter'
+    | 'onMouseLeave'
+    | 'onFocus'
+    | 'onBlur'
   > {
   className?: string | string[]
-  content: string
   disabled?: boolean
+  /** Serialized directives to run on click. */
+  onClick?: string
+  /** Serialized directives to run on mouse down. */
+  onMouseDown?: string
+  /** Serialized directives to run on mouse up. */
+  onMouseUp?: string
   /** Serialized directives to run on mouse enter. */
   onMouseEnter?: string
   /** Serialized directives to run on mouse leave. */
@@ -27,13 +39,15 @@ interface TriggerButtonProps
 }
 
 /**
- * Button that processes directive content when clicked.
+ * Button that processes directive content on interaction events.
  *
  * @param className - Optional CSS classes.
- * @param content - Serialized directive block.
  * @param children - Button label.
  * @param disabled - Disables the button when true.
  * @param style - Optional inline styles.
+ * @param onClick - Serialized directives to run on click.
+ * @param onMouseDown - Serialized directives to run on mouse down.
+ * @param onMouseUp - Serialized directives to run on mouse up.
  * @param onMouseEnter - Serialized directives to run on mouse enter.
  * @param onMouseLeave - Serialized directives to run on mouse leave.
  * @param onFocus - Serialized directives to run on focus.
@@ -41,15 +55,16 @@ interface TriggerButtonProps
  */
 export const TriggerButton = ({
   className,
-  content,
   children,
   disabled,
   style,
+  onClick,
+  onMouseDown,
+  onMouseUp,
   onMouseEnter,
   onMouseLeave,
   onFocus,
   onBlur,
-  onClick,
   ...rest
 }: TriggerButtonProps) => {
   const handlers = useDirectiveHandlers()
@@ -59,6 +74,10 @@ export const TriggerButton = ({
     onFocus,
     onBlur
   )
+  const run = (content?: string) => {
+    if (!content) return
+    runDirectiveBlock(clone(JSON.parse(content)) as RootContent[], handlers)
+  }
   return (
     <button
       type='button'
@@ -74,9 +93,18 @@ export const TriggerButton = ({
       {...directiveEvents}
       onClick={e => {
         e.stopPropagation()
-        onClick?.(e)
         if (e.defaultPrevented || disabled) return
-        runDirectiveBlock(clone(JSON.parse(content)) as RootContent[], handlers)
+        run(onClick)
+      }}
+      onMouseDown={e => {
+        e.stopPropagation()
+        if (e.defaultPrevented || disabled) return
+        run(onMouseDown)
+      }}
+      onMouseUp={e => {
+        e.stopPropagation()
+        if (e.defaultPrevented || disabled) return
+        run(onMouseUp)
       }}
     >
       {children}

--- a/apps/campfire/src/components/Passage/__tests__/If.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/If.test.tsx
@@ -122,7 +122,7 @@ describe('If', () => {
 
   it('executes trigger directives', async () => {
     const content = makeMixedContent(
-      ':::trigger{label="Fire"}\n:::set[fired=true]\n:::\n:::'
+      ':::trigger{label="Fire"}\n:::onClick\n:set[fired=true]\n:::\n:::'
     )
     render(<If test='true' content={content} />)
     const button = await screen.findByRole('button', { name: 'Fire' })

--- a/apps/campfire/src/components/Passage/__tests__/Passage.trigger.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Passage.trigger.test.tsx
@@ -35,7 +35,7 @@ describe('Passage trigger directives', () => {
         {
           type: 'text',
           value:
-            ':::trigger{label="Fire" className="extra"}\n:::set[fired=true]\n:::\n:::'
+            ':::trigger{label="Fire" className="extra"}\n:::onClick\n:set[fired=true]\n:::\n:::'
         }
       ]
     }
@@ -80,7 +80,7 @@ describe('Passage trigger directives', () => {
         {
           type: 'text',
           value:
-            ':::trigger{label="Stop" disabled}\n:::set[stopped=true]\n:::\n:::'
+            ':::trigger{label="Stop" disabled}\n:::onClick\n:set[stopped=true]\n:::\n:::'
         }
       ]
     }
@@ -105,7 +105,7 @@ describe('Passage trigger directives', () => {
         {
           type: 'text',
           value:
-            ':::trigger{label="Go" disabled=false}\n:::set[go=true]\n:::\n:::'
+            ':::trigger{label="Go" disabled=false}\n:::onClick\n:set[go=true]\n:::\n:::'
         }
       ]
     }
@@ -149,7 +149,7 @@ describe('Passage trigger directives', () => {
         {
           type: 'text',
           value:
-            ':::trigger{label="Do"}\n:::onMouseEnter\n:set[hovered=true]\n:::\n:::onFocus\n:set[focused=true]\n:::\n:::onBlur\n:set[blurred=true]\n:::\n:set[clicked=true]\n:::\n'
+            ':::trigger{label="Do"}\n:::onMouseEnter\n:set[hovered=true]\n:::\n:::onFocus\n:set[focused=true]\n:::\n:::onBlur\n:set[blurred=true]\n:::\n:::onClick\n:set[clicked=true]\n:::\n'
         }
       ]
     }
@@ -178,7 +178,8 @@ describe('Passage trigger directives', () => {
       children: [
         {
           type: 'text',
-          value: ':::trigger{label="Fire"}\n:::set[fired=true]\n:::\n:::'
+          value:
+            ':::trigger{label="Fire"}\n:::onClick\n:set[fired=true]\n:::\n:::'
         }
       ]
     }
@@ -224,8 +225,7 @@ describe('Passage trigger directives', () => {
             ':::wrapper{as="span" className="fancy"}\n' +
             'Styled Label\n' +
             ':::\n' +
-            ':::set[fired=true]\n' +
-            ':::\n' +
+            ':::onClick\n:set[fired=true]\n:::\n' +
             ':::'
         }
       ]

--- a/apps/storybook/src/TriggerButton.stories.tsx
+++ b/apps/storybook/src/TriggerButton.stories.tsx
@@ -17,8 +17,8 @@ export default meta
 export const States: StoryObj<typeof TriggerButton> = {
   render: () => (
     <div className='flex gap-2'>
-      <TriggerButton content='[]'>Enabled</TriggerButton>
-      <TriggerButton content='[]' disabled>
+      <TriggerButton onClick='[]'>Enabled</TriggerButton>
+      <TriggerButton onClick='[]' disabled>
         Disabled
       </TriggerButton>
     </div>
@@ -33,7 +33,7 @@ export const States: StoryObj<typeof TriggerButton> = {
 export const Styled: StoryObj<typeof TriggerButton> = {
   render: () => (
     <TriggerButton
-      content='[]'
+      onClick='[]'
       style={{
         backgroundColor: 'var(--color-primary-500)',
         color: 'var(--color-primary-foreground)'

--- a/apps/storybook/src/TriggerDirective.stories.tsx
+++ b/apps/storybook/src/TriggerDirective.stories.tsx
@@ -21,7 +21,9 @@ export const Basic: StoryObj = {
 :set[test=true]
 
 :::trigger{label="Click me"}
-  :set[test=false]
+  :::onClick
+    :set[test=false]
+  :::
 :::
 
 :::if[!test]
@@ -90,7 +92,9 @@ export const WithWrapperLabel: StoryObj = {
     ![cat](https://placecats.com/neo/50/50)
     Click the cat
   :::
-  :set[clicked=true]
+  :::onClick
+    :set[clicked=true]
+  :::
 :::
 
 :::if[clicked]

--- a/docs/directives/inputs-and-events.md
+++ b/docs/directives/inputs-and-events.md
@@ -96,14 +96,16 @@ The select button uses the same default styling as trigger and link buttons and 
 
 ### `trigger`
 
-Render a button that runs directives when clicked. Supports event directives inside the block.
+Render a button that runs directives on interaction. Click events must be nested inside an event directive.
 
 ```md
 :::trigger{label="Do it" className="primary"}
 :::onMouseEnter
 :set[hovered=true]
 :::
+:::onClick
 :set[key=value]
+:::
 :::
 ```
 
@@ -146,6 +148,9 @@ Use event directives inside `input`, `select`, or `trigger` blocks to run direct
 | `onMouseLeave` | is no longer hovered      |
 | `onFocus`      | receives focus            |
 | `onBlur`       | loses focus               |
+| `onClick`      | is clicked                |
+| `onMouseDown`  | is pressed                |
+| `onMouseUp`    | is released               |
 
 ## Passage event blocks
 


### PR DESCRIPTION
## Summary
- require click actions in `trigger` blocks to use `onClick`, `onMouseDown`, or `onMouseUp`
- expose click-related directive handlers on `TriggerButton`
- document new trigger usage and supported event directives

## Testing
- `bun tsc`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_68b51575985c8322a5446ceb8d015ade