### PR TITLE
fix: use globalThis for browser APIs

### DIFF
--- a/apps/campfire/src/components/Campfire/applyUserStyles.ts
+++ b/apps/campfire/src/components/Campfire/applyUserStyles.ts
@@ -5,11 +5,9 @@
  * @param {Document | undefined} doc - The document to apply styles to. Defaults to the global document if available.
  */
 export const applyUserStyles = (
-  doc: Document | undefined = typeof document === 'undefined'
-    ? undefined
-    : document
+  doc: Document | undefined = globalThis.document
 ) => {
-  if (!doc || typeof doc.querySelector !== 'function') return
+  if (!doc?.querySelector) return
   const container = doc.querySelector('tw-storydata')
   const el = container?.querySelector(
     '#twine-user-stylesheet'

--- a/apps/campfire/src/components/Campfire/evaluateUserScript.ts
+++ b/apps/campfire/src/components/Campfire/evaluateUserScript.ts
@@ -5,11 +5,9 @@
  * constructor in the global scope. Only use this with trusted content.
  */
 export const evaluateUserScript = (
-  doc: Document | undefined = typeof document === 'undefined'
-    ? undefined
-    : document
+  doc: Document | undefined = globalThis.document
 ) => {
-  if (!doc || typeof doc.getElementById !== 'function') return
+  if (!doc?.getElementById) return
   const el = doc.getElementById('twine-user-script') as HTMLScriptElement | null
   const code = el?.textContent
   if (!code) return

--- a/apps/campfire/src/components/Campfire/index.tsx
+++ b/apps/campfire/src/components/Campfire/index.tsx
@@ -89,12 +89,8 @@ export const Campfire = ({
     return passages
   }
 
-  const initialize = (
-    doc: Document | undefined = typeof document === 'undefined'
-      ? undefined
-      : document
-  ) => {
-    if (!doc || typeof doc.querySelector !== 'function') return
+  const initialize = (doc: Document | undefined = globalThis.document) => {
+    if (!doc?.querySelector) return
     const el = doc.querySelector('tw-storydata')
     if (!el) return
     const tree = fromDom(el)

--- a/apps/campfire/src/components/transition.ts
+++ b/apps/campfire/src/components/transition.ts
@@ -9,8 +9,8 @@ import {
  * @returns True if reduced motion is preferred.
  */
 export const prefersReducedMotion = (): boolean =>
-  typeof window !== 'undefined' &&
-  window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true
+  globalThis.window?.matchMedia?.('(prefers-reduced-motion: reduce)')
+    ?.matches === true
 
 /**
  * Default transition used when none is provided.

--- a/apps/campfire/src/hooks/handlers/persistenceHandlers.ts
+++ b/apps/campfire/src/hooks/handlers/persistenceHandlers.ts
@@ -97,7 +97,7 @@ export const createPersistenceHandlers = (ctx: PersistenceHandlerContext) => {
     const id = typeof attrs.id === 'string' ? attrs.id : 'campfire.save'
     setLoading(true)
     try {
-      if (typeof localStorage !== 'undefined') {
+      if ('localStorage' in globalThis) {
         const cps = getCheckpoints()
         const state = getState()
         const data = {
@@ -107,7 +107,7 @@ export const createPersistenceHandlers = (ctx: PersistenceHandlerContext) => {
           checkpoints: { ...cps },
           currentPassageId: getCurrentPassageId()
         }
-        localStorage.setItem(id, JSON.stringify(data))
+        globalThis.localStorage.setItem(id, JSON.stringify(data))
       }
     } catch (error) {
       console.error('Error saving game state:', error)
@@ -132,8 +132,8 @@ export const createPersistenceHandlers = (ctx: PersistenceHandlerContext) => {
     const id = typeof attrs.id === 'string' ? attrs.id : 'campfire.save'
     setLoading(true)
     try {
-      if (typeof localStorage !== 'undefined') {
-        const raw = localStorage.getItem(id)
+      if ('localStorage' in globalThis) {
+        const raw = globalThis.localStorage.getItem(id)
         if (raw) {
           const data = JSON.parse(raw) as {
             gameData?: Record<string, unknown>
@@ -180,8 +180,8 @@ export const createPersistenceHandlers = (ctx: PersistenceHandlerContext) => {
     const id = typeof attrs.id === 'string' ? attrs.id : 'campfire.save'
     setLoading(true)
     try {
-      if (typeof localStorage !== 'undefined') {
-        localStorage.removeItem(id)
+      if ('localStorage' in globalThis) {
+        globalThis.localStorage.removeItem(id)
       }
     } catch (error) {
       console.error('Error clearing saved game state:', error)

--- a/apps/campfire/src/state/useGameStore/index.ts
+++ b/apps/campfire/src/state/useGameStore/index.ts
@@ -90,11 +90,12 @@ export interface SavedGame {
  */
 export const listSavedGames = (prefix = 'campfire.save'): SavedGame[] => {
   const saves: SavedGame[] = []
-  if (typeof localStorage === 'undefined') return saves
-  for (let i = 0; i < localStorage.length; i++) {
-    const key = localStorage.key(i)
+  if (!('localStorage' in globalThis)) return saves
+  const ls = globalThis.localStorage
+  for (let i = 0; i < ls.length; i++) {
+    const key = ls.key(i)
     if (!key || !key.startsWith(prefix)) continue
-    const raw = localStorage.getItem(key)
+    const raw = ls.getItem(key)
     if (!raw) continue
     try {
       const data = JSON.parse(raw) as {

--- a/apps/campfire/src/utils/core.ts
+++ b/apps/campfire/src/utils/core.ts
@@ -151,19 +151,13 @@ export const getTranslationOptions = (src: {
  * @returns The base URL string.
  */
 export const getBaseUrl = (): string => {
-  if (
-    typeof window !== 'undefined' &&
-    window.location?.origin &&
-    window.location.origin !== 'null'
-  ) {
-    return window.location.origin
+  const origin = globalThis.window?.location?.origin
+  if (origin && origin !== 'null') {
+    return origin
   }
-  if (
-    typeof document !== 'undefined' &&
-    document.baseURI &&
-    document.baseURI !== 'about:blank'
-  ) {
-    return document.baseURI
+  const baseURI = globalThis.document?.baseURI
+  if (baseURI && baseURI !== 'about:blank') {
+    return baseURI
   }
   return 'http://localhost'
 }


### PR DESCRIPTION
## Summary
- replace typeof checks with globalThis references in browser-specific code
- guard optional browser APIs with optional chaining

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68ba2439830883228df88203230317e2