### PR TITLE
refactor: use selector shorthand for game data

### DIFF
--- a/apps/campfire/src/hooks/useSerializedDirectiveRunner.ts
+++ b/apps/campfire/src/hooks/useSerializedDirectiveRunner.ts
@@ -61,7 +61,7 @@ export const useSerializedDirectiveRunner = (content: string) => {
     runDirectiveBlock(processed, handlers)
   }
 
-  const gameData = useGameStore(state => state.gameData)
+  const gameData = useGameStore.use.gameData()
 
   return useCallback(() => {
     // TODO(campfire): Profile large blocks to avoid long


### PR DESCRIPTION
## Summary
- use the `useGameStore.use` selector for game data in serialized directive runner

## Testing
- `bun tsc && echo tsc-done`
- `bun test && echo test-done`
- `bunx prettier . --write`


------
https://chatgpt.com/codex/tasks/task_e_68b885f323888322b303e92ca57bc30d