### PR TITLE
fix(wrapper): allow image directives inside trigger wrapper

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -58,6 +58,8 @@ For all container directives (`trigger`, `if`, `select`, `layer`, `wrapper`, `de
 
 If content after a container stops rendering or is captured unexpectedly, check these sentinel rules first.
 
+If a container directive nests another container and is followed by an inline directive, confirm the inline directive renders and does not leave stray `:::` markers. This regression has appeared repeatedly; add tests for these cases. See `docs/recurring-issues.md` for more information.
+
 ### Attributes
 
 - If a directive attribute's value is surrounded by quotes or backticks, it MUST be treated as a string and NEVER converted into JSON, even if the contents of the string appear to be JSON.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,8 @@ For any container directive (e.g., `trigger`, `if`, `select`, `layer`, `wrapper`
 
 If content “after a container” fails to render or containers accidentally swallow following directives, verify these sentinels and ensure marker‑only nodes are not removed before the handler runs.
 
+If a container directive includes a nested container followed immediately by an inline directive, verify the inline directive renders and no stray `:::` markers remain. This regression has resurfaced multiple times; add tests for these scenarios. See `docs/recurring-issues.md` for details.
+
 ### Attributes
 
 - If a directive attribute's value is surrounded by quotes or backticks, it MUST be treated as a string and NEVER converted into JSON, even if the contents of the string appear to be JSON.

--- a/apps/campfire/src/hooks/__tests__/triggerDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/triggerDirective.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach } from 'bun:test'
+import { render, act } from '@testing-library/preact'
+import type { ComponentChild } from 'preact'
+import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
+import { renderDirectiveMarkdown } from '@campfire/components/Deck/Slide'
+import { useGameStore } from '@campfire/state/useGameStore'
+import { resetStores } from '@campfire/test-utils/helpers'
+
+let output: ComponentChild | null = null
+
+/**
+ * Component used in tests to render markdown with directive handlers.
+ *
+ * @param markdown - Markdown string that may include trigger directives.
+ * @returns Nothing; sets `output` with rendered content.
+ */
+const MarkdownRunner = ({ markdown }: { markdown: string }) => {
+  const handlers = useDirectiveHandlers()
+  output = renderDirectiveMarkdown(markdown, handlers)
+  return <>{output}</>
+}
+
+beforeEach(() => {
+  output = null
+  document.body.innerHTML = ''
+  resetStores()
+})
+
+describe('trigger directive', () => {
+  it('renders text and image in a child wrapper before an inline directive', () => {
+    const md =
+      ':::trigger{label="Fire"}\n' +
+      ':::wrapper{as="span"}\n' +
+      'Run\n' +
+      ':image{src="https://placehold.co/32"}\n' +
+      ':::\n' +
+      ':set[fired=true]\n' +
+      ':::\n'
+    render(<MarkdownRunner markdown={md} />)
+    const button = document.querySelector(
+      '[data-testid="trigger-button"]'
+    ) as HTMLButtonElement
+    const wrapper = button.querySelector(
+      '[data-testid="wrapper"]'
+    ) as HTMLElement
+    const image = wrapper.querySelector(
+      '[data-testid="slideImage"]'
+    ) as HTMLElement
+    expect(button).toBeTruthy()
+    expect(wrapper).toBeTruthy()
+    expect(wrapper.textContent).toContain('Run')
+    expect(image).toBeTruthy()
+    const img = image.querySelector('img') as HTMLImageElement
+    expect(img.getAttribute('src')).toBe('https://placehold.co/32')
+    act(() => {
+      button.click()
+    })
+    expect(useGameStore.getState().gameData.fired).toBe(true)
+    expect(document.body.innerHTML).not.toContain(':::')
+  })
+})

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -3317,13 +3317,23 @@ export const useDirectiveHandlers = () => {
       return props
     },
     children =>
-      children
-        .flatMap(child => {
+      (
+        children.flatMap(child => {
           if (child.type !== 'paragraph') return child
           const paragraph = child as Parent
-          return paragraph.children
-        })
-        .filter(child => !isWhitespaceNode(child as RootContent))
+          const data = paragraph.data as { hName?: unknown } | undefined
+          // Preserve paragraphs representing custom elements such as slideImage
+          return data && typeof data.hName === 'string'
+            ? paragraph
+            : paragraph.children
+        }) as RootContent[]
+      ).filter(child => {
+        if (child.type === 'paragraph') {
+          const data = (child as Parent).data as { hName?: unknown } | undefined
+          if (data && typeof data.hName === 'string') return true
+        }
+        return !isWhitespaceNode(child as RootContent)
+      })
   )
 
   /**

--- a/docs/recurring-issues.md
+++ b/docs/recurring-issues.md
@@ -1,0 +1,12 @@
+# Recurring issues
+
+## Inline directives after nested containers
+
+Container directives that contain another container followed by an inline directive have repeatedly failed to render the inline directive. The parent container would swallow the following directive or leave its `:::` marker in the output when it didn't recursively process the child container or strip marker nodes.
+
+Regression tests cover this scenario:
+
+- `apps/campfire/src/hooks/__tests__/layerDirective.test.tsx` ensures a `layer` with a nested `wrapper` still renders a `radio` directive that follows.
+- `apps/campfire/src/hooks/__tests__/triggerDirective.test.tsx` verifies a `trigger` wrapper can display text and an `image` before an inline `:set` directive.
+
+When adding or updating container directives, verify that inline directives after nested containers render correctly and add regression tests to prevent this regression from returning.


### PR DESCRIPTION
## Summary
- preserve custom elements inside wrapper directive
- test trigger wrapper with text and image before inline directive
- ensure nested container directives render inline siblings after wrappers
- move trigger wrapper regression test to dedicated trigger suite

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68b66511af108322a355f9296fbab4d7