### PR TITLE
feat: support state-driven disabled directives

### DIFF
--- a/apps/campfire/src/components/Passage/Checkbox.tsx
+++ b/apps/campfire/src/components/Passage/Checkbox.tsx
@@ -18,6 +18,7 @@ interface CheckboxProps
     | 'onBlur'
     | 'onMouseEnter'
     | 'onMouseLeave'
+    | 'disabled'
   > {
   /** Key in game state to bind the checkbox value to. */
   stateKey: string
@@ -33,6 +34,8 @@ interface CheckboxProps
   onBlur?: string
   /** Initial value if the state key is unset. */
   initialValue?: boolean
+  /** Boolean or state key controlling the disabled state. */
+  disabled?: boolean | string
 }
 
 /**
@@ -56,12 +59,29 @@ export const Checkbox = ({
   onBlur,
   onClick,
   initialValue,
+  disabled,
   ...rest
 }: CheckboxProps) => {
   const value = useGameStore(state => state.gameData[stateKey]) as
     | boolean
     | string
     | undefined
+  const disabledState = useGameStore(state =>
+    typeof disabled === 'string' &&
+    disabled !== '' &&
+    disabled !== 'true' &&
+    disabled !== 'false'
+      ? state.gameData[disabled]
+      : undefined
+  ) as unknown
+  const isDisabled =
+    typeof disabled === 'string'
+      ? disabled === '' || disabled === 'true'
+        ? true
+        : disabled === 'false'
+          ? false
+          : Boolean(disabledState)
+      : Boolean(disabled)
   const directiveEvents = useDirectiveEvents(
     onMouseEnter,
     onMouseLeave,
@@ -87,11 +107,12 @@ export const Checkbox = ({
       className={mergeClasses('campfire-checkbox', checkboxStyles, className)}
       aria-checked={checked}
       data-state={checked ? 'checked' : 'unchecked'}
+      disabled={isDisabled}
       {...rest}
       {...directiveEvents}
       onClick={e => {
         onClick?.(e)
-        if (e.defaultPrevented) return
+        if (e.defaultPrevented || isDisabled) return
         setGameData({ [stateKey]: !checked })
       }}
     >

--- a/apps/campfire/src/components/Passage/Checkbox.tsx
+++ b/apps/campfire/src/components/Passage/Checkbox.tsx
@@ -1,7 +1,7 @@
 import type { JSX } from 'preact'
 import { useEffect } from 'preact/hooks'
 import { useDirectiveEvents } from '@campfire/hooks/useDirectiveEvents'
-import { mergeClasses } from '@campfire/utils/core'
+import { mergeClasses, evalExpression } from '@campfire/utils/core'
 import { useGameStore } from '@campfire/state/useGameStore'
 import {
   checkboxStyles,
@@ -66,22 +66,18 @@ export const Checkbox = ({
     | boolean
     | string
     | undefined
-  const disabledState = useGameStore(state =>
-    typeof disabled === 'string' &&
-    disabled !== '' &&
-    disabled !== 'true' &&
-    disabled !== 'false'
-      ? state.gameData[disabled]
-      : undefined
-  ) as unknown
-  const isDisabled =
-    typeof disabled === 'string'
-      ? disabled === '' || disabled === 'true'
-        ? true
-        : disabled === 'false'
-          ? false
-          : Boolean(disabledState)
-      : Boolean(disabled)
+  const isDisabled = useGameStore(state => {
+    if (typeof disabled === 'string') {
+      if (disabled === '' || disabled === 'true') return true
+      if (disabled === 'false') return false
+      try {
+        return Boolean(evalExpression(disabled, state.gameData))
+      } catch {
+        return false
+      }
+    }
+    return Boolean(disabled)
+  })
   const directiveEvents = useDirectiveEvents(
     onMouseEnter,
     onMouseLeave,

--- a/apps/campfire/src/components/Passage/Input.tsx
+++ b/apps/campfire/src/components/Passage/Input.tsx
@@ -17,6 +17,7 @@ interface InputProps
     | 'onBlur'
     | 'onMouseEnter'
     | 'onMouseLeave'
+    | 'disabled'
   > {
   /** Key in game state to bind the input value to. */
   stateKey: string
@@ -32,6 +33,8 @@ interface InputProps
   onBlur?: string
   /** Initial value if the state key is unset. */
   initialValue?: string
