### PR TITLE
perf: cache parsed directive event data

### DIFF
--- a/apps/campfire/src/hooks/__tests__/useDirectiveEvents.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/useDirectiveEvents.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach } from 'bun:test'
+import { render, act } from '@testing-library/preact'
+import { unified } from 'unified'
+import remarkParse from 'remark-parse'
+import remarkGfm from 'remark-gfm'
+import remarkDirective from 'remark-directive'
+import type { RootContent } from 'mdast'
+import { useDirectiveEvents } from '@campfire/hooks/useDirectiveEvents'
+import { useGameStore } from '@campfire/state/useGameStore'
+import { resetStores } from '@campfire/test-utils/helpers'
+
+/**
+ * Serializes a directive markdown snippet into a JSON string.
+ *
+ * @param md - Markdown containing directives.
+ * @returns Serialized directive nodes.
+ */
+const serialize = (md: string) =>
+  JSON.stringify(
+    unified().use(remarkParse).use(remarkGfm).use(remarkDirective).parse(md)
+      .children as RootContent[]
+  )
+
+describe('useDirectiveEvents', () => {
+  beforeEach(() => {
+    resetStores()
+  })
+
+  it('executes directives when event handlers fire', () => {
+    const content = serialize('::push{key=items value=1}')
+
+    /** Test component wiring directive events. */
+    const TestComponent = () => {
+      const { onMouseEnter } = useDirectiveEvents(content)
+      return <div data-testid='target' onMouseEnter={onMouseEnter} />
+    }
+
+    render(<TestComponent />)
+    const el = document.querySelector('[data-testid="target"]') as HTMLElement
+
+    act(() => {
+      el.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }))
+      el.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }))
+    })
+
+    expect((useGameStore.getState().gameData.items as unknown[]).length).toBe(2)
+  })
+
+  it('returns undefined handlers when content is missing', () => {
+    /** Component without directive content. */
+    const TestComponent = () => {
+      const { onMouseEnter } = useDirectiveEvents()
+      return <div data-testid='target' onMouseEnter={onMouseEnter} />
+    }
+
+    const { container } = render(<TestComponent />)
+    const el = container.firstElementChild as HTMLDivElement
+    expect(el.onmouseenter).toBeNull()
+  })
+})

--- a/apps/campfire/src/hooks/useDirectiveEvents.ts
+++ b/apps/campfire/src/hooks/useDirectiveEvents.ts
@@ -8,6 +8,22 @@ import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
 const clone = rfdc()
 
 /**
+ * Parses a serialized directive string into directive nodes.
+ *
+ * @param source - Serialized directive string to parse.
+ * @returns Cloned directive nodes or null if parsing fails.
+ */
+const parseDirective = (source?: string): RootContent[] | null => {
+  if (!source) return null
+  try {
+    return clone(JSON.parse(source)) as RootContent[]
+  } catch (error) {
+    console.error('Failed to parse directive JSON', error)
+    return null
+  }
+}
+
+/**
  * Generates directive event handlers from serialized directive strings.
  *
  * @param onMouseEnter - Serialized directives to run on mouse enter.
@@ -29,19 +45,19 @@ export const useDirectiveEvents = (
 } => {
   const handlers = useDirectiveHandlers()
 
-  const enterRef = useRef<RootContent[]>()
-  const leaveRef = useRef<RootContent[]>()
-  const focusRef = useRef<RootContent[]>()
-  const blurRef = useRef<RootContent[]>()
+  const enterRef = useRef<RootContent[] | null>(null)
+  const leaveRef = useRef<RootContent[] | null>(null)
+  const focusRef = useRef<RootContent[] | null>(null)
+  const blurRef = useRef<RootContent[] | null>(null)
 
-  if (onMouseEnter && !enterRef.current)
-    enterRef.current = clone(JSON.parse(onMouseEnter)) as RootContent[]
-  if (onMouseLeave && !leaveRef.current)
-    leaveRef.current = clone(JSON.parse(onMouseLeave)) as RootContent[]
-  if (onFocus && !focusRef.current)
-    focusRef.current = clone(JSON.parse(onFocus)) as RootContent[]
-  if (onBlur && !blurRef.current)
-    blurRef.current = clone(JSON.parse(onBlur)) as RootContent[]
+  if (enterRef.current === null && onMouseEnter)
+    enterRef.current = parseDirective(onMouseEnter)
+  if (leaveRef.current === null && onMouseLeave)
+    leaveRef.current = parseDirective(onMouseLeave)
+  if (focusRef.current === null && onFocus)
+    focusRef.current = parseDirective(onFocus)
+  if (blurRef.current === null && onBlur)
+    blurRef.current = parseDirective(onBlur)
 
   /**
    * Creates an event handler that executes pre-parsed directive nodes.
@@ -49,7 +65,7 @@ export const useDirectiveEvents = (
    * @param nodes - Directive nodes to execute.
    * @returns Event handler or undefined.
    */
-  const createHandler = (nodes?: RootContent[]) =>
+  const createHandler = (nodes: RootContent[] | null) =>
     nodes ? () => runDirectiveBlock(clone(nodes), handlers) : undefined
 
   // TODO(campfire): Consider debouncing mouse events and preventing re-entry


### PR DESCRIPTION
## Summary
- cache parsed directive event arrays in refs so handlers reuse them
- add tests to ensure directive event handlers run correctly

## Testing
- `bun tsc`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_68b9f9be6a1c8322adb7057250d5811f