### PR TITLE
fix: normalize unset directive syntax

### DIFF
--- a/apps/campfire/src/components/Passage/__tests__/Input.directive.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Input.directive.test.tsx
@@ -121,4 +121,31 @@ describe('Input directive', () => {
       (useGameStore.getState().gameData as Record<string, unknown>).name
     ).toBe('Existing')
   })
+
+  it('retains data on blur after focus', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value:
+            ':::input[name]\n:::onFocus\n::set[focused=true]\n:::\n:::onBlur\n::unset[focused]\n:::\n:::\n'
+        }
+      ]
+    }
+    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+    render(<Passage />)
+    const input = await screen.findByTestId('input')
+    expect(useGameStore.getState().gameData.focused).toBeUndefined()
+    act(() => {
+      ;(input as HTMLInputElement).focus()
+    })
+    expect(useGameStore.getState().gameData.focused).toBe(true)
+    act(() => {
+      input.dispatchEvent(new FocusEvent('focusout', { bubbles: true }))
+    })
+    expect(useGameStore.getState().gameData.focused).toBeUndefined()
+  })
 })

--- a/apps/campfire/src/components/Passage/__tests__/Passage.lifecycle.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Passage.lifecycle.test.tsx
@@ -87,7 +87,7 @@ describe('Passage lifecycle directives', () => {
     const root = unified()
       .use(remarkParse)
       .use(remarkDirective)
-      .parse(':::batch\n::set[a=1]\n::unset{key=old}\n:::') as Root
+      .parse(':::batch\n::set[a=1]\n::unset[old]\n:::') as Root
     const content = JSON.stringify(root.children)
     const { unmount } = render(<OnExit content={content} />)
     act(() => {

--- a/apps/campfire/src/components/Passage/__tests__/Passage.state.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Passage.state.test.tsx
@@ -239,7 +239,7 @@ describe('Passage game state directives', () => {
         {
           type: 'text',
           value:
-            '\n:::batch\n::set[visited=true]\n::push{key=items value=sword}\n::unset{key=old}\n:::\n\n'
+            '\n:::batch\n::set[visited=true]\n::push{key=items value=sword}\n::unset[old]\n:::\n\n'
         }
       ]
     }
@@ -1061,7 +1061,7 @@ describe('Passage game state directives', () => {
       type: 'element',
       tagName: 'tw-passagedata',
       properties: { pid: '1', name: 'Start' },
-      children: [{ type: 'text', value: '::unset{key=flag}' }]
+      children: [{ type: 'text', value: '::unset[flag]' }]
     }
 
     useStoryDataStore.setState({

--- a/apps/storybook/src/InputDirective.stories.tsx
+++ b/apps/storybook/src/InputDirective.stories.tsx
@@ -48,7 +48,7 @@ export const WithEvents: StoryObj = {
   ::set[focused=true]
 :::
 :::onBlur
-  ::unset{key=focused}
+  ::unset[focused]
 :::
 :::if[focused]
 

--- a/apps/storybook/src/SelectDirective.stories.tsx
+++ b/apps/storybook/src/SelectDirective.stories.tsx
@@ -72,7 +72,7 @@ export const WithEvents: StoryObj = {
 :::
 
 :::onBlur
-  ::unset{key=focused}
+  ::unset[focused]
 :::
 
 :::if[focused]

--- a/apps/storybook/src/TextareaDirective.stories.tsx
+++ b/apps/storybook/src/TextareaDirective.stories.tsx
@@ -48,7 +48,7 @@ export const WithEvents: StoryObj = {
   ::set[focused=true]
 :::
 :::onBlur
-  ::unset{key=focused}
+  ::unset[focused]
 :::
 :::if[focused]
 

--- a/apps/storybook/src/TriggerDirective.stories.tsx
+++ b/apps/storybook/src/TriggerDirective.stories.tsx
@@ -31,7 +31,7 @@ You clicked the button!
 :::
 
 :::onExit
-  ::unset{key=test}
+  ::unset[test]
 :::
 `}
         </tw-passagedata>

--- a/docs/directives/inputs-and-events.md
+++ b/docs/directives/inputs-and-events.md
@@ -219,7 +219,7 @@ Apply multiple directives as a single update.
 :::batch
 ::set[hp=value]
 ::push{key=items value=sword}
-::unset{key=old}
+::unset[old]
 :::
 ```
 

--- a/docs/directives/variables-and-state.md
+++ b/docs/directives/variables-and-state.md
@@ -91,10 +91,10 @@ Use this to store a random value that should not change on subsequent runs.
 
 ### `unset`
 
-Remove a key from state. This directive is leaf-only and cannot wrap content.
+Remove a key from state. Provide the state key as the directive label. This directive is leaf-only and cannot wrap content.
 
 ```md
-::unset{key=visited}
+::unset[visited]
 ```
 
 | Input | Description         |


### PR DESCRIPTION
## Summary
- support label syntax for the `unset` directive
- update tests, docs, and stories to use `::unset[key]`
- verify input blur event regression with updated syntax
- ensure blur event clears state in input directive regression test

## Testing
- `bun x prettier --write apps/campfire/src/hooks/useDirectiveHandlers.ts apps/campfire/src/components/Passage/__tests__/Input.directive.test.tsx`
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68b7a5cab3e48322805b3dec661006cf