### PR TITLE
fix: prevent nested batch directives from executing

### DIFF
--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -1133,13 +1133,11 @@ export const useDirectiveHandlers = () => {
 
     const container = directive as ContainerDirective
     const allowed = ALLOWED_BATCH_DIRECTIVES
-    const rawChildren = runDirectiveBlock(
-      expandIndentedCode(container.children as RootContent[]),
-      handlersRef.current
-    )
-    const processedChildren = stripLabel(rawChildren)
+    const expanded = expandIndentedCode(container.children as RootContent[])
+    const processedForFilter = runDirectiveBlock(expanded)
+    const stripped = stripLabel(processedForFilter)
     const [filtered, invalid, nested] = filterDirectiveChildren(
-      processedChildren,
+      stripped,
       allowed,
       BANNED_BATCH_DIRECTIVES
     )


### PR DESCRIPTION
## Summary
- avoid executing nested `batch` directives by parsing children without handlers and filtering before execution
- ensure `batch` blocks error on unsupported directives rather than running them

## Testing
- `bun test apps/campfire/src/components/Passage/__tests__/Passage.state.test.tsx`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68b61a891da88322842935d87976405b