### PR TITLE
feat(storybook): add french and thai translations

### DIFF
--- a/apps/storybook/src/Translate.stories.tsx
+++ b/apps/storybook/src/Translate.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/preact'
 import { h } from 'preact'
+import { useEffect, useState } from 'preact/hooks'
 import { Translate } from '@campfire/components'
 import i18next from 'i18next'
 import { initReactI18next } from 'react-i18next'
@@ -19,22 +20,44 @@ export default meta
  */
 export const Examples: StoryObj<typeof Translate> = {
   render: () => {
+    const [lang, setLang] = useState('en-US')
+
+    /**
+     * Initializes i18next with translation resources and updates language.
+     */
     const init = async () => {
       if (!i18next.isInitialized) {
         await i18next.use(initReactI18next).init({
-          lng: 'en-US',
-          resources: { 'en-US': { translation: { hello: 'Hello' } } }
+          lng: lang,
+          resources: {
+            'en-US': { translation: { hello: 'Hello' } },
+            fr: { translation: { hello: 'Bonjour' } },
+            th: { translation: { hello: 'สวัสดี' } }
+          }
         })
       } else {
-        await i18next.changeLanguage('en-US')
-        i18next.addResource('en-US', 'translation', 'hello', 'Hello')
+        await i18next.changeLanguage(lang)
       }
     }
-    void init()
+
+    useEffect(() => {
+      void init()
+    }, [lang])
+
     useGameStore.getState().setGameData({ greet: 'hello', player: 'Sam' })
     const player = useGameStore.getState().gameData.player as string
     return (
       <div className='flex flex-col gap-2'>
+        <select
+          className='campfire-language-select'
+          data-testid='language-select'
+          value={lang}
+          onChange={e => setLang((e.target as HTMLSelectElement).value)}
+        >
+          <option value='en-US'>English</option>
+          <option value='fr'>Français</option>
+          <option value='th'>ไทย</option>
+        </select>
         <Translate
           data-i18n-key='hello'
           className='text-[var(--color-primary-300)]'

--- a/apps/storybook/src/Translate.stories.tsx
+++ b/apps/storybook/src/Translate.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/preact'
 import { h } from 'preact'
-import { useEffect, useState } from 'preact/hooks'
+import { useState } from 'preact/hooks'
 import { Translate } from '@campfire/components'
 import i18next from 'i18next'
 import { initReactI18next } from 'react-i18next'
@@ -30,26 +30,27 @@ export const Examples: StoryObj<typeof Translate> = {
         await i18next.use(initReactI18next).init({
           lng: lang,
           resources: {
-            'en-US': { translation: { hello: 'Hello' } },
-            fr: { translation: { hello: 'Bonjour' } },
-            th: { translation: { hello: 'สวัสดี' } }
-          }
+            'en-US': { translation: { hello: 'Hello, {{player}}!' } },
+            fr: { translation: { hello: 'Bonjour {{player}}!' } },
+            th: { translation: { hello: 'สวัสดี {{player}}!' } },
+            ja: { translation: { hello: 'こんにちは、{{player}}さん！' } }
+          },
+          fallbackLng: 'en-US',
+          interpolation: { escapeValue: false }
         })
       } else {
         await i18next.changeLanguage(lang)
       }
     }
 
-    useEffect(() => {
-      void init()
-    }, [lang])
+    void init()
 
     useGameStore.getState().setGameData({ greet: 'hello', player: 'Sam' })
     const player = useGameStore.getState().gameData.player as string
     return (
       <div className='flex flex-col gap-2'>
         <select
-          className='campfire-language-select'
+          className='campfire-language-select bg-black text-white p-2 rounded'
           data-testid='language-select'
           value={lang}
           onChange={e => setLang((e.target as HTMLSelectElement).value)}
@@ -57,18 +58,16 @@ export const Examples: StoryObj<typeof Translate> = {
           <option value='en-US'>English</option>
           <option value='fr'>Français</option>
           <option value='th'>ไทย</option>
+          <option value='ja'>日本語</option>
         </select>
         <Translate
           data-i18n-key='hello'
           className='text-[var(--color-primary-300)]'
-        />
-        <Translate
-          data-i18n-expr='greet'
-          style={{ color: 'var(--color-destructive-500)' }}
+          data-i18n-vars={`{"player": "${player}"}`}
         />
         <Translate
           data-i18n-key='missing'
-          data-i18n-fallback={`Hello, ${player}!`}
+          data-i18n-fallback={`Hello, ${player}! (In case the key is missing)`}
           className='text-[var(--color-primary-500)]'
         />
       </div>


### PR DESCRIPTION
## Summary
- add language selector to Translate story
- provide French and Thai translation resources

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68b7142eb6888322af4cfa83ad320218