### PR TITLE
refactor: centralize bound field element props

### DIFF
--- a/apps/campfire/src/components/Passage/BoundFieldProps.ts
+++ b/apps/campfire/src/components/Passage/BoundFieldProps.ts
@@ -1,3 +1,5 @@
+import type { JSX } from 'preact'
+
 /**
  * Common props for form fields bound to a game state key.
  *
@@ -21,3 +23,32 @@ export interface BoundFieldProps<V> {
   /** Boolean or state key controlling the disabled state. */
   disabled?: boolean | string
 }
+
+type ElementAttributes<T extends HTMLElement> = T extends HTMLInputElement
+  ? JSX.InputHTMLAttributes<T>
+  : T extends HTMLTextAreaElement
+    ? JSX.TextareaHTMLAttributes<T>
+    : T extends HTMLSelectElement
+      ? JSX.SelectHTMLAttributes<T>
+      : T extends HTMLButtonElement
+        ? JSX.ButtonHTMLAttributes<T>
+        : JSX.HTMLAttributes<T>
+
+/**
+ * Props for a bound field rendering a specific HTMLElement.
+ *
+ * @template T Element type rendered.
+ * @template V Type of the initial value for the bound field.
+ */
+export type BoundFieldElementProps<T extends HTMLElement, V> = Omit<
+  ElementAttributes<T>,
+  | 'className'
+  | 'value'
+  | 'defaultValue'
+  | 'onFocus'
+  | 'onBlur'
+  | 'onMouseEnter'
+  | 'onMouseLeave'
+  | 'disabled'
+> &
+  BoundFieldProps<V>

--- a/apps/campfire/src/components/Passage/Checkbox.tsx
+++ b/apps/campfire/src/components/Passage/Checkbox.tsx
@@ -1,4 +1,3 @@
-import type { JSX } from 'preact'
 import { useEffect } from 'preact/hooks'
 import { useDirectiveEvents } from '@campfire/hooks/useDirectiveEvents'
 import { mergeClasses, parseDisabledAttr } from '@campfire/utils/core'
@@ -7,21 +6,9 @@ import {
   checkboxStyles,
   checkboxIndicatorStyles
 } from '@campfire/utils/remarkStyles'
-import type { BoundFieldProps } from './BoundFieldProps'
+import type { BoundFieldElementProps } from './BoundFieldProps'
 
-interface CheckboxProps
-  extends Omit<
-      JSX.ButtonHTMLAttributes<HTMLButtonElement>,
-      | 'className'
-      | 'value'
-      | 'defaultValue'
-      | 'onFocus'
-      | 'onBlur'
-      | 'onMouseEnter'
-      | 'onMouseLeave'
-      | 'disabled'
-    >,
-    BoundFieldProps<boolean> {}
+type CheckboxProps = BoundFieldElementProps<HTMLButtonElement, boolean>
 
 /**
  * Checkbox bound to a game state key. Updates the key on user interaction.

--- a/apps/campfire/src/components/Passage/Input.tsx
+++ b/apps/campfire/src/components/Passage/Input.tsx
@@ -1,26 +1,13 @@
-import type { JSX } from 'preact'
 import { useEffect } from 'preact/hooks'
 import { useDirectiveEvents } from '@campfire/hooks/useDirectiveEvents'
 import { mergeClasses, parseDisabledAttr } from '@campfire/utils/core'
 import { useGameStore } from '@campfire/state/useGameStore'
-import type { BoundFieldProps } from './BoundFieldProps'
+import type { BoundFieldElementProps } from './BoundFieldProps'
 
 const inputStyles =
   'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive'
 
-interface InputProps
-  extends Omit<
-      JSX.InputHTMLAttributes<HTMLInputElement>,
-      | 'className'
-      | 'value'
-      | 'defaultValue'
-      | 'onFocus'
-      | 'onBlur'
-      | 'onMouseEnter'
-      | 'onMouseLeave'
-      | 'disabled'
-    >,
-    BoundFieldProps<string> {}
+type InputProps = BoundFieldElementProps<HTMLInputElement, string>
 
 /**
  * Text input bound to a game state key. Updates the key on user input.

--- a/apps/campfire/src/components/Passage/Radio.tsx
+++ b/apps/campfire/src/components/Passage/Radio.tsx
@@ -1,24 +1,11 @@
-import type { JSX } from 'preact'
 import { useEffect } from 'preact/hooks'
 import { useDirectiveEvents } from '@campfire/hooks/useDirectiveEvents'
 import { mergeClasses, parseDisabledAttr } from '@campfire/utils/core'
 import { useGameStore } from '@campfire/state/useGameStore'
 import { radioStyles, radioIndicatorStyles } from '@campfire/utils/remarkStyles'
-import type { BoundFieldProps } from './BoundFieldProps'
+import type { BoundFieldElementProps } from './BoundFieldProps'
 
-interface RadioProps
-  extends Omit<
-      JSX.ButtonHTMLAttributes<HTMLButtonElement>,
-      | 'className'
-      | 'value'
-      | 'defaultValue'
-      | 'onFocus'
-      | 'onBlur'
-      | 'onMouseEnter'
-      | 'onMouseLeave'
-      | 'disabled'
-    >,
-    BoundFieldProps<string> {
+type RadioProps = BoundFieldElementProps<HTMLButtonElement, string> & {
   /** Value represented by this radio button. */
   value: string
 }

