### PR TITLE
fix: restrict asset directives to leaf usage

### DIFF
--- a/apps/campfire/src/hooks/__tests__/audioDirectives.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/audioDirectives.test.tsx
@@ -34,7 +34,7 @@ describe('audio directives', () => {
     const nodes = unified()
       .use(remarkParse)
       .use(remarkDirective)
-      .parse(":sound[click]{src='click.wav' volume=0.5 delay=100}")
+      .parse("::sound[click]{src='click.wav' volume=0.5 delay=100}")
       .children as RootContent[]
     runDirectiveBlock(nodes, handlers)
     expect(spy).toHaveBeenCalled()
@@ -46,7 +46,7 @@ describe('audio directives', () => {
     const nodes = unified()
       .use(remarkParse)
       .use(remarkDirective)
-      .parse(":bgm[theme]{src='theme.mp3' volume=0.4 loop=false fade=200}")
+      .parse("::bgm[theme]{src='theme.mp3' volume=0.4 loop=false fade=200}")
       .children as RootContent[]
     runDirectiveBlock(nodes, handlers)
     expect(spy).toHaveBeenCalled()
@@ -58,7 +58,7 @@ describe('audio directives', () => {
     const nodes = unified()
       .use(remarkParse)
       .use(remarkDirective)
-      .parse(":sound{src='beep.mp3'}").children as RootContent[]
+      .parse("::sound{src='beep.mp3'}").children as RootContent[]
     runDirectiveBlock(nodes, handlers)
     expect(spy).toHaveBeenCalled()
     expect(spy.mock.calls[0][0]).toBe('beep.mp3')
@@ -71,7 +71,7 @@ describe('audio directives', () => {
     const nodes = unified()
       .use(remarkParse)
       .use(remarkDirective)
-      .parse(":bgm{src='ambient.mp3'}").children as RootContent[]
+      .parse("::bgm{src='ambient.mp3'}").children as RootContent[]
     runDirectiveBlock(nodes, handlers)
     expect(spy).toHaveBeenCalled()
     expect(spy.mock.calls[0][0]).toBe('ambient.mp3')
@@ -84,7 +84,7 @@ describe('audio directives', () => {
     const nodes = unified()
       .use(remarkParse)
       .use(remarkDirective)
-      .parse(':bgm{stop=true fade=300}').children as RootContent[]
+      .parse('::bgm{stop=true fade=300}').children as RootContent[]
     runDirectiveBlock(nodes, handlers)
     expect(spy).toHaveBeenCalledWith(300)
     spy.mockRestore()
@@ -96,7 +96,7 @@ describe('audio directives', () => {
     const nodes = unified()
       .use(remarkParse)
       .use(remarkDirective)
-      .parse(':volume{bgm=0.2 sfx=0.7}').children as RootContent[]
+      .parse('::volume{bgm=0.2 sfx=0.7}').children as RootContent[]
     runDirectiveBlock(nodes, handlers)
     expect(bgmSpy).toHaveBeenCalledWith(0.2)
     expect(sfxSpy).toHaveBeenCalledWith(0.7)

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -2464,6 +2464,8 @@ export const useDirectiveHandlers = () => {
    * @returns The index of the removed node.
    */
   const handlePreloadAudio: DirectiveHandler = (directive, parent, index) => {
+    const invalid = requireLeafDirective(directive, parent, index)
+    if (typeof invalid !== 'undefined') return invalid
     const { attrs } = extractAttributes(directive, parent, index, {
       id: { type: 'string' },
       src: { type: 'string' }
@@ -2487,6 +2489,8 @@ export const useDirectiveHandlers = () => {
    * @returns The index of the removed node.
    */
   const handlePreloadImage: DirectiveHandler = (directive, parent, index) => {
+    const invalid = requireLeafDirective(directive, parent, index)
+    if (typeof invalid !== 'undefined') return invalid
     const { attrs } = extractAttributes(directive, parent, index, {
       id: { type: 'string' },
       src: { type: 'string' }
@@ -2510,6 +2514,8 @@ export const useDirectiveHandlers = () => {
    * @returns The index of the removed node.
    */
   const handleSound: DirectiveHandler = (directive, parent, index) => {
+    const invalid = requireLeafDirective(directive, parent, index)
+    if (typeof invalid !== 'undefined') return invalid
     const { attrs } = extractAttributes(directive, parent, index, {
       id: { type: 'string' },
       src: { type: 'string' },
@@ -2538,6 +2544,8 @@ export const useDirectiveHandlers = () => {
    * @returns The index of the removed node.
    */
   const handleBgm: DirectiveHandler = (directive, parent, index) => {
+    const invalid = requireLeafDirective(directive, parent, index)
+    if (typeof invalid !== 'undefined') return invalid
     const { attrs } = extractAttributes(directive, parent, index, {
       id: { type: 'string' },
       src: { type: 'string' },
@@ -2574,6 +2582,8 @@ export const useDirectiveHandlers = () => {
    * @returns The index of the removed node.
    */
   const handleVolume: DirectiveHandler = (directive, parent, index) => {
+    const invalid = requireLeafDirective(directive, parent, index)
+    if (typeof invalid !== 'undefined') return invalid
     const { attrs } = extractAttributes(directive, parent, index, {
       bgm: { type: 'number' },
       sfx: { type: 'number' }
@@ -3596,12 +3606,8 @@ export const useDirectiveHandlers = () => {
    */
   const handleImage: DirectiveHandler = (directive, parent, index) => {
     if (!parent || typeof index !== 'number') return
-    if (directive.type === 'containerDirective') {
-      const msg = 'image can only be used as an inline or leaf directive'
-      console.error(msg)
-      addError(msg)
-      return removeNode(parent, index)
-    }
+    const invalid = requireLeafDirective(directive, parent, index)
+    if (typeof invalid !== 'undefined') return invalid
     const { attrs } = extractAttributes<ImageSchema>(
       directive,
       parent,
@@ -3656,16 +3662,6 @@ export const useDirectiveHandlers = () => {
     const data = {
       hName: 'slideImage',
       hProperties: props as Properties
-    }
-    if (parent.type === 'paragraph') {
-      const others = parent.children.filter(
-        child => child !== directive && !isWhitespaceNode(child as RootContent)
-      )
-      if (others.length === 0) {
-        parent.children = []
-        ;(parent as Parent).data = data
-        return index
-      }
     }
     const node: Parent = { type: 'paragraph', children: [], data }
     return replaceWithIndentation(directive, parent, index, [

--- a/docs/directives/asset-management.md
+++ b/docs/directives/asset-management.md
@@ -42,7 +42,7 @@ Supports a `from` attribute to apply presets and uses `layerClassName` and `laye
 Preload an image for later use.
 
 ```md
-:preloadImage[titleScreen]{src='images/title.png'}
+::preloadImage[titleScreen]{src='images/title.png'}
 ```
 
 | Attribute | Description                     |
@@ -57,7 +57,7 @@ Preload an image for later use.
 Preload an audio file for later use.
 
 ```md
-:preloadAudio[click]{src='audio/click.wav'}
+::preloadAudio[click]{src='audio/click.wav'}
 ```
 
 | Attribute | Description                    |
@@ -70,7 +70,7 @@ Preload an audio file for later use.
 Play a one-off sound effect.
 
 ```md
-:sound[click]{volume=0.5 delay=200}
+::sound[click]{volume=0.5 delay=200}
 ```
 
 | Attribute | Description                         |
@@ -86,8 +86,8 @@ Play a one-off sound effect.
 Control background music. Use `stop=true` to stop.
 
 ```md
-:bgm[forest]{volume=0.4 loop=true fade=1000}
-:bgm{stop=true fade=500}
+::bgm[forest]{volume=0.4 loop=true fade=1000}
+::bgm{stop=true fade=500}
 ```
 
 | Attribute | Description                                    |
@@ -104,7 +104,7 @@ Control background music. Use `stop=true` to stop.
 Set global volume levels.
 
 ```md
-:volume{bgm=0.2 sfx=0.8}
+::volume{bgm=0.2 sfx=0.8}
 ```
 
 | Attribute | Description                      |


### PR DESCRIPTION
## Summary
- disallow inline usage for asset directives like preloadImage, sound, bgm, and volume
- update documentation and tests to use leaf directives

## Testing
- `bun tsc && echo tsc completed`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_68b7894297e883229c76d9f337f00940