### PR TITLE
refactor(layer): iterate numeric attributes

### DIFF
--- a/apps/campfire/src/hooks/__tests__/layerDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/layerDirective.test.tsx
@@ -44,14 +44,27 @@ describe('layer directive', () => {
     expect(el.textContent).toContain('Content')
   })
 
-  it('applies layer presets with overrides', () => {
+  it('applies layer presets with overrides for numeric fields', () => {
     const md =
-      ':preset{type="layer" name="base" x=5 y=5 z=2}\n:::layer{from="base" y=10}\nHi\n:::'
+      ':preset{type="layer" name="base" x=5 y=5 w=50 h=60 z=2 rotate=15 scale=2 anchor="center"}\n' +
+      ':::layer{from="base" y=10 w=40 rotate=30 anchor="bottom-right"}\nHi\n:::'
     render(<MarkdownRunner markdown={md} />)
     const el = document.querySelector('[data-testid="layer"]') as HTMLElement
     expect(el.style.left).toBe('5px')
     expect(el.style.top).toBe('10px')
+    expect(el.style.width).toBe('40px')
+    expect(el.style.height).toBe('60px')
     expect(el.style.zIndex).toBe('2')
+    expect(el.style.transform).toBe('rotate(30deg) scale(2)')
+    expect(el.style.transformOrigin).toBe('100% 100%')
+  })
+
+  it('uses anchor from presets when not overridden', () => {
+    const md =
+      ':preset{type="layer" name="base" x=1 y=2 anchor="center"}\n:::layer{from="base"}\nHi\n:::'
+    render(<MarkdownRunner markdown={md} />)
+    const el = document.querySelector('[data-testid="layer"]') as HTMLElement
+    expect(el.style.transformOrigin).toBe('50% 50%')
   })
 
   it('handles nested container directives without stray markers', () => {

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -603,17 +603,18 @@ export const useDirectiveHandlers = () => {
     from: { type: 'string', expression: false }
   } as const
 
-  const LAYER_EXCLUDES = [
+  /** List of numeric attributes supported by layer directives. */
+  const LAYER_NUMERIC_ATTRS = [
     'x',
     'y',
     'w',
     'h',
     'z',
     'rotate',
-    'scale',
-    'anchor',
-    'id'
+    'scale'
   ] as const
+
+  const LAYER_EXCLUDES = [...LAYER_NUMERIC_ATTRS, 'anchor', 'id'] as const
 
   /** Schema describing supported wrapper directive attributes. */
   const wrapperSchema = {
@@ -799,23 +800,17 @@ export const useDirectiveHandlers = () => {
         ? presetsRef.current['layer']?.[String(attrs.from)]
         : undefined
       if (preset) {
-        if (typeof preset.x === 'number') props.x = preset.x
-        if (typeof preset.y === 'number') props.y = preset.y
-        if (typeof preset.w === 'number') props.w = preset.w
-        if (typeof preset.h === 'number') props.h = preset.h
-        if (typeof preset.z === 'number') props.z = preset.z
-        if (typeof preset.rotate === 'number') props.rotate = preset.rotate
-        if (typeof preset.scale === 'number') props.scale = preset.scale
+        for (const key of LAYER_NUMERIC_ATTRS) {
+          const value = preset[key]
+          if (typeof value === 'number') props[key] = value
+        }
         if (preset.anchor) props.anchor = preset.anchor
         applyAdditionalAttributes(preset, props, LAYER_EXCLUDES, addError)
       }
-      if (typeof attrs.x === 'number') props.x = attrs.x
-      if (typeof attrs.y === 'number') props.y = attrs.y
-      if (typeof attrs.w === 'number') props.w = attrs.w
-      if (typeof attrs.h === 'number') props.h = attrs.h
-      if (typeof attrs.z === 'number') props.z = attrs.z
-      if (typeof attrs.rotate === 'number') props.rotate = attrs.rotate
-      if (typeof attrs.scale === 'number') props.scale = attrs.scale
+      for (const key of LAYER_NUMERIC_ATTRS) {
+        const value = attrs[key]
+        if (typeof value === 'number') props[key] = value
+      }
       if (attrs.anchor) props.anchor = attrs.anchor
       const mergedRaw = mergeAttrs(preset, raw)
       props['data-testid'] = 'layer'


### PR DESCRIPTION
## Summary
- refactor layer handler to loop over numeric attribute keys
- test numeric attribute handling and anchor overrides

## Testing
- `bun test`
- `bun tsc`


------
https://chatgpt.com/codex/tasks/task_e_68ba30efe7c083229638c0ab998d2850