### PR TITLE
feat: allow deck directive to hide navigation

### DIFF
--- a/apps/campfire/src/components/Deck/__tests__/Deck.test.tsx
+++ b/apps/campfire/src/components/Deck/__tests__/Deck.test.tsx
@@ -477,6 +477,42 @@ describe('Deck', () => {
     expect(nav.className).toContain('bottom-2')
   })
 
+  it('overrides accessible labels with the a11y prop', () => {
+    render(
+      <Deck
+        showSlideCount
+        a11y={{
+          deck: 'Slide deck',
+          next: 'Forward',
+          prev: 'Back',
+          play: 'Start autoplay',
+          pause: 'Pause autoplay',
+          slide: (i: number, t: number) => `Page ${i} of ${t}`
+        }}
+      >
+        <Slide>One</Slide>
+        <Slide>Two</Slide>
+      </Deck>
+    )
+    expect(screen.getByTestId('deck')).toHaveAttribute(
+      'aria-label',
+      'Slide deck'
+    )
+    expect(screen.getByTestId('deck-next')).toHaveAttribute(
+      'aria-label',
+      'Forward'
+    )
+    expect(screen.getByTestId('deck-prev')).toHaveAttribute(
+      'aria-label',
+      'Back'
+    )
+    expect(screen.getByTestId('deck-autoplay-toggle')).toHaveAttribute(
+      'aria-label',
+      'Start autoplay'
+    )
+    expect(screen.getByText('Page 1 of 2')).toBeInTheDocument()
+  })
+
   it.skip('sets max steps once for multiple SlideReveal elements', async () => {
     const original = useDeckStore.getState().setMaxSteps
     const calls: number[] = []

--- a/apps/campfire/src/components/Passage/__tests__/Passage.imageDirective.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Passage.imageDirective.test.tsx
@@ -35,8 +35,8 @@ describe('Passage image directive', () => {
       children: [
         {
           type: 'text',
-          value: `:::deck{size='1280x720' showNav=false}
-  :::slide
+          value: `:::deck{size='1280x720' hideNavigation=true}
+            :::slide
     :::reveal{at=0}
       ::image{src='https://placecats.com/bella/1280/360'}
 

--- a/apps/campfire/src/hooks/__tests__/deckDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/deckDirective.test.tsx
@@ -299,4 +299,80 @@ describe('deck directive', () => {
     expect(deck.props.autoAdvanceMs).toBe(3000)
     expect(deck.props.autoAdvancePaused).toBe(true)
   })
+
+  it('hides navigation when hideNavigation is true', () => {
+    const md = `:::deck{hideNavigation=true}\n:::slide\nHi\n:::\n:::`
+    render(<MarkdownRunner markdown={md} />)
+    const getDeck = (node: any): any => {
+      if (Array.isArray(node)) return getDeck(node[0])
+      if (node?.type === Fragment) return getDeck(node.props.children)
+      return node
+    }
+    const deck = getDeck(output)
+    expect(deck.props.hideNavigation).toBe(true)
+  })
+
+  it('shows navigation when hideNavigation is false', () => {
+    const md = `:::deck{hideNavigation=false}\n:::slide\nHi\n:::\n:::`
+    render(<MarkdownRunner markdown={md} />)
+    const getDeck = (node: any): any => {
+      if (Array.isArray(node)) return getDeck(node[0])
+      if (node?.type === Fragment) return getDeck(node.props.children)
+      return node
+    }
+    const deck = getDeck(output)
+    expect(deck.props.hideNavigation).toBeUndefined()
+  })
+
+  it('shows slide count when showSlideCount is true', () => {
+    const md = `:::deck{showSlideCount=true}\n:::slide\nHi\n:::\n:::`
+    render(<MarkdownRunner markdown={md} />)
+    const getDeck = (node: any): any => {
+      if (Array.isArray(node)) return getDeck(node[0])
+      if (node?.type === Fragment) return getDeck(node.props.children)
+      return node
+    }
+    const deck = getDeck(output)
+    expect(deck.props.showSlideCount).toBe(true)
+  })
+
+  it('hides slide count when showSlideCount is false', () => {
+    const md = `:::deck{showSlideCount=false}\n:::slide\nHi\n:::\n:::`
+    render(<MarkdownRunner markdown={md} />)
+    const getDeck = (node: any): any => {
+      if (Array.isArray(node)) return getDeck(node[0])
+      if (node?.type === Fragment) return getDeck(node.props.children)
+      return node
+    }
+    const deck = getDeck(output)
+    expect(deck.props.showSlideCount).toBeUndefined()
+  })
+
+  it('uses the provided initial slide', () => {
+    const md = `:::deck{initialSlide=2}\n:::slide\nA\n:::\n:::slide\nB\n:::\n:::slide\nC\n:::\n:::`
+    render(<MarkdownRunner markdown={md} />)
+    const getDeck = (node: any): any => {
+      if (Array.isArray(node)) return getDeck(node[0])
+      if (node?.type === Fragment) return getDeck(node.props.children)
+      return node
+    }
+    const deck = getDeck(output)
+    expect(deck.props.initialSlide).toBe(2)
+  })
+
+  it('parses a11y label overrides from the docs example', () => {
+    const md = `:::deck{a11y='{"deck":"Carousel","next":"Forward","prev":"Back","play":"Start","pause":"Stop"}'}\n:::slide\nContent\n:::\n:::`
+    render(<MarkdownRunner markdown={md} />)
+    const getDeck = (node: any): any => {
+      if (Array.isArray(node)) return getDeck(node[0])
+      if (node?.type === Fragment) return getDeck(node.props.children)
+      return node
+    }
+    const deck = getDeck(output)
+    expect(deck.props.a11y.deck).toBe('Carousel')
+    expect(deck.props.a11y.next).toBe('Forward')
+    expect(deck.props.a11y.prev).toBe('Back')
+    expect(deck.props.a11y.play).toBe('Start')
+    expect(deck.props.a11y.pause).toBe('Stop')
+  })
 })

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -3857,7 +3857,11 @@ export const useDirectiveHandlers = () => {
     'autoplay',
     'autoplayDelay',
     'pause',
-    'id'
+    'id',
+    'hideNavigation',
+    'showSlideCount',
+    'initialSlide',
+    'a11y'
   ] as const
 
   /**
@@ -3890,7 +3894,11 @@ export const useDirectiveHandlers = () => {
         autoplay: { type: 'boolean' },
         autoplayDelay: { type: 'number' },
         pause: { type: 'boolean' },
-        id: { type: 'string' }
+        id: { type: 'string' },
+        hideNavigation: { type: 'boolean' },
+        showSlideCount: { type: 'boolean' },
+        initialSlide: { type: 'number' },
+        a11y: { type: 'object', expression: false }
       },
       { label: false }
     )
@@ -3924,7 +3932,20 @@ export const useDirectiveHandlers = () => {
           : 3000
       if (deckAttrs.pause) deckProps.autoAdvancePaused = true
     }
+    if (deckAttrs.hideNavigation) deckProps.hideNavigation = true
+    if (deckAttrs.showSlideCount) deckProps.showSlideCount = true
+    if (typeof deckAttrs.initialSlide === 'number')
+      deckProps.initialSlide = deckAttrs.initialSlide
     if (deckAttrs.id) deckProps.id = deckAttrs.id
+    if (typeof deckAttrs.a11y === 'string') {
+      try {
+        deckProps.a11y = JSON.parse(deckAttrs.a11y)
+      } catch {
+        /* ignore */
+      }
+    } else if (deckAttrs.a11y) {
+      deckProps.a11y = deckAttrs.a11y
+    }
     const rawDeckAttrs = (directive.attributes || {}) as Record<string, unknown>
     applyAdditionalAttributes(rawDeckAttrs, deckProps, [
       ...DECK_EXCLUDES,

--- a/docs/directives/navigation-composition.md
+++ b/docs/directives/navigation-composition.md
@@ -82,23 +82,50 @@ its own slide if not preceded by a slide directive.
 | -------------------------- | -------------------------------------------------------------------------- |
 | size                       | Slide size as `WIDTHxHEIGHT` in pixels or aspect ratio like `16x9`         |
 | theme                      | Optional JSON object or string of CSS properties applied to the deck theme |
+| transition                 | Default slide transition applied to all slides                             |
 | from                       | Name of a deck preset to apply before other attributes                     |
 | autoplay                   | Whether to automatically advance through slides                            |
 | autoplayDelay              | Milliseconds between automatic slide advances (defaults to 3000)           |
 | pause                      | Start autoplay paused and display a play button                            |
+| initialSlide               | Slide index to start from (0-based)                                        |
 | id                         | Unique identifier for the deck                                             |
+| className                  | Additional classes applied to the deck container                           |
 | groupClassName             | Additional classes applied to the slide group wrapper                      |
 | navClassName               | Additional classes applied to the navigation wrapper                       |
 | hudClassName               | Additional classes applied to the slide counter HUD wrapper                |
+| showSlideCount             | Display the slide counter HUD when set to `true`                           |
 | navButtonClassName         | Additional classes applied to each navigation button                       |
 | rewindButtonClassName      | Additional classes applied to the rewind navigation button                 |
 | playButtonClassName        | Additional classes applied to the autoplay toggle button                   |
 | fastForwardButtonClassName | Additional classes applied to the fast-forward navigation button           |
 | slideHudClassName          | Additional classes applied to the slide count element within the HUD       |
+| hideNavigation             | Hide navigation controls when set to `true`                                |
+| a11y                       | JSON object overriding accessible labels (see below)                       |
 
 The autoplay toggle button also exposes a `data-state` attribute set to
 `playing` or `paused` for targeting styles based on the current autoplay
 state.
+
+The `a11y` attribute accepts an object for customizing accessible labels:
+
+- `deck` – ARIA label for the deck region.
+- `next` – label for the next control.
+- `prev` – label for the previous control.
+- `play` – label for the autoplay play control.
+- `pause` – label for the autoplay pause control.
+- `slide` – function `(index, total) => string` returning the slide count label.
+
+Unspecified keys fall back to default labels.
+
+For example, to override the default labels:
+
+```md
+:::deck{a11y='{"deck":"Carousel","next":"Forward","prev":"Back","play":"Start","pause":"Stop"}'}
+:::slide
+Content
+:::
+:::
+```
 
 ### `slide`
 


### PR DESCRIPTION
## Summary
- parse JSON-encoded `a11y` deck directive attribute and forward to `Deck`
- document `a11y` usage and add test for the docs example

## Testing
- `bun x prettier --write .`
- `bun tsc && echo 'tsc completed'`
- `bun test >/tmp/test.log 2>&1 && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68b786efeef48322aee0abe52bd0b388