### PR TITLE
refactor: simplify undefined checks in directive handlers

### DIFF
--- a/apps/campfire/src/hooks/handlers/controlFlowHandlers.ts
+++ b/apps/campfire/src/hooks/handlers/controlFlowHandlers.ts
@@ -98,7 +98,7 @@ export const createControlFlowHandlers = (ctx: ControlFlowHandlerContext) => {
       const attrs = container.attributes || {}
       const [firstKey, firstValue] = Object.entries(attrs)[0] || []
       if (firstKey) {
-        if (firstValue === '' || typeof firstValue === 'undefined') {
+        if (firstValue === '' || firstValue === undefined) {
           expr = firstKey
         } else {
           const valStr = String(firstValue).trim()
@@ -223,7 +223,7 @@ export const createControlFlowHandlers = (ctx: ControlFlowHandlerContext) => {
     let iterableValue: unknown
     try {
       iterableValue = evalExpression(expr, getGameData())
-      if (typeof iterableValue === 'undefined') {
+      if (iterableValue === undefined) {
         iterableValue = parseTypedValue(expr, getGameData())
       }
     } catch (error) {

--- a/apps/campfire/src/hooks/handlers/i18nHandlers.ts
+++ b/apps/campfire/src/hooks/handlers/i18nHandlers.ts
@@ -87,7 +87,7 @@ export const createI18nHandlers = (ctx: I18nHandlerContext) => {
    */
   const handleLang: DirectiveHandler = (directive, parent, index) => {
     const invalid = requireLeafDirective(directive, parent, index, addError)
-    if (typeof invalid !== 'undefined') return invalid
+    if (invalid !== undefined) return invalid
     const locale = toString(directive).trim()
 
     // Basic locale validation: e.g., "en", "en-US", "fr", "zh-CN"
@@ -115,7 +115,7 @@ export const createI18nHandlers = (ctx: I18nHandlerContext) => {
    */
   const handleTranslations: DirectiveHandler = (directive, parent, index) => {
     const invalid = requireLeafDirective(directive, parent, index, addError)
-    if (typeof invalid !== 'undefined') return invalid
+    if (invalid !== undefined) return invalid
     const locale =
       getLabel(directive as ContainerDirective) || toString(directive).trim()
     const attrs = directive.attributes as Record<string, unknown>
@@ -165,7 +165,7 @@ export const createI18nHandlers = (ctx: I18nHandlerContext) => {
     index
   ) => {
     const invalid = requireLeafDirective(directive, parent, index, addError)
-    if (typeof invalid !== 'undefined') return invalid
+    if (invalid !== undefined) return invalid
     const kv = extractKeyValue(
       directive as DirectiveNode,
       parent,

--- a/apps/campfire/src/hooks/handlers/mediaHandlers.ts
+++ b/apps/campfire/src/hooks/handlers/mediaHandlers.ts
@@ -38,7 +38,7 @@ export const createMediaHandlers = (ctx: MediaHandlerContext) => {
    */
   const handlePreloadAudio: DirectiveHandler = (directive, parent, index) => {
     const invalid = requireLeafDirective(directive, parent, index, addError)
-    if (typeof invalid !== 'undefined') return invalid
+    if (invalid !== undefined) return invalid
     const { attrs } = extractAttributes(directive, parent, index, {
       id: { type: 'string' },
       src: { type: 'string' }
@@ -63,7 +63,7 @@ export const createMediaHandlers = (ctx: MediaHandlerContext) => {
    */
   const handlePreloadImage: DirectiveHandler = (directive, parent, index) => {
     const invalid = requireLeafDirective(directive, parent, index, addError)
-    if (typeof invalid !== 'undefined') return invalid
+    if (invalid !== undefined) return invalid
     const { attrs } = extractAttributes(directive, parent, index, {
       id: { type: 'string' },
       src: { type: 'string' }
@@ -88,7 +88,7 @@ export const createMediaHandlers = (ctx: MediaHandlerContext) => {
    */
   const handleSound: DirectiveHandler = (directive, parent, index) => {
     const invalid = requireLeafDirective(directive, parent, index, addError)
-    if (typeof invalid !== 'undefined') return invalid
+    if (invalid !== undefined) return invalid
     const { attrs } = extractAttributes(directive, parent, index, {
       id: { type: 'string' },
       src: { type: 'string' },
@@ -118,7 +118,7 @@ export const createMediaHandlers = (ctx: MediaHandlerContext) => {
    */
   const handleBgm: DirectiveHandler = (directive, parent, index) => {
     const invalid = requireLeafDirective(directive, parent, index, addError)
-    if (typeof invalid !== 'undefined') return invalid
+    if (invalid !== undefined) return invalid
     const { attrs } = extractAttributes(directive, parent, index, {
       id: { type: 'string' },
       src: { type: 'string' },
@@ -156,7 +156,7 @@ export const createMediaHandlers = (ctx: MediaHandlerContext) => {
    */
   const handleVolume: DirectiveHandler = (directive, parent, index) => {
     const invalid = requireLeafDirective(directive, parent, index, addError)
-    if (typeof invalid !== 'undefined') return invalid
+    if (invalid !== undefined) return invalid
     const { attrs } = extractAttributes(directive, parent, index, {
       bgm: { type: 'number' },
       sfx: { type: 'number' }

--- a/apps/campfire/src/hooks/handlers/navigationHandlers.ts
+++ b/apps/campfire/src/hooks/handlers/navigationHandlers.ts
@@ -137,7 +137,7 @@ export const createNavigationHandlers = (ctx: NavigationHandlerContext) => {
    */
   const handleGoto: DirectiveHandler = (directive, parent, index) => {
     const invalid = requireLeafDirective(directive, parent, index, addError)
-    if (typeof invalid !== 'undefined') return invalid
+    if (invalid !== undefined) return invalid
     const attrs = (directive.attributes || {}) as Record<string, unknown>
     const rawText = toString(directive).trim()
     const target = resolvePassageTarget(rawText, attrs)
@@ -172,7 +172,7 @@ export const createNavigationHandlers = (ctx: NavigationHandlerContext) => {
    */
   const handleTitle: DirectiveHandler = (directive, parent, index) => {
     const invalid = requireLeafDirective(directive, parent, index, addError)
-    if (typeof invalid !== 'undefined') return invalid
+    if (invalid !== undefined) return invalid
     if (getIncludeDepth() > 0) return removeNode(parent, index)
     const raw = toString(directive).trim()
     const title = getQuotedValue(raw)
@@ -203,7 +203,7 @@ export const createNavigationHandlers = (ctx: NavigationHandlerContext) => {
    */
   const handleInclude: DirectiveHandler = (directive, parent, index) => {
     const invalid = requireLeafDirective(directive, parent, index, addError)
-    if (typeof invalid !== 'undefined') return invalid
+    if (invalid !== undefined) return invalid
     const attrs = (directive.attributes || {}) as Record<string, unknown>
     const rawText = toString(directive).trim()
     const target = resolvePassageTarget(rawText, attrs)

--- a/apps/campfire/src/hooks/handlers/persistenceHandlers.ts
+++ b/apps/campfire/src/hooks/handlers/persistenceHandlers.ts
@@ -92,7 +92,7 @@ export const createPersistenceHandlers = (ctx: PersistenceHandlerContext) => {
    */
   const handleSave: DirectiveHandler = (directive, parent, index) => {
     const invalid = requireLeafDirective(directive, parent, index, addError)
-    if (typeof invalid !== 'undefined') return invalid
+    if (invalid !== undefined) return invalid
     const attrs = (directive.attributes || {}) as Record<string, unknown>
     const id = typeof attrs.id === 'string' ? attrs.id : 'campfire.save'
     setLoading(true)
@@ -127,7 +127,7 @@ export const createPersistenceHandlers = (ctx: PersistenceHandlerContext) => {
    */
   const handleLoad: DirectiveHandler = (directive, parent, index) => {
     const invalid = requireLeafDirective(directive, parent, index, addError)
-    if (typeof invalid !== 'undefined') return invalid
+    if (invalid !== undefined) return invalid
     const attrs = (directive.attributes || {}) as Record<string, unknown>
     const id = typeof attrs.id === 'string' ? attrs.id : 'campfire.save'
     setLoading(true)
@@ -175,7 +175,7 @@ export const createPersistenceHandlers = (ctx: PersistenceHandlerContext) => {
    */
   const handleClearSave: DirectiveHandler = (directive, parent, index) => {
     const invalid = requireLeafDirective(directive, parent, index, addError)
-    if (typeof invalid !== 'undefined') return invalid
+    if (invalid !== undefined) return invalid
     const attrs = (directive.attributes || {}) as Record<string, unknown>
     const id = typeof attrs.id === 'string' ? attrs.id : 'campfire.save'
     setLoading(true)
@@ -201,7 +201,7 @@ export const createPersistenceHandlers = (ctx: PersistenceHandlerContext) => {
    */
   const handleCheckpoint: DirectiveHandler = (directive, parent, index) => {
     const invalid = requireLeafDirective(directive, parent, index, addError)
-    if (typeof invalid !== 'undefined') return invalid
+    if (invalid !== undefined) return invalid
     if (getLastPassageId() !== getCurrentPassageId()) {
       resetDirectiveState()
     }
@@ -245,7 +245,7 @@ export const createPersistenceHandlers = (ctx: PersistenceHandlerContext) => {
    */
   const handleLoadCheckpoint: DirectiveHandler = (directive, parent, index) => {
     const invalid = requireLeafDirective(directive, parent, index, addError)
-    if (typeof invalid !== 'undefined') return invalid
+    if (invalid !== undefined) return invalid
     if (getIncludeDepth() > 0) return removeNode(parent, index)
     const cp = loadCheckpoint()
     if (cp?.currentPassageId) {
@@ -267,7 +267,7 @@ export const createPersistenceHandlers = (ctx: PersistenceHandlerContext) => {
     index
   ) => {
     const invalid = requireLeafDirective(directive, parent, index, addError)
-    if (typeof invalid !== 'undefined') return invalid
+    if (invalid !== undefined) return invalid
     if (getIncludeDepth() > 0) return removeNode(parent, index)
     setGameStoreState({ checkpoints: {} })
     return removeNode(parent, index)

--- a/apps/campfire/src/hooks/handlers/stateHandlers.ts
+++ b/apps/campfire/src/hooks/handlers/stateHandlers.ts
@@ -119,7 +119,7 @@ export const createStateHandlers = (ctx: StateHandlerContext) => {
     lock = false
   ): DirectiveHandlerResult => {
     const invalid = requireLeafDirective(directive, parent, index, addError)
-    if (typeof invalid !== 'undefined') return invalid
+    if (invalid !== undefined) return invalid
     const rawLabel = hasLabel(directive) ? directive.label : undefined
     const textContent = toString(directive)
     let shorthand: string | undefined
@@ -199,7 +199,7 @@ export const createStateHandlers = (ctx: StateHandlerContext) => {
     lock = false
   ): DirectiveHandlerResult => {
     const invalid = requireLeafDirective(directive, parent, index, addError)
-    if (typeof invalid !== 'undefined') return invalid
+    if (invalid !== undefined) return invalid
     const splitItems = (input: string): string[] => {
       const result: string[] = []
       let current = ''
@@ -290,7 +290,7 @@ export const createStateHandlers = (ctx: StateHandlerContext) => {
     index: number | undefined
   ): DirectiveHandlerResult => {
     const invalid = requireLeafDirective(directive, parent, index, addError)
-    if (typeof invalid !== 'undefined') return invalid
+    if (invalid !== undefined) return invalid
     const parsed = extractKeyValue(directive, parent, index, addError)
     if (!parsed) return index
     const { key, valueRaw } = parsed
@@ -366,7 +366,7 @@ export const createStateHandlers = (ctx: StateHandlerContext) => {
     lock = false
   ): DirectiveHandlerResult => {
     const invalid = requireLeafDirective(directive, parent, index, addError)
-    if (typeof invalid !== 'undefined') return invalid
+    if (invalid !== undefined) return invalid
     const label = hasLabel(directive) ? directive.label : toString(directive)
     const key = ensureKey(label.trim(), parent, index)
     if (!key) return index
@@ -443,7 +443,7 @@ export const createStateHandlers = (ctx: StateHandlerContext) => {
     ): DirectiveHandler =>
     (directive, parent, index) => {
       const invalid = requireLeafDirective(directive, parent, index, addError)
-      if (typeof invalid !== 'undefined') return invalid
+      if (invalid !== undefined) return invalid
       const attrs = directive.attributes || {}
       const key = ensureKey(
         (attrs as Record<string, unknown>).key,
@@ -542,7 +542,7 @@ export const createStateHandlers = (ctx: StateHandlerContext) => {
    */
   const handleUnset: DirectiveHandler = (directive, parent, index) => {
     const invalid = requireLeafDirective(directive, parent, index, addError)
-    if (typeof invalid !== 'undefined') return invalid
+    if (invalid !== undefined) return invalid
     const attrs = directive.attributes || {}
     const key = ensureKey(
       (attrs as Record<string, unknown>).key ??

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -1209,7 +1209,7 @@ export const useDirectiveHandlers = () => {
   const handleImage: DirectiveHandler = (directive, parent, index) => {
     if (!parent || typeof index !== 'number') return
     const invalid = requireLeafDirective(directive, parent, index, addError)
-    if (typeof invalid !== 'undefined') return invalid
+    if (invalid !== undefined) return invalid
     const { attrs } = extractAttributes<ImageSchema>(
       directive,
       parent,

--- a/apps/campfire/src/state/utils.ts
+++ b/apps/campfire/src/state/utils.ts
@@ -128,8 +128,7 @@ export class StateManager<T extends Record<string, unknown>> {
     }, this.data)
 
   /** Checks if a value exists at the given path. */
-  hasValue = (path: string): boolean =>
-    typeof this.getValue(path) !== 'undefined'
+  hasValue = (path: string): boolean => this.getValue(path) !== undefined
 
   /** Records a modified top-level key. */
   private record = (key: string) => {

--- a/apps/campfire/src/utils/directiveUtils.ts
+++ b/apps/campfire/src/utils/directiveUtils.ts
@@ -434,7 +434,7 @@ const validateRequiredAttribute = (
   value: unknown,
   errors: string[]
 ): boolean => {
-  if (typeof value === 'undefined') {
+  if (value === undefined) {
     if (spec.required)
       errors.push(
         `Directive "${directive}" missing required attribute "${name}"`
@@ -501,7 +501,7 @@ export const extractAttributes = <S extends AttributeSchema>(
   ][]) {
     const raw = attrs[name as string]
     let value = parseAttributeValue(raw, spec, state)
-    if (typeof value === 'undefined' && typeof spec.default !== 'undefined') {
+    if (value === undefined && typeof spec.default !== 'undefined') {
       value = spec.default
     }
     if (name === keyAttr) {


### PR DESCRIPTION
## Summary
- replace `typeof var !== 'undefined'` checks with direct `var !== undefined`
- update undefined comparisons for `invalid`, `value`, `firstValue`, `iterableValue`, and `getValue` calls across handlers

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68ba10a0a6e4832285effb4f99222032