### PR TITLE
refactor: use store selectors in passage components

### DIFF
--- a/apps/campfire/src/components/Passage/If.tsx
+++ b/apps/campfire/src/components/Passage/If.tsx
@@ -66,7 +66,7 @@ export const If = ({ test, content, fallback }: IfProps) => {
     })
     return proc
   }, [handlers])
-  const gameData = useGameStore(state => state.gameData)
+  const gameData = useGameStore.use.gameData()
   let condition = false
   try {
     const fn = new Function('data', `with (data) { return (${test}) }`) as (

--- a/apps/campfire/src/components/Passage/Show.tsx
+++ b/apps/campfire/src/components/Passage/Show.tsx
@@ -24,8 +24,8 @@ interface ShowProps {
  * Updates automatically when the underlying data changes.
  */
 export const Show = ({ className, style, ...props }: ShowProps) => {
-  const addError = useGameStore(state => state.addError)
-  const gameData = useGameStore(state => state.gameData)
+  const addError = useGameStore.use.addError()
+  const gameData = useGameStore.use.gameData()
   const expr = props['data-expr']
 
   const mergedStyle =

--- a/apps/campfire/src/components/Passage/Translate.tsx
+++ b/apps/campfire/src/components/Passage/Translate.tsx
@@ -32,8 +32,8 @@ interface TranslateProps {
  * Returns `null` when the key is missing.
  */
 export const Translate = ({ className, style, ...props }: TranslateProps) => {
-  const addError = useGameStore(state => state.addError)
-  const gameData = useGameStore(state => state.gameData)
+  const addError = useGameStore.use.addError()
+  const gameData = useGameStore.use.gameData()
   const { t } = useTranslation(undefined, { i18n: i18next })
   let ns = props['data-i18n-ns']
   let tKey = props['data-i18n-key']


### PR DESCRIPTION
## Summary
- refactor Translate, If, and Show to use useGameStore.use selectors

## Testing
- `bun tsc`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_68b888730940832293b2f2d578cb17ae