### PR TITLE
refactor: use store selectors in overlay processor

### DIFF
--- a/apps/campfire/src/hooks/useOverlayProcessor.tsx
+++ b/apps/campfire/src/hooks/useOverlayProcessor.tsx
@@ -51,10 +51,8 @@ const normalizeDirectiveIndentation = (input: string): string =>
  */
 export const useOverlayProcessor = (): void => {
   const handlers = useDirectiveHandlers()
-  const overlays = useStoryDataStore(
-    (state: StoryDataState) => state.overlayPassages
-  )
-  const setOverlays = useOverlayStore(state => state.setOverlays)
+  const overlays = useStoryDataStore.use.overlayPassages()
+  const setOverlays = useOverlayStore.use.setOverlays()
 
   /**
    * Deck component bound to the overlay deck store.


### PR DESCRIPTION
## Summary
- simplify overlay selector usage in useOverlayProcessor

## Testing
- `bun tsc`
- `bun test`
- `bunx prettier . --write`


------
https://chatgpt.com/codex/tasks/task_e_68ba24c4842c8322af21e89c583001f4