### PR TITLE
fix: inherit style and class props in slide elements

### DIFF
--- a/apps/campfire/src/components/Deck/Slide/SlideElements.tsx
+++ b/apps/campfire/src/components/Deck/Slide/SlideElements.tsx
@@ -2,22 +2,23 @@ import { type ComponentChildren, type JSX } from 'preact'
 import { createSlideElement } from './createSlideElement'
 import { type SlideLayerProps } from './SlideLayer'
 
+/**
+ * Props for the SlideImage element. Inherits `className` and `style` from
+ * {@link SlideLayerProps}.
+ */
 export interface SlideImageProps
   extends Omit<SlideLayerProps, 'children' | 'as' | 'elementProps'> {
   /** Image source URL. */
   src: string
   /** Alternate text description for the image. */
   alt?: string
-  /** Additional CSS class names for the image element. */
-  className?: string
-  /** Additional CSS properties for the image element. */
-  style?: JSX.CSSProperties | string
 }
 
 /**
  * Renders an image within an absolutely positioned layer.
  *
- * @param props - Configuration options for the image element.
+ * @param props - Configuration options for the image element, including
+ * inherited `className` and `style` fields.
  * @returns The rendered image layer.
  */
 export const SlideImage = createSlideElement<SlideImageProps>({
@@ -31,6 +32,10 @@ export const SlideImage = createSlideElement<SlideImageProps>({
   mapLayerProps: ({ src, alt, ...layerProps }) => layerProps
 })
 
+/**
+ * Props for the SlideText element. Inherits `className` and `style` from
+ * {@link SlideLayerProps}.
+ */
 export interface SlideTextProps
   extends Omit<SlideLayerProps, 'children' | 'as'> {
   /** The HTML tag to render. Defaults to 'p'. */
@@ -45,10 +50,6 @@ export interface SlideTextProps
   lineHeight?: number
   /** Text color. Use Tailwind classes or inline CSS variables (e.g., 'var(--accent)'). */
   color?: string
-  /** Additional CSS class names for the text element. */
-  className?: string
-  /** Additional CSS properties for the text element. */
-  style?: JSX.CSSProperties | string
   /** Text or rich node children to render inside the element. */
   children?: ComponentChildren
 }
@@ -56,18 +57,18 @@ export interface SlideTextProps
 /**
  * Renders typographic content within an absolutely positioned layer.
  *
- * @param props - Configuration options for the text element.
+ * @param props - Configuration options for the text element, including
+ * inherited `className` and `style` fields.
  * @returns The rendered text element.
  */
 export const SlideText = createSlideElement<SlideTextProps>({
   as: 'p',
   getAs: ({ as = 'p' }) => as,
   testId: 'slideText',
-  mapClassName: ({ className }) => {
-    const classes = ['campfire-slide-text', 'text-base', 'font-normal']
-    if (className) classes.unshift(className)
-    return classes.join(' ')
-  },
+  mapClassName: ({ className }) =>
+    [className, 'campfire-slide-text', 'text-base', 'font-normal']
+      .filter(c => c != null && c !== '')
+      .join(' '),
   mapStyleTransform:
     ({ align, size, weight, lineHeight, color }) =>
     (base: JSX.CSSProperties): JSX.CSSProperties => ({
@@ -89,6 +90,10 @@ export const SlideText = createSlideElement<SlideTextProps>({
   }) => layerProps
 })
 
+/**
+ * Props for the SlideShape element. Inherits `className` and `style` from
+ * {@link SlideLayerProps}.
+ */
 export interface SlideShapeProps
   extends Omit<SlideLayerProps, 'children' | 'as' | 'elementProps'> {
   /** Shape type to render. */
@@ -113,16 +118,13 @@ export interface SlideShapeProps
   radius?: number
   /** Adds a drop shadow when true. */
   shadow?: boolean
-  /** Additional CSS class names for the svg element. */
-  className?: string
-  /** Additional CSS properties for the svg element. */
-  style?: JSX.CSSProperties | string
 }
 
 /**
  * Renders basic SVG shapes within an absolutely positioned layer.
  *
- * @param props - Configuration options for the shape element.
+ * @param props - Configuration options for the shape element, including
+ * inherited `className` and `style` fields.
  * @returns The rendered shape layer.
  */
 export const SlideShape = createSlideElement<SlideShapeProps>({


### PR DESCRIPTION
## Summary
- inherit `className` and `style` for slide elements from `SlideLayerProps`
- document inherited styling props for slide image, text, and shape elements

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68ba4cbdb3ac8322b41a5a2e20f32c65