+  /** Boolean or state key controlling the disabled state. */
+  disabled?: boolean | string
 }
 
 /**
@@ -55,11 +58,28 @@ export const Input = ({
   onBlur,
   onInput,
   initialValue,
+  disabled,
   ...rest
 }: InputProps) => {
   const value = useGameStore(state => state.gameData[stateKey]) as
     | string
     | undefined
+  const disabledState = useGameStore(state =>
+    typeof disabled === 'string' &&
+    disabled !== '' &&
+    disabled !== 'true' &&
+    disabled !== 'false'
+      ? state.gameData[disabled]
+      : undefined
+  ) as unknown
+  const isDisabled =
+    typeof disabled === 'string'
+      ? disabled === '' || disabled === 'true'
+        ? true
+        : disabled === 'false'
+          ? false
+          : Boolean(disabledState)
+      : Boolean(disabled)
   const directiveEvents = useDirectiveEvents(
     onMouseEnter,
     onMouseLeave,
@@ -77,6 +97,7 @@ export const Input = ({
       data-testid='input'
       className={mergeClasses('campfire-input', inputStyles, className)}
       value={value ?? ''}
+      disabled={isDisabled}
       {...rest}
       {...directiveEvents}
       onInput={e => {

--- a/apps/campfire/src/components/Passage/Input.tsx
+++ b/apps/campfire/src/components/Passage/Input.tsx
@@ -1,7 +1,7 @@
 import type { JSX } from 'preact'
 import { useEffect } from 'preact/hooks'
 import { useDirectiveEvents } from '@campfire/hooks/useDirectiveEvents'
-import { mergeClasses } from '@campfire/utils/core'
+import { mergeClasses, evalExpression } from '@campfire/utils/core'
 import { useGameStore } from '@campfire/state/useGameStore'
 
 const inputStyles =
@@ -64,22 +64,18 @@ export const Input = ({
   const value = useGameStore(state => state.gameData[stateKey]) as
     | string
     | undefined
-  const disabledState = useGameStore(state =>
-    typeof disabled === 'string' &&
-    disabled !== '' &&
-    disabled !== 'true' &&
-    disabled !== 'false'
-      ? state.gameData[disabled]
-      : undefined
-  ) as unknown
-  const isDisabled =
-    typeof disabled === 'string'
-      ? disabled === '' || disabled === 'true'
-        ? true
-        : disabled === 'false'
-          ? false
-          : Boolean(disabledState)
-      : Boolean(disabled)
+  const isDisabled = useGameStore(state => {
+    if (typeof disabled === 'string') {
+      if (disabled === '' || disabled === 'true') return true
+      if (disabled === 'false') return false
+      try {
+        return Boolean(evalExpression(disabled, state.gameData))
+      } catch {
+        return false
+      }
+    }
+    return Boolean(disabled)
+  })
   const directiveEvents = useDirectiveEvents(
     onMouseEnter,
     onMouseLeave,

--- a/apps/campfire/src/components/Passage/Radio.tsx
+++ b/apps/campfire/src/components/Passage/Radio.tsx
@@ -1,7 +1,7 @@
 import type { JSX } from 'preact'
 import { useEffect } from 'preact/hooks'
 import { useDirectiveEvents } from '@campfire/hooks/useDirectiveEvents'
-import { mergeClasses } from '@campfire/utils/core'
+import { mergeClasses, evalExpression } from '@campfire/utils/core'
 import { useGameStore } from '@campfire/state/useGameStore'
 import { radioStyles, radioIndicatorStyles } from '@campfire/utils/remarkStyles'
 
@@ -66,22 +66,18 @@ export const Radio = ({
   const value = useGameStore(state => state.gameData[stateKey]) as
     | string
     | undefined
-  const disabledState = useGameStore(state =>
-    typeof disabled === 'string' &&
-    disabled !== '' &&
-    disabled !== 'true' &&
-    disabled !== 'false'
-      ? state.gameData[disabled]
-      : undefined
-  ) as unknown
-  const isDisabled =
-    typeof disabled === 'string'
-      ? disabled === '' || disabled === 'true'
-        ? true
-        : disabled === 'false'
-          ? false
-          : Boolean(disabledState)
-      : Boolean(disabled)
+  const isDisabled = useGameStore(state => {
+    if (typeof disabled === 'string') {
+      if (disabled === '' || disabled === 'true') return true
+      if (disabled === 'false') return false
+      try {
+        return Boolean(evalExpression(disabled, state.gameData))
+      } catch {
+        return false
+      }
+    }
+    return Boolean(disabled)
+  })
   const directiveEvents = useDirectiveEvents(
     onMouseEnter,
     onMouseLeave,

--- a/apps/campfire/src/components/Passage/Radio.tsx
+++ b/apps/campfire/src/components/Passage/Radio.tsx
@@ -15,6 +15,7 @@ interface RadioProps
     | 'onBlur'
     | 'onMouseEnter'
     | 'onMouseLeave'
+    | 'disabled'
   > {
   /** Key in game state to bind the radio selection to. */
   stateKey: string
