### PR TITLE
feat: add container option directives

### DIFF
--- a/apps/campfire/src/components/Passage/__tests__/Select.directive.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Select.directive.test.tsx
@@ -24,7 +24,7 @@ describe('Select directive', () => {
         {
           type: 'text',
           value:
-            ':::select[color]{label="Choose"}\n:option{value="red" label="Red"}\n:::\n'
+            ':::select[color]{label="Choose"}\n::option{value="red" label="Red"}\n:::\n'
         }
       ]
     }
@@ -61,7 +61,7 @@ describe('Select directive', () => {
         {
           type: 'text',
           value:
-            ':::select[color]{className="extra" style="color:blue"}\n:option{value="red" label="Red"}\n:option{value="blue" label="Blue"}\n:::\n'
+            ':::select[color]{className="extra" style="color:blue"}\n::option{value="red" label="Red"}\n::option{value="blue" label="Blue"}\n:::\n'
         }
       ]
     }
@@ -78,6 +78,57 @@ describe('Select directive', () => {
     ).toBe('blue')
   })
 
+  it('renders container options with wrapper formatting', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value:
+            ':::select[color]\n:::option{value="red"}\n\n:::wrapper{className="bold"}\nRed\n:::\n\n:::\n:::\n'
+        }
+      ]
+    }
+    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+    render(<Passage />)
+    const select = await screen.findByTestId('select')
+    fireEvent.click(select)
+    await new Promise(r => setTimeout(r, 0))
+    const option = screen.getByTestId('option')
+    expect(option.textContent).toBe('Red')
+    expect(option.querySelector('.campfire-wrapper')).not.toBeNull()
+  })
+
+  it('selects values from options formatted with wrapper directives', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value:
+            ':::select[color]\n:::option{value="red"}\n:::wrapper{className="bold"}\nRed\n:::\n:::\n:::\n'
+        }
+      ]
+    }
+    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+    render(<Passage />)
+    const select = await screen.findByTestId('select')
+    fireEvent.click(select)
+    await new Promise(r => setTimeout(r, 0))
+    const option = screen.getByTestId('option')
+    expect(option.querySelector('.campfire-wrapper')?.classList).toContain(
+      'bold'
+    )
+    fireEvent.click(option)
+    expect(
+      (useGameStore.getState().gameData as Record<string, unknown>).color
+    ).toBe('red')
+  })
+
   it('runs event directives only on interaction', async () => {
     const passage: Element = {
       type: 'element',
@@ -87,7 +138,7 @@ describe('Select directive', () => {
         {
           type: 'text',
           value:
-            ':::select[color]\n:option{value="red" label="Red"}\n:option{value="blue" label="Blue"}\n:::onFocus\n::set[focused=true]\n:::\n:::onBlur\n::set[blurred=true]\n:::\n:::onMouseEnter\n::set[hovered=true]\n:::\n:::\n'
+            ':::select[color]\n::option{value="red" label="Red"}\n::option{value="blue" label="Blue"}\n:::onFocus\n::set[focused=true]\n:::\n:::onBlur\n::set[blurred=true]\n:::\n:::onMouseEnter\n::set[hovered=true]\n:::\n:::\n'
         }
       ]
     }
@@ -115,7 +166,7 @@ describe('Select directive', () => {
       children: [
         {
           type: 'text',
-          value: ':::select[color]\n:option{value="red" label="Red"}\n:::\n'
+          value: ':::select[color]\n::option{value="red" label="Red"}\n:::\n'
         }
       ]
     }
@@ -134,7 +185,7 @@ describe('Select directive', () => {
         {
           type: 'text',
           value:
-            ':::select[color]{value="blue"}\n:option{value="red" label="Red"}\n:option{value="blue" label="Blue"}\n:::\n'
+            ':::select[color]{value="blue"}\n::option{value="red" label="Red"}\n::option{value="blue" label="Blue"}\n:::\n'
         }
       ]
     }
@@ -156,7 +207,7 @@ describe('Select directive', () => {
         {
           type: 'text',
           value:
-            ':::select[color]{value="blue"}\n:option{value="red" label="Red"}\n:option{value="blue" label="Blue"}\n:::\n'
+            ':::select[color]{value="blue"}\n::option{value="red" label="Red"}\n::option{value="blue" label="Blue"}\n:::\n'
         }
       ]
     }
@@ -179,7 +230,7 @@ describe('Select directive', () => {
         {
           type: 'text',
           value:
-            ':::select[color]\n:option{value="red" label="Red"}\n:::onFocus\n::set[focused=true]\n:::\n:::onBlur\n::unset[focused]\n:::\n:::\n'
+            ':::select[color]\n::option{value="red" label="Red"}\n:::onFocus\n::set[focused=true]\n:::\n:::onBlur\n::unset[focused]\n:::\n:::\n'
         }
       ]
     }

--- a/apps/campfire/src/hooks/__tests__/disabledDirectives.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/disabledDirectives.test.tsx
@@ -32,7 +32,7 @@ describe('disabled state directives', () => {
     const md =
       ':input[name]{disabled=disabled}\n' +
       ':::select[color]{disabled=disabled}\n' +
-      ':option{value="r" label="Red"}\n' +
+      '::option{value="r" label="Red"}\n' +
       ':::\n' +
       ':radio[choice]{value="a" disabled=disabled}\n' +
       ':checkbox[check]{disabled=disabled}\n' +
@@ -78,7 +78,7 @@ describe('disabled state directives', () => {
     const md =
       ':input[name]{disabled="count>2"}\n' +
       ':::select[color]{disabled="count>2"}\n' +
-      ':option{value="r" label="Red"}\n' +
+      '::option{value="r" label="Red"}\n' +
       ':::\n' +
       ':radio[choice]{value="a" disabled="count>2"}\n' +
       ':checkbox[check]{disabled="count>2"}\n' +

--- a/apps/storybook/src/SelectDirective.stories.tsx
+++ b/apps/storybook/src/SelectDirective.stories.tsx
@@ -20,8 +20,8 @@ export const Basic: StoryObj = {
           {`
 :::select[color]{label="Choose a color"}
 
-:option{value="red" label="Red"}
-:option{value="blue" label="Blue"}
+::option{value="red" label="Red"}
+::option{value="blue" label="Blue"}
 
 :::
 
@@ -64,8 +64,8 @@ export const WithEvents: StoryObj = {
           {`
 :::select[color]{label="Choose a color"}
 
-:option{value="red" label="Red"}
-:option{value="blue" label="Blue"}
+::option{value="red" label="Red"}
+::option{value="blue" label="Blue"}
 
 :::onFocus
   ::set[focused=true]

--- a/docs/directives/inputs-and-events.md
+++ b/docs/directives/inputs-and-events.md
@@ -72,8 +72,8 @@ Render a dropdown bound to a game state key. Must be used as a container with ne
 
 ```md
 :::select[color]{label="Choose a color"}
-:option{value="red" label="Red"}
-:option{value="blue" label="Blue"}
+::option{value="red" label="Red"}
+::option{value="blue" label="Blue"}
 :::
 ```
 
@@ -90,12 +90,24 @@ The select button uses the same default styling as trigger and link buttons and 
 
 `option` directives accept the following inputs:
 
-| Input     | Description                        |
-| --------- | ---------------------------------- |
-| value     | Value to store when selected       |
-| label     | Text displayed for the option      |
-| className | Optional space-separated classes   |
-| style     | Optional inline style declarations |
+| Input     | Description                               |
+| --------- | ----------------------------------------- |
+| value     | Value to store when selected              |
+| label     | Text displayed for the option (leaf form) |
+| className | Optional space-separated classes          |
+| style     | Optional inline style declarations        |
+
+Container form:
+
+```md
+:::select[color]{label="Choose a color"}
+:::option{value="red"}
+:::wrapper{className="fancy"}Red:::
+:::
+:::
+```
+
+The container form uses its content for the option label, enabling formatting via directives like `wrapper`.
 
 ### `checkbox`
 


### PR DESCRIPTION
## Summary
- disallow inline option directives
- support option as leaf or container with wrapper content
- document container option usage
- test wrapper formatting inside option directives

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68b86670ae748322902c3458e6d82c54