### PR TITLE
feat: support leaf image directive

### DIFF
--- a/apps/campfire/src/components/Passage/__tests__/Passage.imageDirective.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Passage.imageDirective.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, beforeEach, expect } from 'bun:test'
+import { render, screen } from '@testing-library/preact'
+import i18next from 'i18next'
+import { initReactI18next } from 'react-i18next'
+import type { Element } from 'hast'
+import { Passage } from '@campfire/components/Passage/Passage'
+import { useStoryDataStore } from '@campfire/state/useStoryDataStore'
+import { resetStores } from '@campfire/test-utils/helpers'
+
+/**
+ * Verifies that multiple image directives render each image on a slide.
+ */
+describe('Passage image directive', () => {
+  beforeEach(async () => {
+    document.body.innerHTML = ''
+    resetStores()
+    ;(HTMLElement.prototype as any).animate = () => ({
+      finished: Promise.resolve(),
+      cancel() {},
+      finish() {}
+    })
+    if (!i18next.isInitialized) {
+      await i18next.use(initReactI18next).init({ lng: 'en-US', resources: {} })
+    } else {
+      await i18next.changeLanguage('en-US')
+      i18next.services.resourceStore.data = {}
+    }
+  })
+
+  it('renders multiple SlideImage components', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value: `:::deck{size='1280x720' showNav=false}
+  :::slide
+    :::reveal{at=0}
+      ::image{src='https://placecats.com/bella/1280/360'}
+
+      ::image{src='https://placecats.com/neo/250/250' x=50 y=250 className='rounded-full shadow-lg'}
+    :::
+  :::
+:::`
+        }
+      ]
+    }
+    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+    render(<Passage />)
+    const images = await screen.findAllByTestId('slideImage')
+    expect(images).toHaveLength(2)
+    expect(images[0].querySelector('img')?.getAttribute('src')).toBe(
+      'https://placecats.com/bella/1280/360'
+    )
+    expect(images[1].querySelector('img')?.getAttribute('src')).toBe(
+      'https://placecats.com/neo/250/250'
+    )
+  })
+})

