### PR TITLE
docs: remove prettier instructions from agent docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,11 +11,10 @@
 ## Build & Validation
 
 1. **Install**: Always run `bun install` after cloning or switching branches.
-2. **Format**: Run `bun x prettier --write .` before committing.
-3. **Type check**: Run `bun run typecheck` (which executes `tsc --noEmit`).
-4. **Test**: Run `bun test`.
-5. **Build**: Use `bun run build` to regenerate `dist/format.js`. This cleans `apps/campfire/dist`, bundles with Rollup, then assembles the final story format.
-6. Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages.
+2. **Type check**: Run `bun run typecheck` (which executes `tsc --noEmit`).
+3. **Test**: Run `bun test`.
+4. **Build**: Use `bun run build` to regenerate `dist/format.js`. This cleans `apps/campfire/dist`, bundles with Rollup, then assembles the final story format.
+5. Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages.
 
 ## Project Layout
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,5 @@
 # Repository Guidelines
 
-- Always run `bun x prettier --write .` before committing. This ensures consistent formatting across the project.
 - Always run a type check (`bun tsc` or `tsc`) before committing. This helps catch type errors early.
 - After making changes, run `bun test` to verify the test suite passes.
 - When writing tests, exercise both truthy and falsey paths for conditional logic.


### PR DESCRIPTION
## Summary
- remove requirement to run Prettier from AGENTS guidelines
- drop Prettier step from Copilot instructions

## Testing
- `bun run typecheck`
- `bun test >/tmp/test.log 2>&1 && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68b7b3b787988322a280c8b288776faa