### PR TITLE
fix: avoid circular dependency in If component

### DIFF
--- a/apps/campfire/src/components/Passage/If.tsx
+++ b/apps/campfire/src/components/Passage/If.tsx
@@ -15,12 +15,12 @@ import { TriggerButton } from '@campfire/components/Passage/TriggerButton'
 import { Show } from '@campfire/components/Passage/Show'
 import { Translate } from '@campfire/components/Passage/Translate'
 import { OnExit } from '@campfire/components/Passage/OnExit'
+import { SlideReveal } from '@campfire/components/Deck/Slide/SlideReveal'
 import {
-  SlideReveal,
   SlideText,
   SlideImage,
   SlideShape
-} from '@campfire/components/Deck/Slide'
+} from '@campfire/components/Deck/Slide/SlideElements'
 import { rehypeSlideText } from '@campfire/utils/rehypeSlideText'
 
 interface IfProps {


### PR DESCRIPTION
## Summary
- import slide modules directly in If to remove rollup circular dependency warning

## Testing
- `bun tsc`
- `bun test`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8d10997f883228cbf591a455fc60e