### PR TITLE
fix(campfire): use selector hooks in Passage component

### DIFF
--- a/apps/campfire/src/components/Passage/Passage.tsx
+++ b/apps/campfire/src/components/Passage/Passage.tsx
@@ -114,10 +114,8 @@ export const Passage = () => {
   const passage = useStoryDataStore((state: StoryDataState) =>
     state.getCurrentPassage()
   )
-  const storyData = useStoryDataStore(
-    (state: StoryDataState) => state.storyData
-  )
-  const resetDeck = useDeckStore(state => state.reset)
+  const storyData = useStoryDataStore.use.storyData()
+  const resetDeck = useDeckStore.use.reset()
   const [content, setContent] = useState<ComponentChild | null>(null)
   const prevPassageId = useRef<string | undefined>(undefined)
 


### PR DESCRIPTION
## Summary
- refactor Passage component to use store selector hooks for story data and deck reset

## Testing
- `bun tsc`
- `bun test`
- `bunx prettier . --write`


------
https://chatgpt.com/codex/tasks/task_e_68ba26c09c7c832285cf56ef0811edbe