### PR TITLE
refactor: remove typeof attribute checks

### DIFF
--- a/apps/campfire/src/hooks/handlers/stateHandlers.ts
+++ b/apps/campfire/src/hooks/handlers/stateHandlers.ts
@@ -150,7 +150,7 @@ export const createStateHandlers = (ctx: StateHandlerContext) => {
       const key = ensureKey(keyRaw, parent, index)
       if (!key) return
       const parsed = parseTypedValue(valueRaw, getGameData())
-      if (typeof parsed !== 'undefined') {
+      if (parsed !== undefined) {
         safe[key] = parsed
       }
     }
@@ -393,9 +393,9 @@ export const createStateHandlers = (ctx: StateHandlerContext) => {
 
     let value: unknown
     const optionList = attrs.from as unknown[] | undefined
-    const hasFrom = typeof attrs.from !== 'undefined'
-    const hasMin = typeof attrs.min !== 'undefined'
-    const hasMax = typeof attrs.max !== 'undefined'
+    const hasFrom = 'from' in attrs
+    const hasMin = 'min' in attrs
+    const hasMax = 'max' in attrs
 
     if (hasFrom) {
       if (optionList && optionList.length) {

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -1532,7 +1532,7 @@ export const useDirectiveHandlers = () => {
         if (typeof preset.size === 'string')
           deckProps.size = parseDeckSize(preset.size as string)
         if (preset.transition) deckProps.transition = preset.transition
-        if (typeof preset.theme !== 'undefined') {
+        if ('theme' in preset) {
           const t = parseThemeValue(preset.theme)
           if (t) deckProps.theme = t
         }
@@ -1543,7 +1543,7 @@ export const useDirectiveHandlers = () => {
       deckProps.size = parseDeckSize(deckAttrs.size)
     }
     if (deckAttrs.transition) deckProps.transition = deckAttrs.transition
-    if (typeof deckAttrs.theme !== 'undefined') {
+    if ('theme' in deckAttrs) {
       const theme = parseThemeValue(deckAttrs.theme)
       if (theme) deckProps.theme = theme
     }

--- a/apps/campfire/src/utils/directiveUtils.ts
+++ b/apps/campfire/src/utils/directiveUtils.ts
@@ -501,7 +501,7 @@ export const extractAttributes = <S extends AttributeSchema>(
   ][]) {
     const raw = attrs[name as string]
     let value = parseAttributeValue(raw, spec, state)
-    if (value === undefined && typeof spec.default !== 'undefined') {
+    if (value === undefined && spec.default !== undefined) {
       value = spec.default
     }
     if (name === keyAttr) {
@@ -574,7 +574,7 @@ export const parseTypedValue = (
       if (!key) continue
       const value = part.slice(colon + 1)
       const parsed = parseTypedValue(value, data)
-      if (typeof parsed !== 'undefined') obj[key] = parsed
+      if (parsed !== undefined) obj[key] = parsed
     }
     return obj
   }


### PR DESCRIPTION
## Summary
- replace typeof checks for undefined attributes with property existence checks
- simplify undefined comparisons

## Testing
- `bun tsc`
- `bun test`
- `bunx prettier . --write`


------
https://chatgpt.com/codex/tasks/task_e_68ba261f60a48322b3cfc976fb68929e