@@ -32,6 +33,8 @@ interface RadioProps
   onBlur?: string
   /** Initial value if the state key is unset. */
   initialValue?: string
+  /** Boolean or state key controlling the disabled state. */
+  disabled?: boolean | string
 }
 
 /**
@@ -57,11 +60,28 @@ export const Radio = ({
   onBlur,
   onClick,
   initialValue,
+  disabled,
   ...rest
 }: RadioProps) => {
   const value = useGameStore(state => state.gameData[stateKey]) as
     | string
     | undefined
+  const disabledState = useGameStore(state =>
+    typeof disabled === 'string' &&
+    disabled !== '' &&
+    disabled !== 'true' &&
+    disabled !== 'false'
+      ? state.gameData[disabled]
+      : undefined
+  ) as unknown
+  const isDisabled =
+    typeof disabled === 'string'
+      ? disabled === '' || disabled === 'true'
+        ? true
+        : disabled === 'false'
+          ? false
+          : Boolean(disabledState)
+      : Boolean(disabled)
   const directiveEvents = useDirectiveEvents(
     onMouseEnter,
     onMouseLeave,
@@ -83,11 +103,12 @@ export const Radio = ({
       className={mergeClasses('campfire-radio', radioStyles, className)}
       aria-checked={checked}
       data-state={checked ? 'checked' : 'unchecked'}
+      disabled={isDisabled}
       {...rest}
       {...directiveEvents}
       onClick={e => {
         onClick?.(e)
-        if (e.defaultPrevented) return
+        if (e.defaultPrevented || isDisabled) return
         setGameData({ [stateKey]: optionValue })
       }}
     >

--- a/apps/campfire/src/components/Passage/Select.tsx
+++ b/apps/campfire/src/components/Passage/Select.tsx
@@ -17,6 +17,7 @@ interface SelectProps
     | 'onBlur'
     | 'onMouseEnter'
     | 'onMouseLeave'
+    | 'disabled'
   > {
   /** Key in game state to bind the select value to. */
   stateKey: string
@@ -36,6 +37,8 @@ interface SelectProps
   initialValue?: string
   /** Text shown when no option is selected. */
   label?: string
+  /** Boolean or state key controlling the disabled state. */
+  disabled?: boolean | string
 }
 
 /**
@@ -64,12 +67,29 @@ export const Select = ({
   children,
   initialValue,
   label,
+  disabled,
   ...rest
 }: SelectProps) => {
   const value = useGameStore(state => state.gameData[stateKey]) as
     | string
     | undefined
   const setGameData = useGameStore(state => state.setGameData)
+  const disabledState = useGameStore(state =>
+    typeof disabled === 'string' &&
+    disabled !== '' &&
+    disabled !== 'true' &&
+    disabled !== 'false'
+      ? state.gameData[disabled]
+      : undefined
+  ) as unknown
+  const isDisabled =
+    typeof disabled === 'string'
+      ? disabled === '' || disabled === 'true'
+        ? true
+        : disabled === 'false'
+          ? false
+          : Boolean(disabledState)
+      : Boolean(disabled)
   const directiveEvents = useDirectiveEvents(
     onMouseEnter,
     onMouseLeave,
@@ -123,9 +143,10 @@ export const Select = ({
         )}
         style={style}
         value={value ?? ''}
+        disabled={isDisabled}
         {...rest}
         {...directiveEvents}
-        onClick={() => setOpen(prev => !prev)}
+        onClick={() => !isDisabled && setOpen(prev => !prev)}
       >
         <span className='flex-1 truncate text-left pr-2'>
           {selected ? selected.props.children : (label ?? '')}

--- a/apps/campfire/src/components/Passage/Textarea.tsx
+++ b/apps/campfire/src/components/Passage/Textarea.tsx
@@ -1,7 +1,7 @@
 import type { JSX } from 'preact'
 import { useEffect } from 'preact/hooks'
 import { useDirectiveEvents } from '@campfire/hooks/useDirectiveEvents'
-import { mergeClasses } from '@campfire/utils/core'
+import { mergeClasses, evalExpression } from '@campfire/utils/core'
 import { useGameStore } from '@campfire/state/useGameStore'
 
 const textareaStyles =
@@ -64,22 +64,18 @@ export const Textarea = ({
   const value = useGameStore(state => state.gameData[stateKey]) as
     | string
     | undefined
-  const disabledState = useGameStore(state =>
-    typeof disabled === 'string' &&
-    disabled !== '' &&
-    disabled !== 'true' &&
-    disabled !== 'false'
-      ? state.gameData[disabled]
-      : undefined
-  ) as unknown
-  const isDisabled =
-    typeof disabled === 'string'
-      ? disabled === '' || disabled === 'true'
-        ? true
-        : disabled === 'false'
-          ? false
-          : Boolean(disabledState)
-      : Boolean(disabled)
+  const isDisabled = useGameStore(state => {
+    if (typeof disabled === 'string') {
+      if (disabled === '' || disabled === 'true') return true
+      if (disabled === 'false') return false
+      try {
+        return Boolean(evalExpression(disabled, state.gameData))
+      } catch {
+        return false
+      }
+    }
+    return Boolean(disabled)
+  })
   const directiveEvents = useDirectiveEvents(
     onMouseEnter,
     onMouseLeave,

--- a/apps/campfire/src/components/Passage/Textarea.tsx
+++ b/apps/campfire/src/components/Passage/Textarea.tsx
@@ -17,6 +17,7 @@ interface TextareaProps
     | 'onBlur'
     | 'onMouseEnter'
     | 'onMouseLeave'
+    | 'disabled'
   > {
   /** Key in game state to bind the textarea value to. */
   stateKey: string
