### PR TITLE
feat(directives): support id attributes for visual components

### DIFF
--- a/apps/campfire/src/components/Deck/Slide/SlideImage/__tests__/SlideImage.test.tsx
+++ b/apps/campfire/src/components/Deck/Slide/SlideImage/__tests__/SlideImage.test.tsx
@@ -35,4 +35,14 @@ describe('SlideImage', () => {
     expect(img.className).toContain('rounded')
     expect(img.style.border).toBe('1px solid red')
   })
+
+  it('applies id attributes to layer and image', () => {
+    render(
+      <SlideImage src='img.png' alt='test ids' id='img-id' layerId='layer-id' />
+    )
+    const wrapper = screen.getByTestId('slideImage') as HTMLElement
+    const img = wrapper.querySelector('img') as HTMLImageElement
+    expect(wrapper.id).toBe('layer-id')
+    expect(img.id).toBe('img-id')
+  })
 })

--- a/apps/campfire/src/components/Deck/Slide/SlideLayer/index.tsx
+++ b/apps/campfire/src/components/Deck/Slide/SlideLayer/index.tsx
@@ -6,8 +6,12 @@ export interface SlideLayerProps
   extends Omit<LayerProps, 'children' | 'className'> {
   /** Class applied to the Layer wrapper. */
   layerClassName?: string
+  /** id applied to the Layer wrapper. */
+  layerId?: string
   /** Element or component to render inside the Layer. */
   as?: keyof JSX.IntrinsicElements | ComponentType<any>
+  /** id applied to the inner element. */
+  id?: string
   /** Class applied to the inner element. */
   className?: string
   /** Style for the inner element. */
@@ -30,6 +34,8 @@ export interface SlideLayerProps
  */
 export const SlideLayer = ({
   layerClassName,
+  layerId,
+  id,
   as: Tag = 'div',
   className,
   style,
@@ -45,9 +51,10 @@ export const SlideLayer = ({
     <Layer
       data-testid={testId}
       className={mergeClasses('campfire-slide-layer', layerClassName)}
+      id={layerId}
       {...layerProps}
     >
-      <Tag className={className} style={finalStyle} {...elementProps}>
+      <Tag id={id} className={className} style={finalStyle} {...elementProps}>
         {children}
       </Tag>
     </Layer>

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -2903,7 +2903,8 @@ export const useDirectiveHandlers = () => {
     enterDuration: { type: 'number' },
     exitDuration: { type: 'number' },
     interruptBehavior: { type: 'string' },
-    from: { type: 'string', expression: false }
+    from: { type: 'string', expression: false },
+    id: { type: 'string' }
   } as const
 
   type RevealSchema = typeof revealSchema
@@ -2918,7 +2919,8 @@ export const useDirectiveHandlers = () => {
     'exitDir',
     'enterDuration',
     'exitDuration',
-    'interruptBehavior'
+    'interruptBehavior',
+    'id'
   ] as const
 
   /**
@@ -2964,7 +2966,8 @@ export const useDirectiveHandlers = () => {
     steps: { type: 'number' },
     onEnter: { type: 'string' },
     onExit: { type: 'string' },
-    from: { type: 'string', expression: false }
+    from: { type: 'string', expression: false },
+    id: { type: 'string' }
   } as const
 
   type SlideSchema = typeof slideSchema
@@ -2998,6 +3001,7 @@ export const useDirectiveHandlers = () => {
     scale: { type: 'number' },
     anchor: { type: 'string' },
     className: { type: 'string' },
+    id: { type: 'string' },
     from: { type: 'string', expression: false }
   } as const
 
@@ -3012,13 +3016,15 @@ export const useDirectiveHandlers = () => {
     'z',
     'rotate',
     'scale',
-    'anchor'
+    'anchor',
+    'id'
   ] as const
 
   /** Schema describing supported wrapper directive attributes. */
   const wrapperSchema = {
     as: { type: 'string' },
-    from: { type: 'string', expression: false }
+    from: { type: 'string', expression: false },
+    id: { type: 'string' }
   } as const
 
   type WrapperSchema = typeof wrapperSchema
@@ -3040,6 +3046,8 @@ export const useDirectiveHandlers = () => {
     weight: { type: 'number' },
     lineHeight: { type: 'number' },
     color: { type: 'string' },
+    id: { type: 'string' },
+    layerId: { type: 'string' },
     from: { type: 'string', expression: false }
   } as const
 
@@ -3061,6 +3069,8 @@ export const useDirectiveHandlers = () => {
     style: { type: 'string' },
     className: { type: 'string' },
     layerClassName: { type: 'string' },
+    id: { type: 'string' },
+    layerId: { type: 'string' },
     from: { type: 'string', expression: false }
   } as const
 
@@ -3091,6 +3101,8 @@ export const useDirectiveHandlers = () => {
     className: { type: 'string' },
     layerClassName: { type: 'string' },
     style: { type: 'string' },
+    id: { type: 'string' },
+    layerId: { type: 'string' },
     from: { type: 'string', expression: false }
   } as const
 
@@ -3155,7 +3167,12 @@ export const useDirectiveHandlers = () => {
       if (attrs.interruptBehavior)
         props.interruptBehavior = attrs.interruptBehavior
       const mergedRaw = mergeAttrs(preset, raw)
-      applyAdditionalAttributes(mergedRaw, props, [...REVEAL_EXCLUDES, 'from'])
+      if (attrs.id) props.id = attrs.id
+      applyAdditionalAttributes(mergedRaw, props, [
+        ...REVEAL_EXCLUDES,
+        'from',
+        'id'
+      ])
       return props
     }
   )
@@ -3204,10 +3221,12 @@ export const useDirectiveHandlers = () => {
             ? mergedRaw.className
             : undefined
       if (classAttr) props.className = classAttr
+      if (attrs.id) props.id = attrs.id
       applyAdditionalAttributes(mergedRaw, props, [
         ...LAYER_EXCLUDES,
         'from',
-        'layerClassName'
+        'layerClassName',
+        'id'
       ])
       return props
     },
@@ -3313,7 +3332,13 @@ export const useDirectiveHandlers = () => {
       props.className = ['campfire-wrapper', classAttr]
         .filter(Boolean)
         .join(' ')
-      applyAdditionalAttributes(mergedRaw, props, ['as', 'className', 'from'])
+      if (attrs.id) props.id = attrs.id
+      applyAdditionalAttributes(mergedRaw, props, [
+        'as',
+        'className',
+        'from',
+        'id'
+      ])
       return props
     },
     children =>
@@ -3440,6 +3465,8 @@ export const useDirectiveHandlers = () => {
     if (classAttr) classes.unshift(classAttr)
     props.className = classes.join(' ')
     if (layerClassAttr) props.layerClassName = layerClassAttr
+    if (mergedAttrs.id) props.id = mergedAttrs.id
+    if (mergedAttrs.layerId) props.layerId = mergedAttrs.layerId
     props['data-component'] = 'slideText'
     props['data-as'] = tagName
     applyAdditionalAttributes(mergedRaw, props, [
@@ -3460,6 +3487,8 @@ export const useDirectiveHandlers = () => {
       'style',
       'className',
       'layerClassName',
+      'id',
+      'layerId',
       'from'
     ])
     const processed = runDirectiveBlock(
@@ -3524,6 +3553,8 @@ export const useDirectiveHandlers = () => {
     if (mergedAttrs.className) props.className = mergedAttrs.className
     if (mergedAttrs.layerClassName)
       props.layerClassName = mergedAttrs.layerClassName
+    if (mergedAttrs.id) props.id = mergedAttrs.id
+    if (mergedAttrs.layerId) props.layerId = mergedAttrs.layerId
     applyAdditionalAttributes(mergedRaw, props, [
       'x',
       'y',
@@ -3538,6 +3569,8 @@ export const useDirectiveHandlers = () => {
       'style',
       'className',
       'layerClassName',
+      'id',
+      'layerId',
       'from'
     ])
     const node: Parent = {
@@ -3608,6 +3641,8 @@ export const useDirectiveHandlers = () => {
     if (mergedAttrs.className) props.className = mergedAttrs.className
     if (mergedAttrs.layerClassName)
       props.layerClassName = mergedAttrs.layerClassName
+    if (mergedAttrs.id) props.id = mergedAttrs.id
+    if (mergedAttrs.layerId) props.layerId = mergedAttrs.layerId
     applyAdditionalAttributes(mergedRaw, props, [
       'x',
       'y',
@@ -3631,6 +3666,8 @@ export const useDirectiveHandlers = () => {
       'style',
       'className',
       'layerClassName',
+      'id',
+      'layerId',
       'from'
     ])
     const node: Parent = {
@@ -3724,7 +3761,8 @@ export const useDirectiveHandlers = () => {
     'theme',
     'autoplay',
     'autoplayDelay',
-    'pause'
+    'pause',
+    'id'
   ] as const
 
   /**
@@ -3756,7 +3794,8 @@ export const useDirectiveHandlers = () => {
         from: { type: 'string', expression: false },
         autoplay: { type: 'boolean' },
         autoplayDelay: { type: 'number' },
-        pause: { type: 'boolean' }
+        pause: { type: 'boolean' },
+        id: { type: 'string' }
       },
       { label: false }
     )
@@ -3790,10 +3829,12 @@ export const useDirectiveHandlers = () => {
           : 3000
       if (deckAttrs.pause) deckProps.autoAdvancePaused = true
     }
+    if (deckAttrs.id) deckProps.id = deckAttrs.id
     const rawDeckAttrs = (directive.attributes || {}) as Record<string, unknown>
     applyAdditionalAttributes(rawDeckAttrs, deckProps, [
       ...DECK_EXCLUDES,
-      'from'
+      'from',
+      'id'
     ])
 
     const slides: Parent[] = []

--- a/apps/campfire/src/remark-campfire/__tests__/id-attribute.test.ts
+++ b/apps/campfire/src/remark-campfire/__tests__/id-attribute.test.ts
@@ -3,15 +3,23 @@ import { unified } from 'unified'
 import { VFile } from 'vfile'
 import remarkParse from 'remark-parse'
 import remarkDirective from 'remark-directive'
-import remarkCampfire, { type DirectiveHandler } from '../index'
-import type { TextDirective } from 'mdast-util-directive'
+import remarkCampfire, {
+  type DirectiveHandler,
+  type DirectiveNode
+} from '../index'
 
-type DirectiveName = 'checkpoint' | 'save' | 'load' | 'clearSave'
+type DirectiveName =
+  | 'checkpoint'
+  | 'save'
+  | 'load'
+  | 'clearSave'
+  | 'image'
+  | 'slide'
 
 const parse = (name: DirectiveName, md: string) => {
-  let captured: TextDirective | undefined
+  let captured: DirectiveNode | undefined
   const handler: DirectiveHandler = directive => {
-    captured = directive as TextDirective
+    captured = directive
   }
   const processor = unified()
     .use(remarkParse)
@@ -28,22 +36,26 @@ describe('id attribute quoting', () => {
     'checkpoint',
     'save',
     'load',
-    'clearSave'
+    'clearSave',
+    'image',
+    'slide'
   ]
   for (const name of directives) {
+    const open = name === 'slide' ? ':::' : ':'
+    const close = name === 'slide' ? '\n:::' : ''
     it(`accepts quoted id for ${name}`, () => {
-      const { node } = parse(name, `:${name}{id="cp1"}`)
+      const { node } = parse(name, `${open}${name}{id="cp1"}${close}`)
       expect(node?.attributes).toEqual({ id: 'cp1' })
     })
 
     it(`accepts unquoted state key for ${name}`, () => {
-      const { node, file } = parse(name, `:${name}{id=cp.id}`)
+      const { node, file } = parse(name, `${open}${name}{id=cp.id}${close}`)
       expect(node?.attributes).toEqual({ id: 'cp.id' })
       expect(file.messages).toHaveLength(0)
     })
 
     it(`rejects unquoted literal id for ${name}`, () => {
-      const { node, file } = parse(name, `:${name}{id=cp1}`)
+      const { node, file } = parse(name, `${open}${name}{id=cp1}${close}`)
       expect(node?.attributes).toEqual({})
       expect(
         file.messages.some(m =>

--- a/apps/campfire/src/remark-campfire/index.ts
+++ b/apps/campfire/src/remark-campfire/index.ts
@@ -280,10 +280,7 @@ const remarkCampfire =
               )
             }
             if (
-              (directive.name === 'checkpoint' ||
-                directive.name === 'save' ||
-                directive.name === 'load' ||
-                directive.name === 'clearSave') &&
+              directive.attributes &&
               Object.prototype.hasOwnProperty.call(directive.attributes, 'id')
             ) {
               ensureQuotedAttribute(

--- a/apps/storybook/src/SlideImage.stories.tsx
+++ b/apps/storybook/src/SlideImage.stories.tsx
@@ -24,6 +24,8 @@ export const Basic: StoryObj<typeof SlideImage> = {
           exit={{ type: 'fade', duration: 300 }}
         >
           <SlideImage
+            id='kitten-img'
+            layerId='kitten-layer'
             className={'rounded-full'}
             src='https://placecats.com/neo/200/200'
             alt='Kitten'

--- a/docs/directives/asset-management.md
+++ b/docs/directives/asset-management.md
@@ -11,12 +11,12 @@ Position an image within a slide.
 ```md
 :::deck
 :::slide
-:image{src='https://example.com/cat.png' x=10 y=20}
+:image{id='cat' layerId='cat-layer' src='https://example.com/cat.png' x=10 y=20}
 :::
 :::
 ```
 
-Supports a `from` attribute to apply presets.
+Supports a `from` attribute to apply presets and uses `layerClassName` and `layerId` to customize the Layer wrapper.
 
 | Input          | Description                              |
 | -------------- | ---------------------------------------- |
@@ -33,6 +33,8 @@ Supports a `from` attribute to apply presets.
 | style          | Inline styles applied to the `<img>`     |
 | className      | Classes applied to the `<img>`           |
 | layerClassName | Classes applied to the Layer wrapper     |
+| id             | Unique identifier for the `<img>`        |
+| layerId        | Unique identifier for the Layer wrapper  |
 | from           | Name of an image preset to apply         |
 
 ### `preloadImage`

--- a/docs/directives/navigation-composition.md
+++ b/docs/directives/navigation-composition.md
@@ -86,6 +86,7 @@ its own slide if not preceded by a slide directive.
 | autoplay                   | Whether to automatically advance through slides                            |
 | autoplayDelay              | Milliseconds between automatic slide advances (defaults to 3000)           |
 | pause                      | Start autoplay paused and display a play button                            |
+| id                         | Unique identifier for the deck                                             |
 | groupClassName             | Additional classes applied to the slide group wrapper                      |
 | navClassName               | Additional classes applied to the navigation wrapper                       |
 | hudClassName               | Additional classes applied to the slide counter HUD wrapper                |
@@ -126,6 +127,7 @@ Content
 | steps         | Number of build steps on this slide |
 | onEnter       | Directive block to run on enter     |
 | onExit        | Directive block to run on exit      |
+| id            | Unique identifier for the slide     |
 | from          | Name of a slide preset to apply     |
 
 ### `reveal`
@@ -159,6 +161,7 @@ Second
 | enterDuration     | Enter transition duration in ms      |
 | exitDuration      | Exit transition duration in ms       |
 | interruptBehavior | How to handle interrupted animations |
+| id                | Unique identifier for the reveal     |
 | from              | Name of a reveal preset to apply     |
 
 ### `layer`
@@ -185,6 +188,7 @@ Content
 | scale     | Scale multiplier                         |
 | anchor    | Transform origin (`top-left` by default) |
 | className | Additional classes applied to the Layer  |
+| id        | Unique identifier for the Layer wrapper  |
 | from      | Name of a layer preset to apply          |
 
 ### `text`
@@ -200,7 +204,7 @@ Hello
 :::
 ```
 
-Supports a `from` attribute to apply presets and uses `layerClassName` to add classes to the Layer wrapper.
+Supports a `from` attribute to apply presets and uses `layerClassName` and `layerId` to customize the Layer wrapper.
 
 | Input          | Description                              |
 | -------------- | ---------------------------------------- |
@@ -220,6 +224,8 @@ Supports a `from` attribute to apply presets and uses `layerClassName` to add cl
 | style          | Inline styles applied to the text node   |
 | className      | Classes applied to the text node         |
 | layerClassName | Classes applied to the Layer wrapper     |
+| id             | Unique identifier for the text element   |
+| layerId        | Unique identifier for the Layer wrapper  |
 | from           | Name of a text preset to apply           |
 
 ### `shape`
@@ -233,6 +239,8 @@ Draw basic shapes within a slide.
 :::
 :::
 ```
+
+Supports a `from` attribute to apply presets and uses `layerClassName` and `layerId` to customize the Layer wrapper.
 
 | Input          | Description                                       |
 | -------------- | ------------------------------------------------- |
@@ -257,6 +265,8 @@ Draw basic shapes within a slide.
 | shadow         | Adds a drop shadow when true                      |
 | className      | Classes applied to the `<svg>` element            |
 | layerClassName | Classes applied to the Layer wrapper              |
+| id             | Unique identifier for the `<svg>` element         |
+| layerId        | Unique identifier for the Layer wrapper           |
 | style          | Inline styles applied to the `<svg>` element      |
 | from           | Name of a shape preset to apply                   |
 
@@ -280,6 +290,7 @@ Text
 | --------- | ----------------------------------------------------------------- |
 | as        | Element tag (`div`, `span`, `p`, or `section`, defaults to `div`) |
 | className | Additional classes applied to the element                         |
+| id        | Unique identifier for the element                                 |
 | from      | Name of a wrapper preset to apply                                 |
 
 Note: When a `wrapper` is placed inside a `trigger` directive block, it is rendered as the button’s label and takes precedence over the `label` attribute. Only one wrapper is allowed as a trigger label, and the wrapper must use an inline tag valid within a `<button>` (unsupported tags are coerced to `span`). This enables rich button labels (for example, adding icons or extra inline styling) without affecting the trigger’s click behavior.

--- a/docs/spec/markdown-directives.md
+++ b/docs/spec/markdown-directives.md
@@ -41,7 +41,7 @@ Special cases (validation enforced by remark plugin)
 
 - `trigger[label]` or `:::trigger{label="..."}`: `label` MUST be a quoted/backticked string.
 - `slide{transition="..."}` (and `deck > slide transition`): `transition` MUST be a quoted/backticked string.
-- `checkpoint|save|load|clearSave { id=... }`: `id` MUST be quoted unless it is a state key path. Unquoted literals (e.g., `id=foo`) are invalid; unquoted state keys (e.g., `id=cp.id`) are allowed.
+- `id` or `layerId` attributes across directives MUST be quoted/backticked strings unless referencing a state key path. Unquoted literals (e.g., `id=foo`) are invalid; unquoted state keys (e.g., `id=cp.id`) are allowed.
 
 Evaluation
 


### PR DESCRIPTION
## Summary
- document `id` and `layerId` support for deck, slide, reveal, layer, wrapper, text, image, and shape directives
- clarify that `id` and `layerId` attributes must be quoted unless referencing state keys

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68b70d2ec2a48322adecf45aeefaa802