### PR TITLE
refactor: combine directive and whitespace walks

### DIFF
--- a/apps/campfire/src/remark-campfire/__tests__/whitespace-paragraphs.test.ts
+++ b/apps/campfire/src/remark-campfire/__tests__/whitespace-paragraphs.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'bun:test'
+import { VFile } from 'vfile'
+import remarkCampfire from '../index'
+import type { Root, Paragraph, Text } from 'mdast'
+import type { LeafDirective } from 'mdast-util-directive'
+
+/**
+ * Creates a paragraph node containing only whitespace.
+ *
+ * @returns Whitespace-only paragraph node.
+ */
+const createWhitespaceParagraph = (): Paragraph => ({
+  type: 'paragraph',
+  children: [{ type: 'text', value: '  ' } as Text]
+})
+
+describe('remarkCampfire whitespace stripping', () => {
+  it('handles directives and removes whitespace-only paragraphs', () => {
+    const directive: LeafDirective = {
+      type: 'leafDirective',
+      name: 'test',
+      children: []
+    }
+    const retained: Paragraph = {
+      type: 'paragraph',
+      data: { hName: 'span' },
+      children: [{ type: 'text', value: ' ' } as Text]
+    }
+    const tree: Root = {
+      type: 'root',
+      children: [createWhitespaceParagraph(), directive, retained]
+    }
+    let handled = false
+    remarkCampfire({
+      handlers: {
+        test: () => {
+          handled = true
+        }
+      }
+    })(tree, new VFile(''))
+    expect(handled).toBe(true)
+    expect(tree.children).toHaveLength(2)
+    expect(tree.children[0]).toBe(directive)
+    expect((tree.children[1] as Paragraph).data?.hName).toBe('span')
+  })
+})

--- a/apps/campfire/src/remark-campfire/index.ts
+++ b/apps/campfire/src/remark-campfire/index.ts
@@ -1,12 +1,19 @@
 import { visit } from 'unist-util-visit'
-import type { Root, Parent, Paragraph, Text, InlineCode } from 'mdast'
+import type { SKIP } from 'unist-util-visit'
+import type {
+  Root,
+  RootContent,
+  Parent,
+  Paragraph,
+  Text,
+  InlineCode
+} from 'mdast'
 import type { Node, Data } from 'unist'
 import type {
   ContainerDirective,
   LeafDirective,
   TextDirective
 } from 'mdast-util-directive'
-import type { SKIP } from 'unist-util-visit'
 import type { VFile } from 'vfile'
 
 export type DirectiveNode = ContainerDirective | LeafDirective | TextDirective
@@ -253,9 +260,32 @@ const remarkCampfire =
   (options: RemarkCampfireOptions = {}) =>
   (tree: Root, file: VFile) => {
     const content = typeof file.value === 'string' ? file.value : undefined
+    const parentMap = new WeakMap<Parent, Parent | undefined>()
+    const pendingRemoval: Array<{ parent: Parent; index: number }> = []
     visit(
       tree,
       (node: Node, index: number | undefined, parent: Parent | undefined) => {
+        if (parent && typeof (node as Parent).children !== 'undefined') {
+          parentMap.set(node as Parent, parent)
+        }
+        if (node.type === 'paragraph' && parent && typeof index === 'number') {
+          const paragraph = node as ParagraphWithData
+          // Preserve paragraphs transformed into custom elements
+          if (paragraph.data?.hName) return
+          // TODO(campfire): Do not remove marker-only paragraphs/text at the
+          // remark stage. Double-check we only strip paragraphs that are truly
+          // whitespace-only. Add regression tests for this sentinel.
+          const hasContent = paragraph.children.some(child => {
+            return !(
+              child.type === 'text' && (child as Text).value.trim() === ''
+            )
+          })
+          if (!hasContent) {
+            parent.children.splice(index, 1)
+            return index
+          }
+          return
+        }
         if (
           node &&
           (node.type === 'textDirective' ||
@@ -355,35 +385,38 @@ const remarkCampfire =
             }
           }
           const handler = options.handlers?.[directive.name]
+          let result: DirectiveHandlerResult | void = undefined
           if (handler) {
-            return handler(directive, parent, index)
+            result = handler(directive, parent, index)
           }
+          if (parent && parent.type === 'paragraph') {
+            const paragraph = parent as ParagraphWithData
+            if (!paragraph.data?.hName) {
+              const hasContent = paragraph.children.some(child => {
+                return !(
+                  child.type === 'text' && (child as Text).value.trim() === ''
+                )
+              })
+              if (!hasContent) {
+                const grand = parentMap.get(parent)
+                if (grand) {
+                  const pIndex = grand.children.indexOf(
+                    parent as unknown as RootContent
+                  )
+                  if (pIndex > -1) {
+                    pendingRemoval.push({ parent: grand, index: pIndex })
+                  }
+                }
+              }
+            }
+          }
+          return result
         }
       }
     )
-
-    visit(
-      tree,
-      (node: Node, index: number | undefined, parent: Parent | undefined) => {
-        if (node.type === 'paragraph' && parent && typeof index === 'number') {
-          const paragraph = node as ParagraphWithData
-          // Preserve paragraphs transformed into custom elements
-          if (paragraph.data?.hName) return
-          // TODO(campfire): Do not remove marker-only paragraphs/text at the
-          // remark stage. Double-check we only strip paragraphs that are truly
-          // whitespace-only. Add regression tests for this sentinel.
-          const hasContent = paragraph.children.some(child => {
-            return !(
-              child.type === 'text' && (child as Text).value.trim() === ''
-            )
-          })
-          if (!hasContent) {
-            parent.children.splice(index, 1)
-            return index
-          }
-        }
-      }
-    )
+    for (const { parent: grand, index: pIndex } of pendingRemoval.reverse()) {
+      grand.children.splice(pIndex, 1)
+    }
   }
 
 export default remarkCampfire


### PR DESCRIPTION
## Summary
- unify directive processing and whitespace cleanup in a single remark visitor
- guard paragraphs with `hName` and queue empty ones for removal
- add regression test for directive handling with whitespace stripping

## Testing
- `bun tsc`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_68b9d556168c8322856ebf5f5a60841d