@@ -32,6 +33,8 @@ interface TextareaProps
   onBlur?: string
   /** Initial value if the state key is unset. */
   initialValue?: string
+  /** Boolean or state key controlling the disabled state. */
+  disabled?: boolean | string
 }
 
 /**
@@ -55,11 +58,28 @@ export const Textarea = ({
   onBlur,
   onInput,
   initialValue,
+  disabled,
   ...rest
 }: TextareaProps) => {
   const value = useGameStore(state => state.gameData[stateKey]) as
     | string
     | undefined
+  const disabledState = useGameStore(state =>
+    typeof disabled === 'string' &&
+    disabled !== '' &&
+    disabled !== 'true' &&
+    disabled !== 'false'
+      ? state.gameData[disabled]
+      : undefined
+  ) as unknown
+  const isDisabled =
+    typeof disabled === 'string'
+      ? disabled === '' || disabled === 'true'
+        ? true
+        : disabled === 'false'
+          ? false
+          : Boolean(disabledState)
+      : Boolean(disabled)
   const directiveEvents = useDirectiveEvents(
     onMouseEnter,
     onMouseLeave,
@@ -77,6 +97,7 @@ export const Textarea = ({
       data-testid='textarea'
       className={mergeClasses('campfire-textarea', textareaStyles, className)}
       value={value ?? ''}
+      disabled={isDisabled}
       {...rest}
       {...directiveEvents}
       onInput={e => {

--- a/apps/campfire/src/components/Passage/TriggerButton.tsx
+++ b/apps/campfire/src/components/Passage/TriggerButton.tsx
@@ -2,7 +2,7 @@ import type { RootContent } from 'mdast'
 import rfdc from 'rfdc'
 import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
 import { runDirectiveBlock } from '@campfire/utils/directiveUtils'
-import { mergeClasses } from '@campfire/utils/core'
+import { mergeClasses, evalExpression } from '@campfire/utils/core'
 import type { JSX } from 'preact'
 import { useDirectiveEvents } from '@campfire/hooks/useDirectiveEvents'
 import { useGameStore } from '@campfire/state/useGameStore'
@@ -66,22 +66,18 @@ export const TriggerButton = ({
     onFocus,
     onBlur
   )
-  const disabledState = useGameStore(state =>
-    typeof disabled === 'string' &&
-    disabled !== '' &&
-    disabled !== 'true' &&
-    disabled !== 'false'
-      ? state.gameData[disabled]
-      : undefined
-  ) as unknown
-  const isDisabled =
-    typeof disabled === 'string'
-      ? disabled === '' || disabled === 'true'
-        ? true
-        : disabled === 'false'
-          ? false
-          : Boolean(disabledState)
-      : Boolean(disabled)
+  const isDisabled = useGameStore(state => {
+    if (typeof disabled === 'string') {
+      if (disabled === '' || disabled === 'true') return true
+      if (disabled === 'false') return false
+      try {
+        return Boolean(evalExpression(disabled, state.gameData))
+      } catch {
+        return false
+      }
+    }
+    return Boolean(disabled)
+  })
   return (
     <button
       type='button'

--- a/apps/campfire/src/hooks/__tests__/disabledDirectives.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/disabledDirectives.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach } from 'bun:test'
+import { render, act } from '@testing-library/preact'
+import type { ComponentChild } from 'preact'
+import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
+import { renderDirectiveMarkdown } from '@campfire/components/Deck/Slide'
+import { useGameStore } from '@campfire/state/useGameStore'
+import { resetStores } from '@campfire/test-utils/helpers'
+
+let output: ComponentChild | null = null
+
+/**
+ * Component used in tests to render markdown with directive handlers.
+ *
+ * @param markdown - Markdown string including various directives.
+ * @returns Rendered content.
+ */
+const MarkdownRunner = ({ markdown }: { markdown: string }) => {
+  const handlers = useDirectiveHandlers()
+  output = renderDirectiveMarkdown(markdown, handlers)
+  return <>{output}</>
+}
+
+beforeEach(() => {
+  output = null
+  document.body.innerHTML = ''
+  resetStores()
+})
+
+describe('disabled state directives', () => {
+  it('toggles disabled attribute based on state', async () => {
+    useGameStore.setState({ gameData: { disabled: true } })
+    const md =
+      ':input[name]{disabled=disabled}\n' +
+      ':::select[color]{disabled=disabled}\n' +
+      ':option{value="r" label="Red"}\n' +
+      ':::\n' +
+      ':radio[choice]{value="a" disabled=disabled}\n' +
+      ':checkbox[check]{disabled=disabled}\n' +
+      ':textarea[bio]{disabled=disabled}\n' +
+      ':::trigger{label="Go" disabled=disabled}\n' +
+      ':::\n'
+    render(<MarkdownRunner markdown={md} />)
+    const trigger = document.querySelector(
+      '[data-testid="trigger-button"]'
+    ) as HTMLButtonElement
+    const input = document.querySelector(
+      '[data-testid="input"]'
+    ) as HTMLInputElement
+    const select = document.querySelector(
+      '[data-testid="select"]'
+    ) as HTMLButtonElement
+    const radio = document.querySelector(
+      '[data-testid="radio"]'
+    ) as HTMLButtonElement
+    const checkbox = document.querySelector(
+      '[data-testid="checkbox"]'
+    ) as HTMLButtonElement
+    const textarea = document.querySelector(
+      '[data-testid="textarea"]'
+    ) as HTMLTextAreaElement
+    expect(trigger.disabled).toBe(true)
+    expect(input.disabled).toBe(true)
+    expect(select.disabled).toBe(true)
+    expect(radio.disabled).toBe(true)
+    expect(checkbox.disabled).toBe(true)
+    expect(textarea.disabled).toBe(true)
+    await act(() => useGameStore.getState().setGameData({ disabled: false }))
+    expect(trigger.disabled).toBe(false)
+    expect(input.disabled).toBe(false)
+    expect(select.disabled).toBe(false)
+    expect(radio.disabled).toBe(false)
+    expect(checkbox.disabled).toBe(false)
+    expect(textarea.disabled).toBe(false)
+  })
+})

