### PR TITLE
feat: centralize disabled attribute parsing

### DIFF
--- a/apps/campfire/src/components/Passage/Checkbox.tsx
+++ b/apps/campfire/src/components/Passage/Checkbox.tsx
@@ -1,7 +1,7 @@
 import type { JSX } from 'preact'
 import { useEffect } from 'preact/hooks'
 import { useDirectiveEvents } from '@campfire/hooks/useDirectiveEvents'
-import { mergeClasses, evalExpression } from '@campfire/utils/core'
+import { mergeClasses, parseDisabledAttr } from '@campfire/utils/core'
 import { useGameStore } from '@campfire/state/useGameStore'
 import {
   checkboxStyles,
@@ -49,18 +49,7 @@ export const Checkbox = ({
 }: CheckboxProps) => {
   const gameData = useGameStore.use.gameData()
   const value = gameData[stateKey] as boolean | string | undefined
-  const isDisabled = (() => {
-    if (typeof disabled === 'string') {
-      if (disabled === '' || disabled === 'true') return true
-      if (disabled === 'false') return false
-      try {
-        return Boolean(evalExpression(disabled, gameData))
-      } catch {
-        return false
-      }
-    }
-    return Boolean(disabled)
-  })()
+  const isDisabled = parseDisabledAttr(disabled, gameData)
   const directiveEvents = useDirectiveEvents(
     onMouseEnter,
     onMouseLeave,

--- a/apps/campfire/src/components/Passage/Input.tsx
+++ b/apps/campfire/src/components/Passage/Input.tsx
@@ -1,7 +1,7 @@
 import type { JSX } from 'preact'
 import { useEffect } from 'preact/hooks'
 import { useDirectiveEvents } from '@campfire/hooks/useDirectiveEvents'
-import { mergeClasses, evalExpression } from '@campfire/utils/core'
+import { mergeClasses, parseDisabledAttr } from '@campfire/utils/core'
 import { useGameStore } from '@campfire/state/useGameStore'
 import type { BoundFieldProps } from './BoundFieldProps'
 
@@ -48,18 +48,7 @@ export const Input = ({
 }: InputProps) => {
   const gameData = useGameStore.use.gameData()
   const value = gameData[stateKey] as string | undefined
-  const isDisabled = (() => {
-    if (typeof disabled === 'string') {
-      if (disabled === '' || disabled === 'true') return true
-      if (disabled === 'false') return false
-      try {
-        return Boolean(evalExpression(disabled, gameData))
-      } catch {
-        return false
-      }
-    }
-    return Boolean(disabled)
-  })()
+  const isDisabled = parseDisabledAttr(disabled, gameData)
   const directiveEvents = useDirectiveEvents(
     onMouseEnter,
     onMouseLeave,

--- a/apps/campfire/src/components/Passage/Radio.tsx
+++ b/apps/campfire/src/components/Passage/Radio.tsx
@@ -1,7 +1,7 @@
 import type { JSX } from 'preact'
 import { useEffect } from 'preact/hooks'
 import { useDirectiveEvents } from '@campfire/hooks/useDirectiveEvents'
-import { mergeClasses, evalExpression } from '@campfire/utils/core'
+import { mergeClasses, parseDisabledAttr } from '@campfire/utils/core'
 import { useGameStore } from '@campfire/state/useGameStore'
 import { radioStyles, radioIndicatorStyles } from '@campfire/utils/remarkStyles'
 import type { BoundFieldProps } from './BoundFieldProps'
@@ -51,18 +51,7 @@ export const Radio = ({
 }: RadioProps) => {
   const gameData = useGameStore.use.gameData()
   const value = gameData[stateKey] as string | undefined
-  const isDisabled = (() => {
-    if (typeof disabled === 'string') {
-      if (disabled === '' || disabled === 'true') return true
-      if (disabled === 'false') return false
-      try {
-        return Boolean(evalExpression(disabled, gameData))
-      } catch {
-        return false
-      }
-    }
-    return Boolean(disabled)
-  })()
+  const isDisabled = parseDisabledAttr(disabled, gameData)
   const directiveEvents = useDirectiveEvents(
     onMouseEnter,
     onMouseLeave,

--- a/apps/campfire/src/components/Passage/Select.tsx
+++ b/apps/campfire/src/components/Passage/Select.tsx
@@ -2,7 +2,7 @@ import type { JSX, VNode } from 'preact'
 import { cloneElement, toChildArray } from 'preact'
 import { useEffect, useRef, useState } from 'preact/hooks'
 import { useDirectiveEvents } from '@campfire/hooks/useDirectiveEvents'
-import { mergeClasses, evalExpression } from '@campfire/utils/core'
+import { mergeClasses, parseDisabledAttr } from '@campfire/utils/core'
 import { useGameStore } from '@campfire/state/useGameStore'
 import type { OptionProps } from './Option'
 import { getOptionId } from './Option'
@@ -71,18 +71,7 @@ export const Select = ({
   const gameData = useGameStore.use.gameData()
   const value = gameData[stateKey] as string | undefined
   const setGameData = useGameStore.use.setGameData()
-  const isDisabled = (() => {
-    if (typeof disabled === 'string') {
-      if (disabled === '' || disabled === 'true') return true
-      if (disabled === 'false') return false
-      try {
-        return Boolean(evalExpression(disabled, gameData))
-      } catch {
-        return false
-      }
-    }
-    return Boolean(disabled)
-  })()
+  const isDisabled = parseDisabledAttr(disabled, gameData)
   const directiveEvents = useDirectiveEvents(
     onMouseEnter,
     onMouseLeave,

--- a/apps/campfire/src/components/Passage/Textarea.tsx
+++ b/apps/campfire/src/components/Passage/Textarea.tsx
@@ -1,7 +1,7 @@
 import type { JSX } from 'preact'
 import { useEffect } from 'preact/hooks'
 import { useDirectiveEvents } from '@campfire/hooks/useDirectiveEvents'
-import { mergeClasses, evalExpression } from '@campfire/utils/core'
+import { mergeClasses, parseDisabledAttr } from '@campfire/utils/core'
 import { useGameStore } from '@campfire/state/useGameStore'
 import type { BoundFieldProps } from './BoundFieldProps'
 
@@ -48,18 +48,7 @@ export const Textarea = ({
 }: TextareaProps) => {
   const gameData = useGameStore.use.gameData()
   const value = gameData[stateKey] as string | undefined
-  const isDisabled = (() => {
-    if (typeof disabled === 'string') {
-      if (disabled === '' || disabled === 'true') return true
-      if (disabled === 'false') return false
-      try {
-        return Boolean(evalExpression(disabled, gameData))
-      } catch {
-        return false
-      }
-    }
-    return Boolean(disabled)
-  })()
+  const isDisabled = parseDisabledAttr(disabled, gameData)
   const directiveEvents = useDirectiveEvents(
     onMouseEnter,
     onMouseLeave,

--- a/apps/campfire/src/components/Passage/TriggerButton.tsx
+++ b/apps/campfire/src/components/Passage/TriggerButton.tsx
@@ -2,7 +2,7 @@ import type { RootContent } from 'mdast'
 import rfdc from 'rfdc'
 import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
 import { runDirectiveBlock } from '@campfire/utils/directiveUtils'
-import { mergeClasses, evalExpression } from '@campfire/utils/core'
+import { mergeClasses, parseDisabledAttr } from '@campfire/utils/core'
 import type { JSX } from 'preact'
 import { useDirectiveEvents } from '@campfire/hooks/useDirectiveEvents'
 import { useGameStore } from '@campfire/state/useGameStore'
@@ -66,18 +66,9 @@ export const TriggerButton = ({
     onFocus,
     onBlur
   )
-  const isDisabled = useGameStore(state => {
-    if (typeof disabled === 'string') {
-      if (disabled === '' || disabled === 'true') return true
-      if (disabled === 'false') return false
-      try {
-        return Boolean(evalExpression(disabled, state.gameData))
-      } catch {
-        return false
-      }
-    }
-    return Boolean(disabled)
-  })
+  const isDisabled = useGameStore(state =>
+    parseDisabledAttr(disabled, state.gameData)
+  )
   return (
     <button
       type='button'

--- a/apps/campfire/src/utils/__tests__/core.test.ts
+++ b/apps/campfire/src/utils/__tests__/core.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, afterEach } from 'bun:test'
-import { extractQuoted, getBaseUrl, mergeClasses } from '@campfire/utils/core'
+import {
+  extractQuoted,
+  getBaseUrl,
+  mergeClasses,
+  parseDisabledAttr
+} from '@campfire/utils/core'
 
 describe('extractQuoted', () => {
   it('unwraps single-quoted strings', () => {
@@ -72,5 +77,23 @@ describe('getBaseUrl', () => {
     delete (globalThis as { window?: unknown }).window
     delete (globalThis as { document?: unknown }).document
     expect(getBaseUrl()).toBe('http://localhost')
+  })
+})
+
+describe('parseDisabledAttr', () => {
+  it('handles boolean values', () => {
+    expect(parseDisabledAttr(true)).toBe(true)
+    expect(parseDisabledAttr(false)).toBe(false)
+  })
+
+  it('handles truthy and falsey strings', () => {
+    expect(parseDisabledAttr('')).toBe(true)
+    expect(parseDisabledAttr('true')).toBe(true)
+    expect(parseDisabledAttr('false')).toBe(false)
+  })
+
+  it('evaluates expressions against scope', () => {
+    expect(parseDisabledAttr('count > 0', { count: 1 })).toBe(true)
+    expect(parseDisabledAttr('count > 0', { count: 0 })).toBe(false)
   })
 })

--- a/apps/campfire/src/utils/core.ts
+++ b/apps/campfire/src/utils/core.ts
@@ -126,6 +126,34 @@ export const mergeClasses = (
     .join(' ')
 
 /**
+ * Normalizes a disabled attribute to a boolean.
+ *
+ * Accepts string, boolean, or undefined values. When a string is provided,
+ * empty strings and the literal `'true'` are treated as true, `'false'` as
+ * false, and other strings are evaluated as expressions against the provided
+ * scope.
+ *
+ * @param disabled - Attribute value to parse.
+ * @param scope - Optional scope for expression evaluation.
+ * @returns The resolved boolean value.
+ */
+export const parseDisabledAttr = (
+  disabled: string | boolean | undefined,
+  scope: Record<string, unknown> = {}
+): boolean => {
+  if (typeof disabled === 'string') {
+    if (disabled === '' || disabled === 'true') return true
+    if (disabled === 'false') return false
+    try {
+      return Boolean(evalExpression(disabled, scope))
+    } catch {
+      return false
+    }
+  }
+  return Boolean(disabled)
+}
+
+/**
  * Extracts translation options from directive attributes or component props.
  *
  * @param src - Source object that may contain `ns` and `count` values.


### PR DESCRIPTION
## Summary
- add `parseDisabledAttr` helper for string/boolean disabled attributes
- use helper in passage components to compute disabled state
- test helper with boolean values and truthy/falsey strings

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68ba336bdb188322b2911c0e17048679