### PR TITLE
docs: use leaf unset directive in stories

### DIFF
--- a/apps/storybook/src/InputDirective.stories.tsx
+++ b/apps/storybook/src/InputDirective.stories.tsx
@@ -48,7 +48,7 @@ export const WithEvents: StoryObj = {
   ::set[focused=true]
 :::
 :::onBlur
-  :unset[focused]
+  ::unset{key=focused}
 :::
 :::if[focused]
 

--- a/apps/storybook/src/SelectDirective.stories.tsx
+++ b/apps/storybook/src/SelectDirective.stories.tsx
@@ -72,7 +72,7 @@ export const WithEvents: StoryObj = {
 :::
 
 :::onBlur
-  :unset[focused]
+  ::unset{key=focused}
 :::
 
 :::if[focused]

--- a/apps/storybook/src/TextareaDirective.stories.tsx
+++ b/apps/storybook/src/TextareaDirective.stories.tsx
@@ -48,7 +48,7 @@ export const WithEvents: StoryObj = {
   ::set[focused=true]
 :::
 :::onBlur
-  :unset[focused]
+  ::unset{key=focused}
 :::
 :::if[focused]
 

--- a/apps/storybook/src/TriggerDirective.stories.tsx
+++ b/apps/storybook/src/TriggerDirective.stories.tsx
@@ -31,7 +31,7 @@ You clicked the button!
 :::
 
 :::onExit
-  :unset[test]
+  ::unset{key=test}
 :::
 `}
         </tw-passagedata>


### PR DESCRIPTION
## Summary
- use leaf `::unset` directive in Input and Textarea event stories
- update Select and Trigger stories to remove inline `:unset`

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68b78663ef808322b0be2b9fbd47c36e