--- a/apps/campfire/src/hooks/__tests__/disabledDirectives.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/disabledDirectives.test.tsx
@@ -27,7 +27,7 @@ beforeEach(() => {
 })
 
 describe('disabled state directives', () => {
-  it('toggles disabled attribute based on state', async () => {
+  it('toggles disabled attribute based on state key', async () => {
     useGameStore.setState({ gameData: { disabled: true } })
     const md =
       ':input[name]{disabled=disabled}\n' +
@@ -71,5 +71,51 @@ describe('disabled state directives', () => {
     expect(radio.disabled).toBe(false)
     expect(checkbox.disabled).toBe(false)
     expect(textarea.disabled).toBe(false)
+  })
+
+  it('toggles disabled attribute based on an expression', async () => {
+    useGameStore.setState({ gameData: { count: 1 } })
+    const md =
+      ':input[name]{disabled="count>2"}\n' +
+      ':::select[color]{disabled="count>2"}\n' +
+      ':option{value="r" label="Red"}\n' +
+      ':::\n' +
+      ':radio[choice]{value="a" disabled="count>2"}\n' +
+      ':checkbox[check]{disabled="count>2"}\n' +
+      ':textarea[bio]{disabled="count>2"}\n' +
+      ':::trigger{label="Go" disabled="count>2"}\n' +
+      ':::\n'
+    render(<MarkdownRunner markdown={md} />)
+    const trigger = document.querySelector(
+      '[data-testid="trigger-button"]'
+    ) as HTMLButtonElement
+    const input = document.querySelector(
+      '[data-testid="input"]'
+    ) as HTMLInputElement
+    const select = document.querySelector(
+      '[data-testid="select"]'
+    ) as HTMLButtonElement
+    const radio = document.querySelector(
+      '[data-testid="radio"]'
+    ) as HTMLButtonElement
+    const checkbox = document.querySelector(
+      '[data-testid="checkbox"]'
+    ) as HTMLButtonElement
+    const textarea = document.querySelector(
+      '[data-testid="textarea"]'
+    ) as HTMLTextAreaElement
+    expect(trigger.disabled).toBe(false)
+    expect(input.disabled).toBe(false)
+    expect(select.disabled).toBe(false)
+    expect(radio.disabled).toBe(false)
+    expect(checkbox.disabled).toBe(false)
+    expect(textarea.disabled).toBe(false)
+    await act(() => useGameStore.getState().setGameData({ count: 3 }))
+    expect(trigger.disabled).toBe(true)
+    expect(input.disabled).toBe(true)
+    expect(select.disabled).toBe(true)
+    expect(radio.disabled).toBe(true)
+    expect(checkbox.disabled).toBe(true)
+    expect(textarea.disabled).toBe(true)
   })
 })

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -1751,10 +1751,7 @@ export const useDirectiveHandlers = () => {
     const defaultLabel =
       typeof attrs.label === 'string' ? attrs.label : getLabel(container)
     const classAttr = typeof attrs.className === 'string' ? attrs.className : ''
-    const disabled =
-      typeof attrs.disabled === 'string'
-        ? attrs.disabled !== 'false'
-        : Boolean(attrs.disabled)
+    const disabledAttr = attrs.disabled
     const styleAttr = typeof attrs.style === 'string' ? attrs.style : undefined
     // Prepare two views of children:
     // 1) A limited-processed view that only resolves wrapper elements for label detection
@@ -1902,7 +1899,7 @@ export const useDirectiveHandlers = () => {
     const hProps: Record<string, unknown> = {
       className: classes,
       content: JSON.stringify(finalContentNodes),
-      disabled,
+      ...(disabledAttr !== undefined ? { disabled: disabledAttr } : {}),
       ...(styleAttr ? { style: styleAttr } : {})
     }
     if (events.onMouseEnter) hProps.onMouseEnter = events.onMouseEnter

--- a/docs/directives/inputs-and-events.md
+++ b/docs/directives/inputs-and-events.md
@@ -26,14 +26,15 @@ Container form:
 :::
 ```
 
-| Input       | Description                                |
-| ----------- | ------------------------------------------ |
-| state_key   | Key in game state to store the input value |
-| placeholder | Optional text shown when empty             |
-| value       | Initial value when the state key is unset  |
-| type        | Optional input `type` attribute            |
-| className   | Optional space-separated classes           |
-| style       | Optional inline style declarations         |
+| Input       | Description                                        |
+| ----------- | -------------------------------------------------- |
+| state_key   | Key in game state to store the input value         |
+| placeholder | Optional text shown when empty                     |
+| value       | Initial value when the state key is unset          |
+| type        | Optional input `type` attribute                    |
+| className   | Optional space-separated classes                   |
+| disabled    | Optional boolean or state key to disable the input |
+| style       | Optional inline style declarations                 |
 
 ### `textarea`
 
@@ -55,14 +56,15 @@ Container form:
 :::
 ```
 
-| Input       | Description                                   |
-| ----------- | --------------------------------------------- |
-| state_key   | Key in game state to store the textarea value |
-| placeholder | Optional text shown when empty                |
-| rows        | Optional number of visible text rows          |
-| value       | Initial value when the state key is unset     |
-| className   | Optional space-separated classes              |
-| style       | Optional inline style declarations            |
+| Input       | Description                                           |
+| ----------- | ----------------------------------------------------- |
+| state_key   | Key in game state to store the textarea value         |
+| placeholder | Optional text shown when empty                        |
+| rows        | Optional number of visible text rows                  |
+| value       | Initial value when the state key is unset             |
+| className   | Optional space-separated classes                      |
+| disabled    | Optional boolean or state key to disable the textarea |
+| style       | Optional inline style declarations                    |
 
 ### `select`
 
@@ -75,13 +77,14 @@ Render a dropdown bound to a game state key. Must be used as a container with ne
 :::
 ```
 
-| Input     | Description                                  |
-| --------- | -------------------------------------------- |
-| state_key | Key in game state to store the select value  |
-| className | Optional space-separated classes             |
-| style     | Optional inline style declarations           |
-| value     | Initial selected value when the key is unset |
-| label     | Text displayed when no option is selected    |
+| Input     | Description                                         |
+| --------- | --------------------------------------------------- |
+| state_key | Key in game state to store the select value         |
+| className | Optional space-separated classes                    |
+| disabled  | Optional boolean or state key to disable the select |
+| style     | Optional inline style declarations                  |
+| value     | Initial selected value when the key is unset        |
+| label     | Text displayed when no option is selected           |
 
 The select button uses the same default styling as trigger and link buttons and includes a downward caret on the right. The menu closes when clicking outside the button or pressing Escape.
 
@@ -93,6 +96,63 @@ The select button uses the same default styling as trigger and link buttons and 
 | label     | Text displayed for the option      |
 | className | Optional space-separated classes   |
 | style     | Optional inline style declarations |
+
+### `checkbox`
+
+Render a toggle bound to a game state key. Use as a leaf or container. The container form can include event directives. If the key already exists in game state, its value is used; otherwise, the optional `value` attribute sets the starting value.
+
+Leaf form:
+
+```md
+:checkbox[agree]
+```
+
+Container form:
+
+```md
+:::checkbox[agree]
+:::onFocus
+:set[focused=true]
+:::
+:::
+```
+
+| Input     | Description                                           |
+| --------- | ----------------------------------------------------- |
+| state_key | Key in game state to store the checkbox value         |
+| value     | Initial value when the state key is unset             |
+| className | Optional space-separated classes                      |
+| disabled  | Optional boolean or state key to disable the checkbox |
+| style     | Optional inline style declarations                    |
+
+### `radio`
+
+Render a radio button bound to a game state key. Use multiple radios with the same key to build a group. Use as a leaf or container. The container form can include event directives. If the key already exists in game state, its value is used; otherwise, the optional `checked` attribute sets the starting value.
+
+Leaf form:
+
+```md
+:radio[color]{value="red"}
+```
+
+Container form:
+
+```md
+:::radio[color]{value="red"}
+:::onFocus
+:set[focused=true]
+:::
+:::
+```
+
+| Input     | Description                                        |
+| --------- | -------------------------------------------------- |
+| state_key | Key in game state to store the selected value      |
+| value     | Value represented by this radio button             |
+| checked   | Initial selected value when the state key is unset |
+| className | Optional space-separated classes                   |
+| disabled  | Optional boolean or state key to disable the radio |
+| style     | Optional inline style declarations                 |
 
 ### `trigger`
 
@@ -133,7 +193,7 @@ In this case, the `wrapper` content (“Start”) is used as the button label, a
 | --------- | ---------------------------------------------------------------------- |
 | label     | Text displayed on the button (ignored when a wrapper child is present) |
 | className | Optional space-separated classes                                       |
-| disabled  | Optional boolean to disable the button                                 |
+| disabled  | Optional boolean or state key to disable the button                    |
 | style     | Optional inline style declarations                                     |
 
 ### Event directives

--- a/docs/directives/inputs-and-events.md
+++ b/docs/directives/inputs-and-events.md
@@ -26,15 +26,15 @@ Container form:
 :::
 ```
 
-| Input       | Description                                        |
-| ----------- | -------------------------------------------------- |
-| state_key   | Key in game state to store the input value         |
-| placeholder | Optional text shown when empty                     |
-| value       | Initial value when the state key is unset          |
-| type        | Optional input `type` attribute                    |
-| className   | Optional space-separated classes                   |
-| disabled    | Optional boolean or state key to disable the input |
-| style       | Optional inline style declarations                 |
+| Input       | Description                                                     |
+| ----------- | --------------------------------------------------------------- |
+| state_key   | Key in game state to store the input value                      |
+| placeholder | Optional text shown when empty                                  |
+| value       | Initial value when the state key is unset                       |
+| type        | Optional input `type` attribute                                 |
+| className   | Optional space-separated classes                                |
+| disabled    | Optional boolean, state key, or expression to disable the input |
+| style       | Optional inline style declarations                              |
 
 ### `textarea`
 
@@ -56,15 +56,15 @@ Container form:
 :::
 ```
 
-| Input       | Description                                           |
-| ----------- | ----------------------------------------------------- |
-| state_key   | Key in game state to store the textarea value         |
-| placeholder | Optional text shown when empty                        |
-| rows        | Optional number of visible text rows                  |
-| value       | Initial value when the state key is unset             |
-| className   | Optional space-separated classes                      |
-| disabled    | Optional boolean or state key to disable the textarea |
-| style       | Optional inline style declarations                    |
+| Input       | Description                                                        |
+| ----------- | ------------------------------------------------------------------ |
+| state_key   | Key in game state to store the textarea value                      |
+| placeholder | Optional text shown when empty                                     |
+| rows        | Optional number of visible text rows                               |
+| value       | Initial value when the state key is unset                          |
+| className   | Optional space-separated classes                                   |
+| disabled    | Optional boolean, state key, or expression to disable the textarea |
+| style       | Optional inline style declarations                                 |
 
 ### `select`
 
@@ -77,14 +77,14 @@ Render a dropdown bound to a game state key. Must be used as a container with ne
 :::
 ```
 
-| Input     | Description                                         |
-| --------- | --------------------------------------------------- |
-| state_key | Key in game state to store the select value         |
-| className | Optional space-separated classes                    |
-| disabled  | Optional boolean or state key to disable the select |
-| style     | Optional inline style declarations                  |
-| value     | Initial selected value when the key is unset        |
-| label     | Text displayed when no option is selected           |
+| Input     | Description                                                      |
+| --------- | ---------------------------------------------------------------- |
+| state_key | Key in game state to store the select value                      |
+| className | Optional space-separated classes                                 |
+| disabled  | Optional boolean, state key, or expression to disable the select |
+| style     | Optional inline style declarations                               |
+| value     | Initial selected value when the key is unset                     |
+| label     | Text displayed when no option is selected                        |
 
 The select button uses the same default styling as trigger and link buttons and includes a downward caret on the right. The menu closes when clicking outside the button or pressing Escape.
 
@@ -117,13 +117,13 @@ Container form:
 :::
 ```
 
-| Input     | Description                                           |
-| --------- | ----------------------------------------------------- |
-| state_key | Key in game state to store the checkbox value         |
-| value     | Initial value when the state key is unset             |
-| className | Optional space-separated classes                      |
-| disabled  | Optional boolean or state key to disable the checkbox |
-| style     | Optional inline style declarations                    |
+| Input     | Description                                                        |
+| --------- | ------------------------------------------------------------------ |
+| state_key | Key in game state to store the checkbox value                      |
+| value     | Initial value when the state key is unset                          |
+| className | Optional space-separated classes                                   |
+| disabled  | Optional boolean, state key, or expression to disable the checkbox |
+| style     | Optional inline style declarations                                 |
 
 ### `radio`
 
@@ -145,14 +145,14 @@ Container form:
 :::
 ```
 
-| Input     | Description                                        |
-| --------- | -------------------------------------------------- |
-| state_key | Key in game state to store the selected value      |
-| value     | Value represented by this radio button             |
-| checked   | Initial selected value when the state key is unset |
-| className | Optional space-separated classes                   |
-| disabled  | Optional boolean or state key to disable the radio |
-| style     | Optional inline style declarations                 |
+| Input     | Description                                                     |
+| --------- | --------------------------------------------------------------- |
+| state_key | Key in game state to store the selected value                   |
+| value     | Value represented by this radio button                          |
+| checked   | Initial selected value when the state key is unset              |
+| className | Optional space-separated classes                                |
+| disabled  | Optional boolean, state key, or expression to disable the radio |
+| style     | Optional inline style declarations                              |
 
 ### `trigger`
 
@@ -193,7 +193,7 @@ In this case, the `wrapper` content (“Start”) is used as the button label, a
 | --------- | ---------------------------------------------------------------------- |
 | label     | Text displayed on the button (ignored when a wrapper child is present) |
 | className | Optional space-separated classes                                       |
-| disabled  | Optional boolean or state key to disable the button                    |
+| disabled  | Optional boolean, state key, or expression to disable the button       |
 | style     | Optional inline style declarations                                     |
 
 ### Event directives


### PR DESCRIPTION
## Summary
- support state-controlled `disabled` for trigger, input, select, radio, checkbox and textarea directives
- test state toggling of `disabled` attributes

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68b720bab5cc8322a16504dbb94e4f55