### PR TITLE
feat(state): add selector helpers for Zustand stores

### DIFF
--- a/apps/campfire/src/components/Passage/__tests__/Select.directive.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Select.directive.test.tsx
@@ -24,7 +24,7 @@ describe('Select directive', () => {
         {
           type: 'text',
           value:
-            ':::select[color]{label="Choose"}\n:option{value="red" label="Red"}\n:::\n'
+            ':::select[color]{label="Choose"}\n::option{value="red" label="Red"}\n:::\n'
         }
       ]
     }
@@ -61,7 +61,7 @@ describe('Select directive', () => {
         {
           type: 'text',
           value:
-            ':::select[color]{className="extra" style="color:blue"}\n:option{value="red" label="Red"}\n:option{value="blue" label="Blue"}\n:::\n'
+            ':::select[color]{className="extra" style="color:blue"}\n::option{value="red" label="Red"}\n::option{value="blue" label="Blue"}\n:::\n'
         }
       ]
     }
@@ -78,6 +78,57 @@ describe('Select directive', () => {
     ).toBe('blue')
   })
 
+  it('renders container options with wrapper formatting', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value:
+            ':::select[color]\n:::option{value="red"}\n\n:::wrapper{className="bold"}\nRed\n:::\n\n:::\n:::\n'
+        }
+      ]
+    }
+    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+    render(<Passage />)
+    const select = await screen.findByTestId('select')
+    fireEvent.click(select)
+    await new Promise(r => setTimeout(r, 0))
+    const option = screen.getByTestId('option')
+    expect(option.textContent).toBe('Red')
+    expect(option.querySelector('.campfire-wrapper')).not.toBeNull()
+  })
+
+  it('selects values from options formatted with wrapper directives', async () => {
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value:
+            ':::select[color]\n:::option{value="red"}\n:::wrapper{className="bold"}\nRed\n:::\n:::\n:::\n'
+        }
+      ]
+    }
+    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+    render(<Passage />)
+    const select = await screen.findByTestId('select')
+    fireEvent.click(select)
+    await new Promise(r => setTimeout(r, 0))
+    const option = screen.getByTestId('option')
+    expect(option.querySelector('.campfire-wrapper')?.classList).toContain(
+      'bold'
+    )
+    fireEvent.click(option)
+    expect(
+      (useGameStore.getState().gameData as Record<string, unknown>).color
+    ).toBe('red')
+  })
+
   it('runs event directives only on interaction', async () => {
     const passage: Element = {
       type: 'element',
@@ -87,7 +138,7 @@ describe('Select directive', () => {
         {
           type: 'text',
           value:
-            ':::select[color]\n:option{value="red" label="Red"}\n:option{value="blue" label="Blue"}\n:::onFocus\n::set[focused=true]\n:::\n:::onBlur\n::set[blurred=true]\n:::\n:::onMouseEnter\n::set[hovered=true]\n:::\n:::\n'
+            ':::select[color]\n::option{value="red" label="Red"}\n::option{value="blue" label="Blue"}\n:::onFocus\n::set[focused=true]\n:::\n:::onBlur\n::set[blurred=true]\n:::\n:::onMouseEnter\n::set[hovered=true]\n:::\n:::\n'
         }
       ]
     }
@@ -115,7 +166,7 @@ describe('Select directive', () => {
       children: [
         {
           type: 'text',
-          value: ':::select[color]\n:option{value="red" label="Red"}\n:::\n'
+          value: ':::select[color]\n::option{value="red" label="Red"}\n:::\n'
         }
       ]
     }
@@ -134,7 +185,7 @@ describe('Select directive', () => {
         {
           type: 'text',
           value:
-            ':::select[color]{value="blue"}\n:option{value="red" label="Red"}\n:option{value="blue" label="Blue"}\n:::\n'
+            ':::select[color]{value="blue"}\n::option{value="red" label="Red"}\n::option{value="blue" label="Blue"}\n:::\n'
         }
       ]
     }
@@ -156,7 +207,7 @@ describe('Select directive', () => {
         {
           type: 'text',
           value:
-            ':::select[color]{value="blue"}\n:option{value="red" label="Red"}\n:option{value="blue" label="Blue"}\n:::\n'
+            ':::select[color]{value="blue"}\n::option{value="red" label="Red"}\n::option{value="blue" label="Blue"}\n:::\n'
         }
       ]
     }
@@ -179,7 +230,7 @@ describe('Select directive', () => {
         {
           type: 'text',
           value:
-            ':::select[color]\n:option{value="red" label="Red"}\n:::onFocus\n::set[focused=true]\n:::\n:::onBlur\n::unset[focused]\n:::\n:::\n'
+            ':::select[color]\n::option{value="red" label="Red"}\n:::onFocus\n::set[focused=true]\n:::\n:::onBlur\n::unset[focused]\n:::\n:::\n'
         }
       ]
     }

--- a/apps/campfire/src/hooks/__tests__/disabledDirectives.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/disabledDirectives.test.tsx
@@ -32,7 +32,7 @@ describe('disabled state directives', () => {
     const md =
       ':input[name]{disabled=disabled}\n' +
       ':::select[color]{disabled=disabled}\n' +
-      ':option{value="r" label="Red"}\n' +
+      '::option{value="r" label="Red"}\n' +
       ':::\n' +
       ':radio[choice]{value="a" disabled=disabled}\n' +
       ':checkbox[check]{disabled=disabled}\n' +
@@ -78,7 +78,7 @@ describe('disabled state directives', () => {
     const md =
       ':input[name]{disabled="count>2"}\n' +
       ':::select[color]{disabled="count>2"}\n' +
-      ':option{value="r" label="Red"}\n' +
+      '::option{value="r" label="Red"}\n' +
       ':::\n' +
       ':radio[choice]{value="a" disabled="count>2"}\n' +
       ':checkbox[check]{disabled="count>2"}\n' +

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -1000,16 +1000,6 @@ export const useDirectiveHandlers = () => {
       addError(msg)
       return removeNode(parent, index)
     }
-    const labelAttr =
-      directive.type === 'leafDirective' && typeof attrs.label === 'string'
-        ? attrs.label
-        : undefined
-    if (directive.type === 'leafDirective' && !labelAttr) {
-      const msg = 'option leaf directives require a label attribute'
-      console.error(msg)
-      addError(msg)
-      return removeNode(parent, index)
-    }
     if (Object.prototype.hasOwnProperty.call(attrs, 'class')) {
       const msg = 'class is a reserved attribute. Use className instead.'
       console.error(msg)
@@ -1028,9 +1018,17 @@ export const useDirectiveHandlers = () => {
     ])
 
     if (directive.type === 'leafDirective') {
+      const labelAttr =
+        typeof attrs.label === 'string' ? attrs.label : undefined
+      if (!labelAttr) {
+        const msg = 'option leaf directives require a label attribute'
+        console.error(msg)
+        addError(msg)
+        return removeNode(parent, index)
+      }
       const node: Parent = {
         type: 'paragraph',
-        children: [{ type: 'text', value: labelAttr! }],
+        children: [{ type: 'text', value: labelAttr }],
         data: { hName: 'option', hProperties: props as Properties }
       }
       return replaceWithIndentation(directive, parent, index, [

--- a/apps/campfire/src/state/useDeckStore/index.ts
+++ b/apps/campfire/src/state/useDeckStore/index.ts
@@ -3,10 +3,14 @@ import {
   createDeckStore,
   type DeckState
 } from '@campfire/state/createDeckStore'
+import { createSelectors } from '@campfire/state/utils'
 
 /**
  * Zustand store for tracking slide and step navigation.
  */
-export const useDeckStore = create<DeckState>(createDeckStore())
+const useDeckStoreBase = create<DeckState>(createDeckStore())
+
+/** Global deck store with selector helpers. */
+export const useDeckStore = createSelectors(useDeckStoreBase)
 
 export type { DeckState }

--- a/apps/campfire/src/state/useGameStore/__tests__/index.test.ts
+++ b/apps/campfire/src/state/useGameStore/__tests__/index.test.ts
@@ -1,3 +1,5 @@
+import { h } from 'preact'
+import { render, screen } from '@testing-library/preact'
 import { useGameStore, listSavedGames } from '../index'
 import { describe, it, expect, beforeEach } from 'bun:test'
 
@@ -148,5 +150,22 @@ describe('useGameStore', () => {
     expect((globalThis as { listSavedGames?: unknown }).listSavedGames).toBe(
       listSavedGames
     )
+  })
+
+  it('provides selector hooks via `use`', () => {
+    useGameStore.setState({ gameData: { hp: 2 } })
+
+    /** Test component displaying health */
+    const Test = () => {
+      const data = useGameStore.use.gameData()
+      return h(
+        'span',
+        { class: 'campfire-test', 'data-testid': 'hp' },
+        (data as Record<string, unknown>).hp as unknown as string
+      )
+    }
+
+    render(h(Test, {}))
+    expect(screen.getByTestId('hp').textContent).toBe('2')
   })
 })

--- a/apps/campfire/src/state/useGameStore/__tests__/index.test.ts
+++ b/apps/campfire/src/state/useGameStore/__tests__/index.test.ts
@@ -157,11 +157,11 @@ describe('useGameStore', () => {
 
     /** Test component displaying health */
     const Test = () => {
-      const data = useGameStore.use.gameData()
+      const data = useGameStore.use.gameData() as Record<string, unknown>
       return h(
         'span',
         { class: 'campfire-test', 'data-testid': 'hp' },
-        (data as Record<string, unknown>).hp as unknown as string
+        String(data.hp)
       )
     }
 

--- a/apps/campfire/src/state/useGameStore/index.ts
+++ b/apps/campfire/src/state/useGameStore/index.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand'
 import { subscribeWithSelector } from 'zustand/middleware'
-import { setImmer } from '@campfire/state/utils'
+import { setImmer, createSelectors } from '@campfire/state/utils'
 
 export interface GameState<T = Record<string, unknown>> {
   /** Arbitrary game state */
@@ -117,7 +117,8 @@ export const listSavedGames = (prefix = 'campfire.save'): SavedGame[] => {
 ;(globalThis as { listSavedGames?: typeof listSavedGames }).listSavedGames =
   listSavedGames
 
-export const useGameStore = create(
+/** Internal instance of the game store. */
+const useGameStoreBase = create(
   subscribeWithSelector<InternalState<Record<string, unknown>>>((set, get) => {
     const immer = setImmer<InternalState<Record<string, unknown>>>(set)
     return {
@@ -225,3 +226,6 @@ export const useGameStore = create(
     }
   })
 )
+
+/** Global store managing game state and persistence. */
+export const useGameStore = createSelectors(useGameStoreBase)

--- a/apps/campfire/src/state/useOverlayDeckStore.ts
+++ b/apps/campfire/src/state/useOverlayDeckStore.ts
@@ -3,13 +3,17 @@ import {
   createDeckStore,
   type DeckState
 } from '@campfire/state/createDeckStore'
+import { createSelectors } from '@campfire/state/utils'
 
 /**
  * Zustand store for overlay decks to keep their navigation state persistent
  * across passage changes.
  */
-export const useOverlayDeckStore = create<DeckState>(
+const useOverlayDeckStoreBase = create<DeckState>(
   createDeckStore({ persistent: true })
 )
+
+/** Overlay deck store with selector hooks. */
+export const useOverlayDeckStore = createSelectors(useOverlayDeckStoreBase)
 
 export default useOverlayDeckStore

--- a/apps/campfire/src/state/useOverlayStore.ts
+++ b/apps/campfire/src/state/useOverlayStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import type { ComponentChild } from 'preact'
+import { createSelectors } from '@campfire/state/utils'
 
 export interface OverlayItem {
   /** Unique name for the overlay passage */
@@ -32,7 +33,7 @@ export interface OverlayState {
 /**
  * Global store holding processed overlay components.
  */
-export const useOverlayStore = create<OverlayState>(set => ({
+const useOverlayStoreBase = create<OverlayState>(set => ({
   overlays: [],
   setOverlays: items => set({ overlays: items }),
   showOverlay: name =>
@@ -60,3 +61,6 @@ export const useOverlayStore = create<OverlayState>(set => ({
       )
     }))
 }))
+
+/** Zustand store with selector hooks for overlays. */
+export const useOverlayStore = createSelectors(useOverlayStoreBase)

--- a/apps/campfire/src/state/useStoryDataStore/index.ts
+++ b/apps/campfire/src/state/useStoryDataStore/index.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import { setImmer } from '@campfire/state/utils'
+import { setImmer, createSelectors } from '@campfire/state/utils'
 import type { Element } from 'hast'
 
 export interface StoryDataState {
@@ -16,7 +16,7 @@ export interface StoryDataState {
   getPassageByName: (name: string) => Element | undefined
 }
 
-export const useStoryDataStore = create<StoryDataState>((set, get) => {
+const useStoryDataStoreBase = create<StoryDataState>((set, get) => {
   const immer = setImmer<StoryDataState>(set)
   return {
     storyData: {},
@@ -54,3 +54,6 @@ export const useStoryDataStore = create<StoryDataState>((set, get) => {
       get().passages.find(p => p.properties?.name === name)
   }
 })
+
+/** Story data store with selector helpers. */
+export const useStoryDataStore = createSelectors(useStoryDataStoreBase)

--- a/apps/campfire/src/state/utils.ts
+++ b/apps/campfire/src/state/utils.ts
@@ -30,12 +30,13 @@ type WithSelectors<S> = S extends { getState: () => infer T }
  * Adds hook-based selectors to a Zustand store.
  *
  * @param store - The base Zustand store.
- * @returns The store augmented with a `use` object containing selectors.
+ * @returns The store augmented with a memoized `use` object containing selectors.
  */
 export const createSelectors = <S extends UseBoundStore<StoreApi<object>>>(
   store: S
 ) => {
   const typed = store as WithSelectors<typeof store>
+  if ((typed as any).use) return typed
   typed.use = {} as Record<string, () => unknown>
   for (const k of Object.keys(typed.getState())) {
     ;(typed.use as Record<string, unknown>)[k] = () =>

--- a/apps/storybook/src/SelectDirective.stories.tsx
+++ b/apps/storybook/src/SelectDirective.stories.tsx
@@ -20,8 +20,8 @@ export const Basic: StoryObj = {
           {`
 :::select[color]{label="Choose a color"}
 
-:option{value="red" label="Red"}
-:option{value="blue" label="Blue"}
+::option{value="red" label="Red"}
+::option{value="blue" label="Blue"}
 
 :::
 
@@ -64,8 +64,8 @@ export const WithEvents: StoryObj = {
           {`
 :::select[color]{label="Choose a color"}
 
-:option{value="red" label="Red"}
-:option{value="blue" label="Blue"}
+::option{value="red" label="Red"}
+::option{value="blue" label="Blue"}
 
 :::onFocus
   ::set[focused=true]

--- a/docs/directives/inputs-and-events.md
+++ b/docs/directives/inputs-and-events.md
@@ -72,8 +72,8 @@ Render a dropdown bound to a game state key. Must be used as a container with ne
 
 ```md
 :::select[color]{label="Choose a color"}
-:option{value="red" label="Red"}
-:option{value="blue" label="Blue"}
+::option{value="red" label="Red"}
+::option{value="blue" label="Blue"}
 :::
 ```
 
@@ -90,12 +90,24 @@ The select button uses the same default styling as trigger and link buttons and 
 
 `option` directives accept the following inputs:
 
-| Input     | Description                        |
-| --------- | ---------------------------------- |
-| value     | Value to store when selected       |
-| label     | Text displayed for the option      |
-| className | Optional space-separated classes   |
-| style     | Optional inline style declarations |
+| Input     | Description                               |
+| --------- | ----------------------------------------- |
+| value     | Value to store when selected              |
+| label     | Text displayed for the option (leaf form) |
+| className | Optional space-separated classes          |
+| style     | Optional inline style declarations        |
+
+Container form:
+
+```md
+:::select[color]{label="Choose a color"}
+:::option{value="red"}
+:::wrapper{className="fancy"}Red:::
+:::
+:::
+```
+
+The container form uses its content for the option label, enabling formatting via directives like `wrapper`.
 
 ### `checkbox`
 


### PR DESCRIPTION
## Summary
- add `createSelectors` util for hook-based store selectors
- wire up selector helpers across state stores
- verify selector usage in game store tests

## Testing
- `bun tsc`
- `bun test`
- `bunx prettier . --write`


------
https://chatgpt.com/codex/tasks/task_e_68b87244235c83228f1a44be25b29382