### PR TITLE
fix: avoid paragraph wrapper around image directive

### DIFF
--- a/apps/campfire/src/hooks/__tests__/imageDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/imageDirective.test.tsx
@@ -51,6 +51,15 @@ describe('image directive', () => {
     expect(img.style.border).toBe('1px solid red')
   })
 
+  it('does not wrap SlideImage in a paragraph', () => {
+    const md = ':::reveal\n:image{src="https://example.com/cat.png"}\n:::\n'
+    render(<MarkdownRunner markdown={md} />)
+    const el = document.querySelector(
+      '[data-testid="slideImage"]'
+    ) as HTMLElement
+    expect(el.closest('p')).toBeNull()
+  })
+
   it('applies image presets with overrides', () => {
     const md =
       ':preset{type="image" name="cat" x=5 y=5 src="https://example.com/cat.png"}\n:::reveal\n:image{from="cat" y=10}\n:::\n'

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -3591,11 +3591,21 @@ export const useDirectiveHandlers = () => {
       'layerId',
       'from'
     ])
-    const node: Parent = {
-      type: 'paragraph',
-      children: [],
-      data: { hName: 'slideImage', hProperties: props as Properties }
+    const data = {
+      hName: 'slideImage',
+      hProperties: props as Properties
     }
+    if (parent.type === 'paragraph') {
+      const others = parent.children.filter(
+        child => child !== directive && !isWhitespaceNode(child as RootContent)
+      )
+      if (others.length === 0) {
+        parent.children = []
+        ;(parent as Parent).data = data
+        return index
+      }
+    }
+    const node: Parent = { type: 'paragraph', children: [], data }
     return replaceWithIndentation(directive, parent, index, [
       node as RootContent
     ])


### PR DESCRIPTION
## Summary
- ensure `:image` directive doesn't wrap `slideImage` in `<p>`
- add regression test for image directive paragraph wrapping

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_68b7452ffa18832288cab9a7d84c3b96