--- a/apps/campfire/src/hooks/__tests__/imageDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/imageDirective.test.tsx
@@ -31,7 +31,7 @@ beforeEach(() => {
 describe('image directive', () => {
   it('renders a SlideImage component with props', () => {
     const md =
-      ':::reveal\n:image{src="https://example.com/cat.png" x=10 y=20 alt="Cat" className="rounded" layerClassName="wrapper" style="border:1px solid red" data-test="ok"}\n:::\n'
+      ':::reveal\n::image{src="https://example.com/cat.png" x=10 y=20 alt="Cat" className="rounded" layerClassName="wrapper" style="border:1px solid red" data-test="ok"}\n:::\n'
     render(<MarkdownRunner markdown={md} />)
     const el = document.querySelector(
       '[data-testid="slideImage"]'
@@ -53,7 +53,7 @@ describe('image directive', () => {
 
   it('handles hyphenated class names without evaluation', () => {
     const md =
-      ':::reveal\n:image{src="https://example.com/cat.png" className="w-full"}\n:::\n'
+      ':::reveal\n::image{src="https://example.com/cat.png" className="w-full"}\n:::\n'
     render(<MarkdownRunner markdown={md} />)
     const img = document.querySelector(
       '[data-testid="slideImage"] img'
@@ -63,7 +63,7 @@ describe('image directive', () => {
   })
 
   it('does not wrap SlideImage in a paragraph', () => {
-    const md = ':::reveal\n:image{src="https://example.com/cat.png"}\n:::\n'
+    const md = ':::reveal\n::image{src="https://example.com/cat.png"}\n:::\n'
     render(<MarkdownRunner markdown={md} />)
     const el = document.querySelector(
       '[data-testid="slideImage"]'
@@ -73,7 +73,7 @@ describe('image directive', () => {
 
   it('applies image presets with overrides', () => {
     const md =
-      ':preset{type="image" name="cat" x=5 y=5 src="https://example.com/cat.png"}\n:::reveal\n:image{from="cat" y=10}\n:::\n'
+      ':preset{type="image" name="cat" x=5 y=5 src="https://example.com/cat.png"}\n:::reveal\n::image{from="cat" y=10}\n:::\n'
     render(<MarkdownRunner markdown={md} />)
     const el = document.querySelector(
       '[data-testid="slideImage"]'
@@ -86,7 +86,7 @@ describe('image directive', () => {
 
   it('applies class names from presets', () => {
     const md =
-      ':preset{type="image" name="cat" className="rounded" layerClassName="wrap" src="https://example.com/cat.png"}\n:::reveal\n:image{from="cat"}\n:::\n'
+      ':preset{type="image" name="cat" className="rounded" layerClassName="wrap" src="https://example.com/cat.png"}\n:::reveal\n::image{from="cat"}\n:::\n'
     render(<MarkdownRunner markdown={md} />)
     const el = document.querySelector(
       '[data-testid="slideImage"]'

--- a/apps/campfire/src/hooks/__tests__/triggerDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/triggerDirective.test.tsx
@@ -32,7 +32,7 @@ describe('trigger directive', () => {
       ':::trigger{label="Fire"}\n' +
       ':::wrapper{as="span"}\n' +
       'Run\n' +
-      ':image{src="https://placehold.co/32"}\n' +
+      '::image{src="https://placehold.co/32"}\n' +
       ':::\n' +
       ':set[fired=true]\n' +
       ':::\n'

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -3525,7 +3525,7 @@ export const useDirectiveHandlers = () => {
   }
 
   /**
-   * Converts a `:image` directive into a SlideImage element.
+   * Converts an `image` directive into a SlideImage element.
    *
    * @param directive - The image directive node.
    * @param parent - Parent node containing the directive.
@@ -3534,8 +3534,8 @@ export const useDirectiveHandlers = () => {
    */
   const handleImage: DirectiveHandler = (directive, parent, index) => {
     if (!parent || typeof index !== 'number') return
-    if (directive.type !== 'textDirective') {
-      const msg = 'image can only be used as a leaf directive'
+    if (directive.type === 'containerDirective') {
+      const msg = 'image can only be used as an inline or leaf directive'
       console.error(msg)
       addError(msg)
       return removeNode(parent, index)

--- a/docs/directives/asset-management.md
+++ b/docs/directives/asset-management.md
@@ -11,7 +11,7 @@ Position an image within a slide.
 ```md
 :::deck
 :::slide
-:image{id='cat' layerId='cat-layer' src='https://example.com/cat.png' x=10 y=20}
+::image{id='cat' layerId='cat-layer' src='https://example.com/cat.png' x=10 y=20}
 :::
 :::
 ```

--- a/docs/spec/markdown-directives.md
+++ b/docs/spec/markdown-directives.md
@@ -11,8 +11,8 @@ This document defines the normative behavior for Campfire’s Markdown directive
 ## Terminology
 
 - Container directive: Block directive that can contain child nodes. Written with leading and trailing `:::` markers (e.g., `:::if … :::`).
-- Leaf directive: Standalone directive with no nested block (e.g., `:set{key="v"}`).
-- Text directive: Inline directive syntax parsed by `remark-directive`.
+- Leaf directive: Block-level directive with no nested content. Written with leading `::` markers (e.g., `::image{src="cat.png"}`).
+- Inline directive: Directive embedded in text flow, written with a single leading `:` (e.g., `:show[hp]`). Parsed by `remark-directive` as a text directive.
 - Label: The optional first paragraph inside a container used to carry short values (e.g., an expression for `if`, a locale for `lang`).
 - Marker: A paragraph composed solely of directive marker tokens `:::` and whitespace.
 - State key: Unquoted identifier path referencing game state (e.g., `user.name`, `items[0]`).
@@ -20,8 +20,8 @@ This document defines the normative behavior for Campfire’s Markdown directive
 ## Syntax
 
 - Container: `:::name[optional-label]{attrs}\n…children…\n:::`
-- Leaf: `:name[optional-label]{attrs}`
-- Inline/text: `:name[...]` in text flow (parsed by `remark-directive`).
+- Leaf: `::name[optional-label]{attrs}`
+- Inline: `:name[optional-label]{attrs}` in text flow.
 
 Notes
 


### PR DESCRIPTION
## Summary
- allow `image` directive to be used as a leaf (`::image`)
- clarify documentation for leaf vs inline directives
- update tests and examples to use leaf image syntax

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68b74d2ede808322b43c0abfd5146671