### PR TITLE
docs: remove JSON attribute assignment guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -64,7 +64,6 @@ If a container directive nests another container and is followed by an inline di
 
 - If a directive attribute's value is surrounded by quotes or backticks, it MUST be treated as a string and NEVER converted into JSON, even if the contents of the string appear to be JSON.
 - Wrap string values in quotes or backticks unless referencing a state key.
-- To pass an object via an attribute, do not wrap the object in quotes (e.g., `:directive{attribute={key: val}}`).
 - When adding new directive attributes, expose them via the directive API and extend directive tests to cover them.
 
 ## Notes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,5 +53,4 @@ If a container directive includes a nested container followed immediately by an 
 
 - If a directive attribute's value is surrounded by quotes or backticks, it MUST be treated as a string and NEVER converted into JSON, even if the contents of the string appear to be JSON.
 - Wrap string values in quotes or backticks unless referencing a state key.
-- To pass an object via an attribute, do not wrap the object in quotes (e.g., `:directive{attribute={key: val}}`).
 - When adding new directive attributes, expose them through the directive API and update directive tests to cover the new behavior.


### PR DESCRIPTION
## Summary
- remove JSON attribute assignment references from agent instructions
- mirror change in Copilot instructions

## Testing
- `bun x prettier --write .`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68b7a30306bc8322adfc626f56e4233f