### PR TITLE
docs: require exposing new attributes via directives

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -65,6 +65,7 @@ If a container directive nests another container and is followed by an inline di
 - If a directive attribute's value is surrounded by quotes or backticks, it MUST be treated as a string and NEVER converted into JSON, even if the contents of the string appear to be JSON.
 - Wrap string values in quotes or backticks unless referencing a state key.
 - To pass an object via an attribute, do not wrap the object in quotes (e.g., `:directive{attribute={key: val}}`).
+- When adding new directive attributes, expose them via the directive API and extend directive tests to cover them.
 
 ## Notes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,3 +54,4 @@ If a container directive includes a nested container followed immediately by an 
 - If a directive attribute's value is surrounded by quotes or backticks, it MUST be treated as a string and NEVER converted into JSON, even if the contents of the string appear to be JSON.
 - Wrap string values in quotes or backticks unless referencing a state key.
 - To pass an object via an attribute, do not wrap the object in quotes (e.g., `:directive{attribute={key: val}}`).
+- When adding new directive attributes, expose them through the directive API and update directive tests to cover the new behavior.

--- a/docs/spec/markdown-directives.md
+++ b/docs/spec/markdown-directives.md
@@ -36,6 +36,7 @@ General
 - Wrap literal strings in quotes or backticks unless referencing a state key.
 - To pass an object or array via an attribute, do not wrap the JSON in quotes, e.g., `:d{options={a:1}}` or valid JSON `:d{options={"a":1}}`.
 - Safe attribute characters: attribute extraction only accepts values composed of safe characters to reduce injection risk.
+- New directive attributes must be exposed through their handlers and accompanied by directive tests verifying their behavior.
 
 Special cases (validation enforced by remark plugin)
 


### PR DESCRIPTION
## Summary
- document that new directive attributes must be exposed through directive APIs
- note that directive tests must be extended when attributes are added

## Testing
- `bun run typecheck`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68b78cf04e0883229b91c3ac26856db5