### PR TITLE
feat(store): list saved games

### DIFF
--- a/apps/campfire/src/components/Passage/__tests__/Passage.checkpoint.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Passage.checkpoint.test.tsx
@@ -353,6 +353,74 @@ describe('Passage checkpoint directives', () => {
     expect(useGameStore.getState().loading).toBe(false)
   })
 
+  it('lists saves and loads a selected entry', async () => {
+    localStorage.setItem(
+      'campfire.save1',
+      JSON.stringify({
+        label: 'One',
+        gameData: { hp: 1 },
+        lockedKeys: {},
+        onceKeys: {},
+        checkpoints: {},
+        currentPassageId: '2'
+      })
+    )
+    localStorage.setItem(
+      'campfire.save2',
+      JSON.stringify({
+        label: 'Two',
+        gameData: { hp: 2 },
+        lockedKeys: {},
+        onceKeys: {},
+        checkpoints: {},
+        currentPassageId: '3'
+      })
+    )
+
+    const start: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value:
+            '::set[saves=listSavedGames()]\n' +
+            ':::for[save in saves]\n' +
+            ':::trigger{label=save.label||save.id}\n' +
+            '::load{id=save.id}\n' +
+            ':::\n' +
+            ':::'
+        }
+      ]
+    }
+    const second: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '2', name: 'Second' },
+      children: [{ type: 'text', value: 'Second' }]
+    }
+    const third: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '3', name: 'Third' },
+      children: [{ type: 'text', value: 'Third' }]
+    }
+
+    useStoryDataStore.setState({
+      passages: [start, second, third],
+      currentPassageId: '1'
+    })
+
+    render(<Passage />)
+    const buttons = await screen.findAllByRole('button')
+    expect(buttons.map(b => b.textContent)).toEqual(['One', 'Two'])
+
+    act(() => {
+      buttons[1].click()
+    })
+  })
+
   it('stores error when loadCheckpoint cannot find a checkpoint', async () => {
     const logged: unknown[] = []
     const orig = console.error

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -52,6 +52,7 @@ import {
 } from '@campfire/utils/math'
 import {
   parseTypedValue,
+  parseAttributeValue,
   extractKeyValue,
   replaceWithIndentation,
   expandIndentedCode,
@@ -1881,8 +1882,14 @@ export const useDirectiveHandlers = () => {
       addError(msg)
     }
     // Default label from attribute or container label paragraph
-    const defaultLabel =
-      typeof attrs.label === 'string' ? attrs.label : getLabel(container)
+    const rawLabel = typeof attrs.label === 'string' ? attrs.label : undefined
+    const evaluatedLabel =
+      rawLabel && /[.()?:|&]/.test(rawLabel)
+        ? (parseAttributeValue(rawLabel, { type: 'string' }, gameData) as
+            | string
+            | undefined)
+        : rawLabel
+    const defaultLabel = evaluatedLabel ?? getLabel(container)
     const classAttr = getClassAttr(attrs)
     const disabledAttr = attrs.disabled
     const styleAttr = getStyleAttr(attrs)

--- a/apps/campfire/src/utils/core.ts
+++ b/apps/campfire/src/utils/core.ts
@@ -24,6 +24,8 @@ const cache = new Map<string, (scope: Record<string, unknown>) => unknown>()
  *
  * @param expr - Expression to compile and evaluate.
  * @param scope - Scope object providing variables for evaluation.
+ *                 Merged with `globalThis` so globally exposed helpers are
+ *                 available; provided scope values take precedence.
  * @returns Result of the evaluated expression.
  */
 export const evalExpression = (
@@ -35,7 +37,7 @@ export const evalExpression = (
     fn = compile(expr) as (scope: Record<string, unknown>) => unknown
     cache.set(expr, fn)
   }
-  return fn(scope)
+  return fn({ ...(globalThis as Record<string, unknown>), ...scope })
 }
 
 /**

--- a/docs/directives/persistence.md
+++ b/docs/directives/persistence.md
@@ -97,3 +97,25 @@ backticks unless referencing a state key.
 | Input | Description           |
 | ----- | --------------------- |
 | id    | Storage key to remove |
+
+### `listSavedGames`
+
+Retrieve metadata for existing saves. This helper scans `localStorage` for
+keys starting with `campfire.save` and returns their labels, passage ids, and
+timestamps when available.
+Call the function in a directive expression and iterate over the results:
+
+```md
+::set[saves=listSavedGames()]
+:::for[save in saves]
+
+:show[save.id]
+
+:::
+```
+
+Provide a custom prefix to scan a different namespace:
+
+```md
+::set[demoSaves=listSavedGames('demo-')]
+```

--- a/docs/directives/persistence.md
+++ b/docs/directives/persistence.md
@@ -108,8 +108,7 @@ build a list of triggers that load each save when clicked:
 ```md
 ::set[saves=listSavedGames()]
 :::for[save in saves]
-:::trigger
-:show[save.label ?? save.id]
+:::trigger{label=save.label||save.id}
 ::load{id=save.id}
 :::
 :::

--- a/docs/directives/persistence.md
+++ b/docs/directives/persistence.md
@@ -102,15 +102,16 @@ backticks unless referencing a state key.
 
 Retrieve metadata for existing saves. This helper scans `localStorage` for
 keys starting with `campfire.save` and returns their labels, passage ids, and
-timestamps when available.
-Call the function in a directive expression and iterate over the results:
+timestamps when available. Call the function in a directive expression and
+build a list of triggers that load each save when clicked:
 
 ```md
 ::set[saves=listSavedGames()]
 :::for[save in saves]
-
-:show[save.id]
-
+:::trigger
+:show[save.label ?? save.id]
+::load{id=save.id}
+:::
 :::
 ```
 


### PR DESCRIPTION
## Summary
- expose `listSavedGames` helper to enumerate saved slots in localStorage
- document listing saves through directives and set helper on the global scope
- cover save listing with unit tests

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68b795a15e7c83229207b5ea4c95ebd2