### PR TITLE
docs: correct leaf and text directive description

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ A cozy story format for Twine.
 Campfire extends Markdown with
 [remark-directive](https://github.com/remarkjs/remark-directive) syntax.
 Directives begin with a colon and let passages interact with the game state.
-They come in leaf or container form.
+They come in leaf, text, or container form.
 
-- **Leaf/Text** – `:name[LABEL]{attr=value}`
+- **Leaf** – `::name[LABEL]{attr=value}`
+- **Text** – `:name[LABEL]{attr=value}`
 - **Container** –
 
   ```md


### PR DESCRIPTION
## Summary
- clarify leaf (`::`) and text (`:`) directive syntax in README

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68b7887da7fc83229a6e7bfe42caafdb