### PR TITLE
fix: preserve hyphenated strings during attr parsing

### DIFF
--- a/apps/campfire/src/hooks/__tests__/imageDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/imageDirective.test.tsx
@@ -51,6 +51,17 @@ describe('image directive', () => {
     expect(img.style.border).toBe('1px solid red')
   })
 
+  it('handles hyphenated class names without evaluation', () => {
+    const md =
+      ':::reveal\n:image{src="https://example.com/cat.png" className="w-full"}\n:::\n'
+    render(<MarkdownRunner markdown={md} />)
+    const img = document.querySelector(
+      '[data-testid="slideImage"] img'
+    ) as HTMLImageElement
+    expect(img.className).toContain('campfire-slide-image')
+    expect(img.className).toContain('w-full')
+  })
+
   it('does not wrap SlideImage in a paragraph', () => {
     const md = ':::reveal\n:image{src="https://example.com/cat.png"}\n:::\n'
     render(<MarkdownRunner markdown={md} />)

--- a/apps/campfire/src/utils/directiveUtils.ts
+++ b/apps/campfire/src/utils/directiveUtils.ts
@@ -259,6 +259,7 @@ export const parseAttributeValue = (
         if (spec.expression === false) return raw
         const evaluated = evalExpr(raw)
         if (typeof evaluated === 'string') return evaluated
+        if (typeof evaluated === 'number' && Number.isNaN(evaluated)) return raw
         return evaluated != null ? String(evaluated) : raw
       }
       return String(raw)


### PR DESCRIPTION
## Summary
- prevent expression parsing from turning hyphenated strings into `NaN`
- cover hyphenated class names in image directive tests

## Testing
- `bun tsc && echo tsc OK`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_68b747dee0388322969d816a8f9a78d0