--- a/apps/campfire/src/components/Passage/Select.tsx
+++ b/apps/campfire/src/components/Passage/Select.tsx
@@ -6,7 +6,7 @@ import { mergeClasses, parseDisabledAttr } from '@campfire/utils/core'
 import { useGameStore } from '@campfire/state/useGameStore'
 import type { OptionProps } from './Option'
 import { getOptionId } from './Option'
-import type { BoundFieldProps } from './BoundFieldProps'
+import type { BoundFieldElementProps } from './BoundFieldProps'
 
 /** Counter used to generate deterministic IDs. */
 let idCounter = 0
@@ -21,18 +21,10 @@ const generateId = (prefix: string) => `${prefix}-${++idCounter}`
 const selectStyles =
   'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-2 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive'
 
-interface SelectProps
-  extends Omit<
-      JSX.HTMLAttributes<HTMLButtonElement>,
-      | 'className'
-      | 'onInput'
-      | 'onFocus'
-      | 'onBlur'
-      | 'onMouseEnter'
-      | 'onMouseLeave'
-      | 'disabled'
-    >,
-    BoundFieldProps<string> {
+type SelectProps = Omit<
+  BoundFieldElementProps<HTMLButtonElement, string>,
+  'onInput'
+> & {
   /** Optional input event handler. */
   onInput?: JSX.HTMLAttributes<HTMLButtonElement>['onInput']
   /** Text shown when no option is selected. */

--- a/apps/campfire/src/components/Passage/Textarea.tsx
+++ b/apps/campfire/src/components/Passage/Textarea.tsx
@@ -1,26 +1,13 @@
-import type { JSX } from 'preact'
 import { useEffect } from 'preact/hooks'
 import { useDirectiveEvents } from '@campfire/hooks/useDirectiveEvents'
 import { mergeClasses, parseDisabledAttr } from '@campfire/utils/core'
 import { useGameStore } from '@campfire/state/useGameStore'
-import type { BoundFieldProps } from './BoundFieldProps'
+import type { BoundFieldElementProps } from './BoundFieldProps'
 
 const textareaStyles =
   'border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm'
 
-interface TextareaProps
-  extends Omit<
-      JSX.TextareaHTMLAttributes<HTMLTextAreaElement>,
-      | 'className'
-      | 'value'
-      | 'defaultValue'
-      | 'onFocus'
-      | 'onBlur'
-      | 'onMouseEnter'
-      | 'onMouseLeave'
-      | 'disabled'
-    >,
-    BoundFieldProps<string> {}
+type TextareaProps = BoundFieldElementProps<HTMLTextAreaElement, string>
 
 /**
  * Textarea bound to a game state key. Updates the key on user input.


### PR DESCRIPTION
## Summary
- introduce generic `BoundFieldElementProps` to share common field attributes
- update form components to reference new alias

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68ba3919af7c8322a708d6a1a7f1524a