### PR TITLE
refactor: centralize bound field props

### DIFF
--- a/apps/campfire/src/components/Passage/BoundFieldProps.ts
+++ b/apps/campfire/src/components/Passage/BoundFieldProps.ts
@@ -1,0 +1,23 @@
+/**
+ * Common props for form fields bound to a game state key.
+ *
+ * @template V Type of the initial value for the bound field.
+ */
+export interface BoundFieldProps<V> {
+  /** Key in game state to bind the field value to. */
+  stateKey: string
+  /** Additional CSS classes for the element. */
+  className?: string | string[]
+  /** Serialized directives to run on mouse enter. */
+  onMouseEnter?: string
+  /** Serialized directives to run on mouse leave. */
+  onMouseLeave?: string
+  /** Serialized directives to run on focus. */
+  onFocus?: string
+  /** Serialized directives to run on blur. */
+  onBlur?: string
+  /** Initial value if the state key is unset. */
+  initialValue?: V
+  /** Boolean or state key controlling the disabled state. */
+  disabled?: boolean | string
+}

--- a/apps/campfire/src/components/Passage/Checkbox.tsx
+++ b/apps/campfire/src/components/Passage/Checkbox.tsx
@@ -7,36 +7,21 @@ import {
   checkboxStyles,
   checkboxIndicatorStyles
 } from '@campfire/utils/remarkStyles'
+import type { BoundFieldProps } from './BoundFieldProps'
 
 interface CheckboxProps
   extends Omit<
