### PR TITLE
refactor(passage): use store selectors for form fields

### DIFF
--- a/apps/campfire/src/components/Passage/Checkbox.tsx
+++ b/apps/campfire/src/components/Passage/Checkbox.tsx
@@ -62,29 +62,27 @@ export const Checkbox = ({
   disabled,
   ...rest
 }: CheckboxProps) => {
-  const value = useGameStore(state => state.gameData[stateKey]) as
-    | boolean
-    | string
-    | undefined
-  const isDisabled = useGameStore(state => {
+  const gameData = useGameStore.use.gameData()
+  const value = gameData[stateKey] as boolean | string | undefined
+  const isDisabled = (() => {
     if (typeof disabled === 'string') {
       if (disabled === '' || disabled === 'true') return true
       if (disabled === 'false') return false
       try {
-        return Boolean(evalExpression(disabled, state.gameData))
+        return Boolean(evalExpression(disabled, gameData))
       } catch {
         return false
       }
     }
     return Boolean(disabled)
-  })
+  })()
   const directiveEvents = useDirectiveEvents(
     onMouseEnter,
     onMouseLeave,
     onFocus,
     onBlur
   )
-  const setGameData = useGameStore(state => state.setGameData)
+  const setGameData = useGameStore.use.setGameData()
   useEffect(() => {
     if (value === undefined) {
       const init =

--- a/apps/campfire/src/components/Passage/Input.tsx
+++ b/apps/campfire/src/components/Passage/Input.tsx
@@ -61,28 +61,27 @@ export const Input = ({
   disabled,
   ...rest
 }: InputProps) => {
-  const value = useGameStore(state => state.gameData[stateKey]) as
-    | string
-    | undefined
-  const isDisabled = useGameStore(state => {
+  const gameData = useGameStore.use.gameData()
+  const value = gameData[stateKey] as string | undefined
+  const isDisabled = (() => {
     if (typeof disabled === 'string') {
       if (disabled === '' || disabled === 'true') return true
       if (disabled === 'false') return false
       try {
-        return Boolean(evalExpression(disabled, state.gameData))
+        return Boolean(evalExpression(disabled, gameData))
       } catch {
         return false
       }
     }
     return Boolean(disabled)
-  })
+  })()
   const directiveEvents = useDirectiveEvents(
     onMouseEnter,
     onMouseLeave,
     onFocus,
     onBlur
   )
-  const setGameData = useGameStore(state => state.setGameData)
+  const setGameData = useGameStore.use.setGameData()
   useEffect(() => {
     if (value === undefined) {
       setGameData({ [stateKey]: initialValue ?? '' })

--- a/apps/campfire/src/components/Passage/Radio.tsx
+++ b/apps/campfire/src/components/Passage/Radio.tsx
@@ -63,28 +63,27 @@ export const Radio = ({
   disabled,
   ...rest
 }: RadioProps) => {
-  const value = useGameStore(state => state.gameData[stateKey]) as
-    | string
-    | undefined
-  const isDisabled = useGameStore(state => {
+  const gameData = useGameStore.use.gameData()
+  const value = gameData[stateKey] as string | undefined
+  const isDisabled = (() => {
     if (typeof disabled === 'string') {
       if (disabled === '' || disabled === 'true') return true
       if (disabled === 'false') return false
       try {
-        return Boolean(evalExpression(disabled, state.gameData))
+        return Boolean(evalExpression(disabled, gameData))
       } catch {
         return false
       }
     }
     return Boolean(disabled)
-  })
+  })()
   const directiveEvents = useDirectiveEvents(
     onMouseEnter,
     onMouseLeave,
     onFocus,
     onBlur
   )
-  const setGameData = useGameStore(state => state.setGameData)
+  const setGameData = useGameStore.use.setGameData()
   useEffect(() => {
     if (value === undefined && initialValue !== undefined) {
       setGameData({ [stateKey]: initialValue })

--- a/apps/campfire/src/components/Passage/Select.tsx
+++ b/apps/campfire/src/components/Passage/Select.tsx
@@ -70,22 +70,21 @@ export const Select = ({
   disabled,
   ...rest
 }: SelectProps) => {
-  const value = useGameStore(state => state.gameData[stateKey]) as
-    | string
-    | undefined
-  const setGameData = useGameStore(state => state.setGameData)
-  const isDisabled = useGameStore(state => {
+  const gameData = useGameStore.use.gameData()
+  const value = gameData[stateKey] as string | undefined
+  const setGameData = useGameStore.use.setGameData()
+  const isDisabled = (() => {
     if (typeof disabled === 'string') {
       if (disabled === '' || disabled === 'true') return true
       if (disabled === 'false') return false
       try {
-        return Boolean(evalExpression(disabled, state.gameData))
+        return Boolean(evalExpression(disabled, gameData))
       } catch {
         return false
       }
     }
     return Boolean(disabled)
-  })
+  })()
   const directiveEvents = useDirectiveEvents(
     onMouseEnter,
     onMouseLeave,

--- a/apps/campfire/src/components/Passage/Textarea.tsx
+++ b/apps/campfire/src/components/Passage/Textarea.tsx
@@ -61,28 +61,27 @@ export const Textarea = ({
   disabled,
   ...rest
 }: TextareaProps) => {
-  const value = useGameStore(state => state.gameData[stateKey]) as
-    | string
-    | undefined
-  const isDisabled = useGameStore(state => {
+  const gameData = useGameStore.use.gameData()
+  const value = gameData[stateKey] as string | undefined
+  const isDisabled = (() => {
     if (typeof disabled === 'string') {
       if (disabled === '' || disabled === 'true') return true
       if (disabled === 'false') return false
       try {
-        return Boolean(evalExpression(disabled, state.gameData))
+        return Boolean(evalExpression(disabled, gameData))
       } catch {
         return false
       }
     }
     return Boolean(disabled)
-  })
+  })()
   const directiveEvents = useDirectiveEvents(
     onMouseEnter,
     onMouseLeave,
     onFocus,
     onBlur
   )
-  const setGameData = useGameStore(state => state.setGameData)
+  const setGameData = useGameStore.use.setGameData()
   useEffect(() => {
     if (value === undefined) {
       setGameData({ [stateKey]: initialValue ?? '' })


### PR DESCRIPTION
## Summary
- use `useGameStore.use.gameData()` to read game state in Input, Textarea, Checkbox, Radio and Select
- call `useGameStore.use.setGameData()` for updates

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68b8887767bc83228b6dc39f86b63434