### PR TITLE
docs: require tagging @codex in comments

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -73,3 +73,4 @@ If a container directive nests another container and is followed by an inline di
 - Trust these instructions and search the repository only if information is missing or incorrect.
 - Define colors using `oklch()` notation instead of hex or other color formats.
 - Ensure tests cover both truthy and falsey paths for conditional logic.
+- Tag `@codex` in any comment.


### PR DESCRIPTION
## Summary
- add guideline to always tag @codex in comments

## Testing
- `bunx prettier . --write`
- `bun run typecheck`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68b88ca56ad48322951bdff919df0971