-    JSX.ButtonHTMLAttributes<HTMLButtonElement>,
-    | 'className'
-    | 'value'
-    | 'defaultValue'
-    | 'onFocus'
-    | 'onBlur'
-    | 'onMouseEnter'
-    | 'onMouseLeave'
-    | 'disabled'
-  > {
-  /** Key in game state to bind the checkbox value to. */
-  stateKey: string
-  /** Additional CSS classes for the checkbox element. */
-  className?: string | string[]
-  /** Serialized directives to run on mouse enter. */
-  onMouseEnter?: string
-  /** Serialized directives to run on mouse leave. */
-  onMouseLeave?: string
-  /** Serialized directives to run on focus. */
-  onFocus?: string
-  /** Serialized directives to run on blur. */
-  onBlur?: string
-  /** Initial value if the state key is unset. */
-  initialValue?: boolean
-  /** Boolean or state key controlling the disabled state. */
-  disabled?: boolean | string
-}
+      JSX.ButtonHTMLAttributes<HTMLButtonElement>,
+      | 'className'
+      | 'value'
+      | 'defaultValue'
+      | 'onFocus'
+      | 'onBlur'
+      | 'onMouseEnter'
+      | 'onMouseLeave'
+      | 'disabled'
+    >,
+    BoundFieldProps<boolean> {}
 
 /**
  * Checkbox bound to a game state key. Updates the key on user interaction.

--- a/apps/campfire/src/components/Passage/Input.tsx
+++ b/apps/campfire/src/components/Passage/Input.tsx
@@ -3,39 +3,24 @@ import { useEffect } from 'preact/hooks'
 import { useDirectiveEvents } from '@campfire/hooks/useDirectiveEvents'
 import { mergeClasses, evalExpression } from '@campfire/utils/core'
 import { useGameStore } from '@campfire/state/useGameStore'
+import type { BoundFieldProps } from './BoundFieldProps'
 
 const inputStyles =
   'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive'
 
 interface InputProps
   extends Omit<
-    JSX.InputHTMLAttributes<HTMLInputElement>,
-    | 'className'
-    | 'value'
-    | 'defaultValue'
-    | 'onFocus'
-    | 'onBlur'
-    | 'onMouseEnter'
-    | 'onMouseLeave'
-    | 'disabled'
-  > {
-  /** Key in game state to bind the input value to. */
-  stateKey: string
-  /** Additional CSS classes for the input element. */
-  className?: string | string[]
-  /** Serialized directives to run on mouse enter. */
-  onMouseEnter?: string
-  /** Serialized directives to run on mouse leave. */
-  onMouseLeave?: string
-  /** Serialized directives to run on focus. */
-  onFocus?: string
-  /** Serialized directives to run on blur. */
-  onBlur?: string
-  /** Initial value if the state key is unset. */
-  initialValue?: string
-  /** Boolean or state key controlling the disabled state. */
-  disabled?: boolean | string
-}
+      JSX.InputHTMLAttributes<HTMLInputElement>,
+      | 'className'
+      | 'value'
+      | 'defaultValue'
+      | 'onFocus'
+      | 'onBlur'
+      | 'onMouseEnter'
+      | 'onMouseLeave'
+      | 'disabled'
+    >,
+    BoundFieldProps<string> {}
 
 /**
  * Text input bound to a game state key. Updates the key on user input.

--- a/apps/campfire/src/components/Passage/Radio.tsx
+++ b/apps/campfire/src/components/Passage/Radio.tsx
@@ -4,37 +4,23 @@ import { useDirectiveEvents } from '@campfire/hooks/useDirectiveEvents'
 import { mergeClasses, evalExpression } from '@campfire/utils/core'
 import { useGameStore } from '@campfire/state/useGameStore'
 import { radioStyles, radioIndicatorStyles } from '@campfire/utils/remarkStyles'
+import type { BoundFieldProps } from './BoundFieldProps'
 
 interface RadioProps
   extends Omit<
-    JSX.ButtonHTMLAttributes<HTMLButtonElement>,
-    | 'className'
-    | 'value'
-    | 'defaultValue'
-    | 'onFocus'
-    | 'onBlur'
-    | 'onMouseEnter'
-    | 'onMouseLeave'
-    | 'disabled'
-  > {
-  /** Key in game state to bind the radio selection to. */
-  stateKey: string
+      JSX.ButtonHTMLAttributes<HTMLButtonElement>,
+      | 'className'
+      | 'value'
+      | 'defaultValue'
+      | 'onFocus'
+      | 'onBlur'
+      | 'onMouseEnter'
+      | 'onMouseLeave'
+      | 'disabled'
+    >,
+    BoundFieldProps<string> {
   /** Value represented by this radio button. */
   value: string
-  /** Additional CSS classes for the radio element. */
-  className?: string | string[]
-  /** Serialized directives to run on mouse enter. */
-  onMouseEnter?: string
-  /** Serialized directives to run on mouse leave. */
-  onMouseLeave?: string
-  /** Serialized directives to run on focus. */
-  onFocus?: string
-  /** Serialized directives to run on blur. */
-  onBlur?: string
-  /** Initial value if the state key is unset. */
-  initialValue?: string
-  /** Boolean or state key controlling the disabled state. */
-  disabled?: boolean | string
 }
 
 /**

--- a/apps/campfire/src/components/Passage/Select.tsx
+++ b/apps/campfire/src/components/Passage/Select.tsx
@@ -5,40 +5,26 @@ import { useDirectiveEvents } from '@campfire/hooks/useDirectiveEvents'
 import { mergeClasses, evalExpression } from '@campfire/utils/core'
 import { useGameStore } from '@campfire/state/useGameStore'
 import type { OptionProps } from './Option'
+import type { BoundFieldProps } from './BoundFieldProps'
 const selectStyles =
   'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-2 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive'
 
 interface SelectProps
   extends Omit<
-    JSX.HTMLAttributes<HTMLButtonElement>,
-    | 'className'
-    | 'onInput'
-    | 'onFocus'
-    | 'onBlur'
-    | 'onMouseEnter'
-    | 'onMouseLeave'
-    | 'disabled'
-  > {
-  /** Key in game state to bind the select value to. */
-  stateKey: string
-  /** Additional CSS classes for the select element. */
-  className?: string | string[]
-  /** Serialized directives to run on mouse enter. */
-  onMouseEnter?: string
-  /** Serialized directives to run on mouse leave. */
-  onMouseLeave?: string
-  /** Serialized directives to run on focus. */
-  onFocus?: string
-  /** Serialized directives to run on blur. */
-  onBlur?: string
+      JSX.HTMLAttributes<HTMLButtonElement>,
+      | 'className'
+      | 'onInput'
+      | 'onFocus'
+      | 'onBlur'
+      | 'onMouseEnter'
+      | 'onMouseLeave'
+      | 'disabled'
+    >,
+    BoundFieldProps<string> {
   /** Optional input event handler. */
   onInput?: JSX.HTMLAttributes<HTMLButtonElement>['onInput']
-  /** Initial value if the state key is unset. */
-  initialValue?: string
   /** Text shown when no option is selected. */
   label?: string
-  /** Boolean or state key controlling the disabled state. */
-  disabled?: boolean | string
 }
 
 /**

--- a/apps/campfire/src/components/Passage/Textarea.tsx
+++ b/apps/campfire/src/components/Passage/Textarea.tsx
@@ -3,39 +3,24 @@ import { useEffect } from 'preact/hooks'
 import { useDirectiveEvents } from '@campfire/hooks/useDirectiveEvents'
 import { mergeClasses, evalExpression } from '@campfire/utils/core'
 import { useGameStore } from '@campfire/state/useGameStore'
+import type { BoundFieldProps } from './BoundFieldProps'
 
 const textareaStyles =
   'border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm'
 
 interface TextareaProps
   extends Omit<
-    JSX.TextareaHTMLAttributes<HTMLTextAreaElement>,
-    | 'className'
-    | 'value'
-    | 'defaultValue'
-    | 'onFocus'
-    | 'onBlur'
-    | 'onMouseEnter'
-    | 'onMouseLeave'
-    | 'disabled'
-  > {
-  /** Key in game state to bind the textarea value to. */
-  stateKey: string
-  /** Additional CSS classes for the textarea element. */
-  className?: string | string[]
-  /** Serialized directives to run on mouse enter. */
-  onMouseEnter?: string
-  /** Serialized directives to run on mouse leave. */
-  onMouseLeave?: string
-  /** Serialized directives to run on focus. */
-  onFocus?: string
-  /** Serialized directives to run on blur. */
-  onBlur?: string
-  /** Initial value if the state key is unset. */
-  initialValue?: string
-  /** Boolean or state key controlling the disabled state. */
-  disabled?: boolean | string
-}
+      JSX.TextareaHTMLAttributes<HTMLTextAreaElement>,
+      | 'className'
+      | 'value'
+      | 'defaultValue'
+      | 'onFocus'
+      | 'onBlur'
+      | 'onMouseEnter'
+      | 'onMouseLeave'
+      | 'disabled'
+    >,
+    BoundFieldProps<string> {}
 
 /**
  * Textarea bound to a game state key. Updates the key on user input.


### PR DESCRIPTION
## Summary
- extract `BoundFieldProps` interface for shared field properties
- update input, textarea, select, checkbox, and radio components to extend `BoundFieldProps`

## Testing
- `bun tsc --pretty false --noEmit`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_68b8b82f2f28832282f413be2f36bcdb