### PR TITLE
docs: clarify Prettier usage

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -13,8 +13,9 @@
 1. **Install**: Always run `bun install` after cloning or switching branches.
 2. **Type check**: Run `bun run typecheck` (which executes `tsc --noEmit`).
 3. **Test**: Run `bun test`.
-4. **Build**: Use `bun run build` to regenerate `dist/format.js`. This cleans `apps/campfire/dist`, bundles with Rollup, then assembles the final story format.
-5. Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages.
+4. **Format**: Run `bunx prettier . --write` once before committing the final changes.
+5. **Build**: Use `bun run build` to regenerate `dist/format.js`. This cleans `apps/campfire/dist`, bundles with Rollup, then assembles the final story format.
+6. Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages.
 
 ## Project Layout
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,7 @@
 
 - Always run a type check (`bun tsc` or `tsc`) before committing. This helps catch type errors early.
 - After making changes, run `bun test` to verify the test suite passes.
+- Run Prettier (`bunx prettier . --write`) once just before finishing up your changes.
 - When writing tests, exercise both truthy and falsey paths for conditional logic.
 - Prefer arrow functions for holding functions when possible.
 - Include JSDoc comments for all functions and components.


### PR DESCRIPTION
## Summary
- note that Prettier must be run once before wrapping up changes
- document the same in Copilot instructions

## Testing
- `bunx tsc --noEmit`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_68b86279a76483228c1b11db32367535