### PR TITLE
fix(wrapper): preserve nested container wrappers

### DIFF
--- a/apps/campfire/src/hooks/__tests__/deepNestedDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/deepNestedDirective.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach } from 'bun:test'
+import { render } from '@testing-library/preact'
+import type { ComponentChild } from 'preact'
+import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
+import { renderDirectiveMarkdown } from '@campfire/components/Deck/Slide'
+
+let output: ComponentChild | null = null
+
+/**
+ * Helper component to render markdown with directive handlers.
+ */
+const MarkdownRunner = ({ markdown }: { markdown: string }) => {
+  const handlers = useDirectiveHandlers()
+  output = renderDirectiveMarkdown(markdown, handlers)
+  return <>{output}</>
+}
+
+beforeEach(() => {
+  output = null
+  document.body.innerHTML = ''
+})
+
+describe('deep nested containers', () => {
+  it('renders nested containers with sibling containers correctly', () => {
+    const md =
+      ':set[show=true]\n' +
+      ':::layer{className="flex"}\n' +
+      ':::wrapper{as="div"}\n' +
+      ':::wrapper{as="div"}\n' +
+      ':radio[choice]{value="a"}\n' +
+      ':::\n' +
+      ':::wrapper{as="div"}\n' +
+      ':radio[choice]{value="b"}\n' +
+      ':::if[show]\n' +
+      'hi\n' +
+      ':::\n' +
+      ':::\n' +
+      ':::\n' +
+      ':::wrapper{as="div"}\n' +
+      ':radio[choice]{value="c"}\n' +
+      ':::\n' +
+      ':::\n'
+    render(<MarkdownRunner markdown={md} />)
+    const layer = document.querySelector('[data-testid="layer"]') as HTMLElement
+    const wrappers = layer.querySelectorAll('[data-testid="wrapper"]')
+    expect(wrappers.length).toBe(4)
+    const radios = layer.querySelectorAll('[data-testid="radio"]')
+    expect(radios.length).toBe(3)
+    expect(document.body.innerHTML).not.toContain(':::')
+  })
+})

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -1134,8 +1134,7 @@ export const useDirectiveHandlers = () => {
     const container = directive as ContainerDirective
     const allowed = ALLOWED_BATCH_DIRECTIVES
     const rawChildren = runDirectiveBlock(
-      expandIndentedCode(container.children as RootContent[]),
-      handlersRef.current
+      expandIndentedCode(container.children as RootContent[])
     )
     const processedChildren = stripLabel(rawChildren)
     const [filtered, invalid, nested] = filterDirectiveChildren(
@@ -3304,8 +3303,8 @@ export const useDirectiveHandlers = () => {
       children
         .flatMap(child => {
           if (child.type !== 'paragraph') return child
-          const paragraph = child as Parent
-          return paragraph.children
+          const paragraph = child as Paragraph
+          return paragraph.data?.hName ? paragraph : paragraph.children
         })
         .filter(child => !isWhitespaceNode(child as RootContent))
   )

--- a/testing-library.ts
+++ b/testing-library.ts
@@ -1,6 +1,11 @@
-import { afterEach, expect } from 'bun:test'
+import { afterEach, expect, setDefaultTimeout } from 'bun:test'
 import { cleanup } from '@testing-library/preact'
 import * as matchers from '@testing-library/jest-dom/matchers'
+
+/**
+ * Sets a default timeout for all tests to avoid infinite loops.
+ */
+setDefaultTimeout(10_000)
 
 expect.extend(matchers)
 


### PR DESCRIPTION
## Summary
- ensure wrapper directive preserves nested container elements instead of unwrapping them
- test deep nested wrapper blocks with sibling containers
- enforce a 10s default timeout to catch hanging tests
- preprocess batch directives to ignore nested or disallowed directives before execution

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68b5ad205f3483228a8a19031eab67e4