### PR TITLE
perf: cache directive processors

### DIFF
--- a/apps/campfire/src/utils/__tests__/directiveUtils.test.ts
+++ b/apps/campfire/src/utils/__tests__/directiveUtils.test.ts
@@ -23,6 +23,26 @@ describe('runDirectiveBlock', () => {
     runDirectiveBlock(nodes, { test: handler })
     expect(called).toBe(true)
   })
+
+  it('reuses processors for identical handler maps', () => {
+    const parse = () =>
+      unified().use(remarkParse).use(remarkDirective).parse(':test[]')
+        .children as RootContent[]
+    const handler: DirectiveHandler = () => {}
+    const handlers = { test: handler }
+
+    const firstNodes = parse()
+    const start1 = performance.now()
+    runDirectiveBlock(firstNodes, handlers)
+    const firstTime = performance.now() - start1
+
+    const secondNodes = parse()
+    const start2 = performance.now()
+    runDirectiveBlock(secondNodes, handlers)
+    const secondTime = performance.now() - start2
+
+    expect(secondTime).toBeLessThan(firstTime)
+  })
 })
 
 describe('parseAttributeValue', () => {


### PR DESCRIPTION
## Summary
- cache unified processors per handler map to reuse pipelines
- automatically discard stale processors when handler identities change
- add unit test showing faster repeated directive processing

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68ba07c760088322b44838d0d2aa5121