### PR TITLE
refactor: centralize directive index guards

### DIFF
--- a/apps/campfire/src/hooks/handlers/formHandlers.ts
+++ b/apps/campfire/src/hooks/handlers/formHandlers.ts
@@ -328,11 +328,11 @@ export const createFormHandlers = (ctx: FormHandlerContext) => {
   const handleRadio: DirectiveHandler = (directive, parent, index) => {
     const pair = ensureParentIndex(parent, index)
     if (!pair) return
-    ;[parent, index] = pair
+    const [p, i] = pair
     if (directive.type === 'textDirective') {
       const label = hasLabel(directive) ? directive.label : toString(directive)
-      const key = ensureKey(label.trim(), parent, index)
-      if (!key) return index
+      const key = ensureKey(label.trim(), p, i)
+      if (!key) return i
       const attrs = (directive.attributes || {}) as Record<string, unknown>
       if (Object.prototype.hasOwnProperty.call(attrs, 'class')) {
         const msg = 'class is a reserved attribute. Use className instead.'
@@ -366,15 +366,15 @@ export const createFormHandlers = (ctx: FormHandlerContext) => {
         children: [],
         data: { hName: 'radio', hProperties: props as Properties }
       }
-      return replaceWithIndentation(directive, parent, index, [
+      return replaceWithIndentation(directive, p, i, [
         node as unknown as RootContent
       ])
     }
     if (directive.type === 'containerDirective') {
       const container = directive as ContainerDirective
       const label = getLabel(container)
-      const key = ensureKey(label.trim(), parent, index)
-      if (!key) return index
+      const key = ensureKey(label.trim(), p, i)
+      if (!key) return i
       const attrs = (container.attributes || {}) as Record<string, unknown>
       if (Object.prototype.hasOwnProperty.call(attrs, 'class')) {
         const msg = 'class is a reserved attribute. Use className instead.'
@@ -395,21 +395,21 @@ export const createFormHandlers = (ctx: FormHandlerContext) => {
       )
       const { events } = extractEventProps(rawChildren)
 
-      const start = index + 1
+      const start = i + 1
       const extras: RootContent[] = []
       let cursor = start
-      while (cursor < parent.children.length) {
-        const sib = parent.children[cursor] as RootContent
+      while (cursor < p.children.length) {
+        const sib = p.children[cursor] as RootContent
         if (
           sib.type === 'containerDirective' &&
           interactiveEvents.has((sib as ContainerDirective).name)
         ) {
           extras.push(sib)
-          parent.children.splice(cursor, 1)
+          p.children.splice(cursor, 1)
           continue
         }
         if (isMarkerParagraph(sib) || isMarkerText(sib)) {
-          parent.children.splice(cursor, 1)
+          p.children.splice(cursor, 1)
         }
         break
       }
@@ -439,27 +439,27 @@ export const createFormHandlers = (ctx: FormHandlerContext) => {
         children: [],
         data: { hName: 'radio', hProperties: props as Properties }
       }
-      const newIndex = replaceWithIndentation(directive, parent, index, [
+      const newIndex = replaceWithIndentation(directive, p, i, [
         node as RootContent
       ])
       const markerIndex = newIndex + 1
-      removeDirectiveMarker(parent, markerIndex)
+      removeDirectiveMarker(p, markerIndex)
       return [SKIP, newIndex]
     }
     const msg = 'radio can only be used as a leaf or container directive'
     console.error(msg)
     addError(msg)
-    return removeNode(parent, index)
+    return removeNode(p, i)
   }
 
   const handleTextarea: DirectiveHandler = (directive, parent, index) => {
     const pair = ensureParentIndex(parent, index)
     if (!pair) return
-    ;[parent, index] = pair
+    const [p, i] = pair
     if (directive.type === 'textDirective') {
       const label = hasLabel(directive) ? directive.label : toString(directive)
-      const key = ensureKey(label.trim(), parent, index)
-      if (!key) return index
+      const key = ensureKey(label.trim(), p, i)
+      if (!key) return i
       const attrs = (directive.attributes || {}) as Record<string, unknown>
       if (Object.prototype.hasOwnProperty.call(attrs, 'class')) {
         const msg = 'class is a reserved attribute. Use className instead.'
@@ -492,15 +492,13 @@ export const createFormHandlers = (ctx: FormHandlerContext) => {
         children: [],
         data: { hName: 'textarea', hProperties: props as Properties }
       }
-      return replaceWithIndentation(directive, parent, index, [
-        node as RootContent
-      ])
+      return replaceWithIndentation(directive, p, i, [node as RootContent])
     }
     if (directive.type === 'containerDirective') {
       const container = directive as ContainerDirective
       const label = getLabel(container)
-      const key = ensureKey(label.trim(), parent, index)
-      if (!key) return index
+      const key = ensureKey(label.trim(), p, i)
+      if (!key) return i
       const attrs = (container.attributes || {}) as Record<string, unknown>
       if (Object.prototype.hasOwnProperty.call(attrs, 'class')) {
         const msg = 'class is a reserved attribute. Use className instead.'
@@ -522,21 +520,21 @@ export const createFormHandlers = (ctx: FormHandlerContext) => {
       )
       const { events } = extractEventProps(rawChildren)
 
-      const start = index + 1
+      const start = i + 1
       const extras: RootContent[] = []
       let cursor = start
-      while (cursor < parent.children.length) {
-        const sib = parent.children[cursor] as RootContent
+      while (cursor < p.children.length) {
+        const sib = p.children[cursor] as RootContent
         if (
           sib.type === 'containerDirective' &&
           interactiveEvents.has((sib as ContainerDirective).name)
         ) {
           extras.push(sib)
-          parent.children.splice(cursor, 1)
+          p.children.splice(cursor, 1)
           continue
         }
         if (isMarkerParagraph(sib) || isMarkerText(sib)) {
-          parent.children.splice(cursor, 1)
+          p.children.splice(cursor, 1)
         }
         break
       }
@@ -565,28 +563,28 @@ export const createFormHandlers = (ctx: FormHandlerContext) => {
         children: [],
         data: { hName: 'textarea', hProperties: props as Properties }
       }
-      const newIndex = replaceWithIndentation(directive, parent, index, [
+      const newIndex = replaceWithIndentation(directive, p, i, [
         node as RootContent
       ])
       const markerIndex = newIndex + 1
-      removeDirectiveMarker(parent, markerIndex)
+      removeDirectiveMarker(p, markerIndex)
       return [SKIP, newIndex]
     }
     const msg = 'textarea can only be used as a leaf or container directive'
     console.error(msg)
     addError(msg)
-    return removeNode(parent, index)
+    return removeNode(p, i)
   }
 
   const handleOption: DirectiveHandler = (directive, parent, index) => {
     const pair = ensureParentIndex(parent, index)
     if (!pair) return
-    ;[parent, index] = pair
+    const [p, i] = pair
     if (directive.type === 'textDirective') {
       const msg = 'option cannot be used as an inline directive'
       console.error(msg)
       addError(msg)
-      return removeNode(parent, index)
+      return removeNode(p, i)
     }
     const attrs = (directive.attributes || {}) as Record<string, unknown>
     const rawValue = attrs.value
@@ -599,7 +597,7 @@ export const createFormHandlers = (ctx: FormHandlerContext) => {
       const msg = 'option requires a value attribute'
       console.error(msg)
       addError(msg)
-      return removeNode(parent, index)
+      return removeNode(p, i)
     }
     if (Object.prototype.hasOwnProperty.call(attrs, 'class')) {
       const msg = 'class is a reserved attribute. Use className instead.'
@@ -629,16 +627,14 @@ export const createFormHandlers = (ctx: FormHandlerContext) => {
         const msg = 'option leaf directives require a label attribute'
         console.error(msg)
         addError(msg)
-        return removeNode(parent, index)
+        return removeNode(p, i)
       }
       const node: Parent = {
         type: 'paragraph',
         children: [{ type: 'text', value: String(labelAttr) }],
         data: { hName: 'option', hProperties: props as Properties }
       }
-      return replaceWithIndentation(directive, parent, index, [
-        node as RootContent
-      ])
+      return replaceWithIndentation(directive, p, i, [node as RootContent])
     }
 
     const container = directive as ContainerDirective
@@ -651,22 +647,22 @@ export const createFormHandlers = (ctx: FormHandlerContext) => {
       children: children as RootContent[],
       data: { hName: 'option', hProperties: props as Properties }
     }
-    const newIndex = replaceWithIndentation(directive, parent, index, [
+    const newIndex = replaceWithIndentation(directive, p, i, [
       node as RootContent
     ])
     const markerIndex = newIndex + 1
-    removeDirectiveMarker(parent, markerIndex)
+    removeDirectiveMarker(p, markerIndex)
     return [SKIP, newIndex]
   }
 
   const handleSelect: DirectiveHandler = (directive, parent, index) => {
     const pair = ensureParentIndex(parent, index)
     if (!pair) return
-    ;[parent, index] = pair
+    const [p, i] = pair
     const container = directive as ContainerDirective
     const label = getLabel(container)
-    const key = ensureKey(label.trim(), parent, index)
-    if (!key) return index
+    const key = ensureKey(label.trim(), p, i)
+    if (!key) return i
     const attrs = (container.attributes || {}) as Record<string, unknown>
     if (Object.prototype.hasOwnProperty.call(attrs, 'class')) {
       const msg = 'class is a reserved attribute. Use className instead.'
@@ -686,21 +682,21 @@ export const createFormHandlers = (ctx: FormHandlerContext) => {
     )
     const { events, remaining } = extractEventProps(rawChildren)
 
-    const start = index + 1
+    const start = i + 1
     const extras: RootContent[] = []
     let cursor = start
-    while (cursor < parent.children.length) {
-      const sib = parent.children[cursor] as RootContent
+    while (cursor < p.children.length) {
+      const sib = p.children[cursor] as RootContent
       if (
         sib.type === 'containerDirective' &&
         interactiveEvents.has((sib as ContainerDirective).name)
       ) {
         extras.push(sib)
-        parent.children.splice(cursor, 1)
+        p.children.splice(cursor, 1)
         continue
       }
       if (isMarkerParagraph(sib) || isMarkerText(sib)) {
-        parent.children.splice(cursor, 1)
+        p.children.splice(cursor, 1)
       }
       break
     }
@@ -729,18 +725,18 @@ export const createFormHandlers = (ctx: FormHandlerContext) => {
       children: options as RootContent[],
       data: { hName: 'select', hProperties: props as Properties }
     }
-    const newIndex = replaceWithIndentation(directive, parent, index, [
+    const newIndex = replaceWithIndentation(directive, p, i, [
       node as RootContent
     ])
     const markerIndex = newIndex + 1
-    removeDirectiveMarker(parent, markerIndex)
+    removeDirectiveMarker(p, markerIndex)
     return [SKIP, newIndex]
   }
 
   const handleTrigger: DirectiveHandler = (directive, parent, index) => {
     const pair = ensureParentIndex(parent, index)
     if (!pair) return
-    ;[parent, index] = pair
+    const [p, i] = pair
     const container = directive as ContainerDirective
     const attrs = (directive.attributes || {}) as Record<string, unknown>
     if (Object.prototype.hasOwnProperty.call(attrs, 'class')) {
@@ -853,12 +849,12 @@ export const createFormHandlers = (ctx: FormHandlerContext) => {
       }
     }
 
-    const start = index + 1
+    const start = i + 1
     const siblings: RootContent[] = []
     let cursor = start
     let endMarker = -1
-    while (cursor < parent.children.length) {
-      const sib = parent.children[cursor] as RootContent
+    while (cursor < p.children.length) {
+      const sib = p.children[cursor] as RootContent
       if (isMarkerParagraph(sib) || isMarkerText(sib)) {
         endMarker = cursor
         break
@@ -872,9 +868,9 @@ export const createFormHandlers = (ctx: FormHandlerContext) => {
     }
 
     if (endMarker !== -1) {
-      parent.children.splice(start, endMarker - start + 1)
+      p.children.splice(start, endMarker - start + 1)
     } else if (siblings.length) {
-      parent.children.splice(start, siblings.length)
+      p.children.splice(start, siblings.length)
     }
 
     const { events: extraEvents, remaining: pendingRemaining } =
@@ -918,7 +914,7 @@ export const createFormHandlers = (ctx: FormHandlerContext) => {
         hProperties: hProps as Properties
       }
     }
-    const newIndex = replaceWithIndentation(directive, parent, index, [
+    const newIndex = replaceWithIndentation(directive, p, i, [
       node as RootContent
     ])
     return [SKIP, newIndex]

--- a/apps/campfire/src/hooks/handlers/i18nHandlers.ts
+++ b/apps/campfire/src/hooks/handlers/i18nHandlers.ts
@@ -16,7 +16,8 @@ import {
 import {
   getClassAttr,
   getStyleAttr,
-  requireLeafDirective
+  requireLeafDirective,
+  ensureParentIndex
 } from '@campfire/utils/directiveHandlerUtils'
 import {
   evalExpression,
@@ -301,9 +302,11 @@ export const createI18nHandlers = (ctx: I18nHandlerContext) => {
         fallback = match ? inner : trimmed
       }
     }
-    if (parent && typeof index === 'number') {
-      const prev = parent.children[index - 1] as MdText | undefined
-      const next = parent.children[index + 1] as MdText | undefined
+    const pair = ensureParentIndex(parent, index)
+    if (pair) {
+      const [p, i] = pair
+      const prev = p.children[i - 1] as MdText | undefined
+      const next = p.children[i + 1] as MdText | undefined
       const inLink =
         prev?.type === 'text' &&
         prev.value.endsWith('[[') &&
@@ -339,10 +342,10 @@ export const createI18nHandlers = (ctx: I18nHandlerContext) => {
         const text = i18next.t(tKey, options)
         if (prev && next) {
           prev.value += text + next.value
-          parent.children.splice(index, 2)
-          return index - 1
+          p.children.splice(i, 2)
+          return i - 1
         }
-        return replaceWithIndentation(directive, parent, index, [
+        return replaceWithIndentation(directive, p, i, [
           { type: 'text', value: text }
         ])
       }
@@ -359,7 +362,7 @@ export const createI18nHandlers = (ctx: I18nHandlerContext) => {
         value: '0',
         data: { hName: 'translate', hProperties: props }
       }
-      return replaceWithIndentation(directive, parent, index, [node])
+      return replaceWithIndentation(directive, p, i, [node])
     }
     return index
   }

--- a/apps/campfire/src/hooks/handlers/navigationHandlers.ts
+++ b/apps/campfire/src/hooks/handlers/navigationHandlers.ts
@@ -15,7 +15,10 @@ import {
   removeNode,
   replaceWithIndentation
 } from '@campfire/utils/directiveUtils'
-import { requireLeafDirective } from '@campfire/utils/directiveHandlerUtils'
+import {
+  ensureParentIndex,
+  requireLeafDirective
+} from '@campfire/utils/directiveHandlerUtils'
 import type { DirectiveHandler } from '@campfire/remark-campfire'
 import { markTitleOverridden } from '@campfire/state/titleState'
 
@@ -208,9 +211,11 @@ export const createNavigationHandlers = (ctx: NavigationHandlerContext) => {
     const rawText = toString(directive).trim()
     const target = resolvePassageTarget(rawText, attrs)
 
-    if (!parent || typeof index !== 'number' || !target) {
+    const pair = ensureParentIndex(parent, index)
+    if (!pair || !target) {
       return removeNode(parent, index)
     }
+    const [p, i] = pair
 
     if (getIncludeDepth() >= MAX_INCLUDE_DEPTH) {
       console.warn('Max include depth reached')
@@ -221,7 +226,7 @@ export const createNavigationHandlers = (ctx: NavigationHandlerContext) => {
       ? getPassageById(target)
       : getPassageByName(target)
 
-    if (!passage) return removeNode(parent, index)
+    if (!passage) return removeNode(p, i)
 
     const text = passage.children
       .map((child: ElementContent) =>
@@ -243,8 +248,8 @@ export const createNavigationHandlers = (ctx: NavigationHandlerContext) => {
 
     const newIndex = replaceWithIndentation(
       directive,
-      parent,
-      index,
+      p,
+      i,
       tree.children as RootContent[]
     )
     return [

--- a/apps/campfire/src/hooks/handlers/stateHandlers.ts
+++ b/apps/campfire/src/hooks/handlers/stateHandlers.ts
@@ -14,7 +14,10 @@ import {
   applyKeyValue,
   isRange
 } from '@campfire/utils/directiveUtils'
-import { requireLeafDirective } from '@campfire/utils/directiveHandlerUtils'
+import {
+  ensureParentIndex,
+  requireLeafDirective
+} from '@campfire/utils/directiveHandlerUtils'
 import {
   getRandomInt,
   getRandomItem,
@@ -177,9 +180,11 @@ export const createStateHandlers = (ctx: StateHandlerContext) => {
       }
     }
 
-    if (parent && typeof index === 'number') {
-      parent.children.splice(index, 1)
-      return index
+    const pair = ensureParentIndex(parent, index)
+    if (pair) {
+      const [p, i] = pair
+      p.children.splice(i, 1)
+      return i
     }
   }
 

--- a/apps/campfire/src/utils/__tests__/directiveHandlerUtils.test.ts
+++ b/apps/campfire/src/utils/__tests__/directiveHandlerUtils.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'bun:test'
+import type { Parent, RootContent } from 'mdast'
+import { ensureParentIndex } from '../directiveHandlerUtils'
+
+describe('ensureParentIndex', () => {
+  it('returns tuple when parent and index are valid', () => {
+    const parent: Parent = { type: 'root', children: [] as RootContent[] }
+    const result = ensureParentIndex(parent, 0)
+    expect(result).toEqual([parent, 0])
+  })
+
+  it('returns undefined when parent or index are missing', () => {
+    const parent: Parent = { type: 'root', children: [] as RootContent[] }
+    expect(ensureParentIndex(undefined, 0)).toBeUndefined()
+    expect(ensureParentIndex(parent, undefined)).toBeUndefined()
+  })
+})

--- a/apps/campfire/src/utils/directiveHandlerUtils.ts
+++ b/apps/campfire/src/utils/directiveHandlerUtils.ts
@@ -70,6 +70,19 @@ export const requireLeafDirective = (
 }
 
 /**
+ * Validates that both `parent` and `index` are provided and returns them when valid.
+ *
+ * @param parent - Parent node potentially containing the directive.
+ * @param index - Index of the directive within the parent node.
+ * @returns A tuple of the parent and index when both are valid, otherwise undefined.
+ */
+export const ensureParentIndex = (
+  parent: Parent | undefined,
+  index: number | undefined
+): [Parent, number] | undefined =>
+  parent && typeof index === 'number' ? [parent, index] : undefined
+
+/**
  * Removes a directive marker paragraph or trims marker text from a paragraph.
  *
  * @param parent - Parent node containing the marker paragraph.


### PR DESCRIPTION
## Summary
- extract reusable `ensureParentIndex` helper
- refactor directive handlers to rely on helper instead of `typeof` checks
- add tests for the new guard

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68ba37d593f483229734f4f0d7f83b2e