### PR TITLE
feat: interpolate string directive attributes

### DIFF
--- a/apps/campfire/src/hooks/__tests__/imageDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/imageDirective.test.tsx
@@ -3,6 +3,7 @@ import { render } from '@testing-library/preact'
 import type { ComponentChild } from 'preact'
 import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
 import { renderDirectiveMarkdown } from '@campfire/components/Deck/Slide'
+import { useGameStore } from '@campfire/state/useGameStore'
 
 let output: ComponentChild | null = null
 
@@ -49,6 +50,37 @@ describe('image directive', () => {
     expect(img.className).toContain('campfire-slide-image')
     expect(img.className).toContain('rounded')
     expect(img.style.border).toBe('1px solid red')
+  })
+
+  it('interpolates className, layerClassName, and style', () => {
+    useGameStore.setState({
+      gameData: { cls: 'rounded', layer: 'wrapper', border: '1px solid red' }
+    })
+    const md =
+      ':::reveal\n::image{src="https://example.com/cat.png" className="${cls}" layerClassName="${layer}" style="border:${border}"}\n:::\n'
+    render(<MarkdownRunner markdown={md} />)
+    const el = document.querySelector(
+      '[data-testid="slideImage"]'
+    ) as HTMLElement
+    expect(el.className).toContain('wrapper')
+    const img = el.querySelector('img') as HTMLImageElement
+    expect(img.className).toContain('rounded')
+    expect(img.style.border).toBe('1px solid red')
+  })
+
+  it('interpolates alt and id attributes', () => {
+    useGameStore.setState({
+      gameData: { altText: 'Kitten', imgId: 'cat-img' }
+    })
+    const md =
+      ':::reveal\n::image{src="https://example.com/cat.png" alt="${altText}" id="${imgId}"}\n:::\n'
+    render(<MarkdownRunner markdown={md} />)
+    const el = document.querySelector(
+      '[data-testid="slideImage"]'
+    ) as HTMLElement
+    const img = el.querySelector('img') as HTMLImageElement
+    expect(img.id).toBe('cat-img')
+    expect(img.getAttribute('alt')).toBe('Kitten')
   })
 
   it('handles hyphenated class names without evaluation', () => {

--- a/apps/campfire/src/hooks/__tests__/shapeDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/shapeDirective.test.tsx
@@ -4,6 +4,7 @@ import type { ComponentChild } from 'preact'
 import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
 import { renderDirectiveMarkdown } from '@campfire/components/Deck/Slide'
 import { getSvgClassName } from '@campfire/test-utils/helpers'
+import { useGameStore } from '@campfire/state/useGameStore'
 
 let output: ComponentChild | null = null
 
@@ -54,6 +55,38 @@ describe('shape directive', () => {
     expect(getSvgClassName(svg)).toContain('campfire-slide-shape')
     expect(svg.classList.contains('rounded')).toBe(true)
     expect(svg.style.filter).toContain('drop-shadow')
+  })
+
+  it('interpolates className, layerClassName, and style', () => {
+    useGameStore.setState({
+      gameData: { cls: 'rounded', layer: 'wrapper', border: '1px solid red' }
+    })
+    const md =
+      ':::reveal\n:shape{type="rect" x=10 y=20 className="${cls}" layerClassName="${layer}" style="border:${border}"}\n:::\n'
+    render(<MarkdownRunner markdown={md} />)
+    const el = document.querySelector(
+      '[data-testid="slideShape"]'
+    ) as HTMLElement
+    expect(el.className).toContain('wrapper')
+    const svg = el.querySelector('svg') as SVGSVGElement
+    expect(svg.classList.contains('rounded')).toBe(true)
+    expect(svg.style.border).toBe('1px solid red')
+  })
+
+  it('interpolates id and stroke attributes', () => {
+    useGameStore.setState({
+      gameData: { sid: 'shape-1', stroke: 'green' }
+    })
+    const md =
+      ':::reveal\n:shape{type="rect" id="${sid}" stroke="${stroke}"}\n:::\n'
+    render(<MarkdownRunner markdown={md} />)
+    const el = document.querySelector(
+      '[data-testid="slideShape"]'
+    ) as HTMLElement
+    const svg = el.querySelector('svg') as SVGSVGElement
+    expect(svg.id).toBe('shape-1')
+    const rect = svg.querySelector('rect') as SVGRectElement
+    expect(rect.getAttribute('stroke')).toBe('green')
   })
 
   it('renders a SlideShape component with props via leaf directive', () => {

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -32,6 +32,7 @@ import {
   parseThemeValue,
   applyAdditionalAttributes,
   mergeAttrs,
+  normalizeStringAttrs,
   ensureParentIndex
 } from '@campfire/utils/directiveHandlerUtils'
 import type {
@@ -1209,30 +1210,26 @@ export const useDirectiveHandlers = () => {
       : undefined
     const mergedRaw = mergeAttrs<Record<string, unknown>>(preset, raw)
     const mergedAttrs = mergeAttrs<ImageAttrs>(preset, attrs)
-    const props: Record<string, unknown> = { src: mergedAttrs.src }
-    if (typeof mergedAttrs.x === 'number') props.x = mergedAttrs.x
-    if (typeof mergedAttrs.y === 'number') props.y = mergedAttrs.y
-    if (typeof mergedAttrs.w === 'number') props.w = mergedAttrs.w
-    if (typeof mergedAttrs.h === 'number') props.h = mergedAttrs.h
-    if (typeof mergedAttrs.z === 'number') props.z = mergedAttrs.z
-    if (typeof mergedAttrs.rotate === 'number')
-      props.rotate = mergedAttrs.rotate
-    if (typeof mergedAttrs.scale === 'number') props.scale = mergedAttrs.scale
-    if (mergedAttrs.anchor) props.anchor = mergedAttrs.anchor
-    if (mergedAttrs.alt) props.alt = mergedAttrs.alt
-    const mergedStyle = getStyleAttr({ style: mergedAttrs.style }, gameData)
-    if (mergedStyle) props.style = mergedStyle
-    const mergedClass = getClassAttr(
-      { className: mergedAttrs.className },
-      gameData
-    )
-    if (mergedClass) props.className = mergedClass
-    if (mergedAttrs.layerClassName)
-      props.layerClassName = mergedAttrs.layerClassName
-    if (mergedAttrs.id) props.id = mergedAttrs.id
-    if (mergedAttrs.layerId) props.layerId = mergedAttrs.layerId
+    const normRaw = normalizeStringAttrs(mergedRaw, gameData)
+    const normAttrs = normalizeStringAttrs(mergedAttrs, gameData)
+    const props: Record<string, unknown> = { src: normAttrs.src }
+    if (typeof normAttrs.x === 'number') props.x = normAttrs.x
+    if (typeof normAttrs.y === 'number') props.y = normAttrs.y
+    if (typeof normAttrs.w === 'number') props.w = normAttrs.w
+    if (typeof normAttrs.h === 'number') props.h = normAttrs.h
+    if (typeof normAttrs.z === 'number') props.z = normAttrs.z
+    if (typeof normAttrs.rotate === 'number') props.rotate = normAttrs.rotate
+    if (typeof normAttrs.scale === 'number') props.scale = normAttrs.scale
+    if (normAttrs.anchor) props.anchor = normAttrs.anchor
+    if (normAttrs.alt) props.alt = normAttrs.alt
+    if (normAttrs.className) props.className = normAttrs.className
+    if (normAttrs.layerClassName)
+      props.layerClassName = normAttrs.layerClassName
+    if (normAttrs.style) props.style = normAttrs.style
+    if (normAttrs.id) props.id = normAttrs.id
+    if (normAttrs.layerId) props.layerId = normAttrs.layerId
     applyAdditionalAttributes(
-      mergedRaw,
+      normRaw,
       props,
       [
         'x',
@@ -1298,45 +1295,39 @@ export const useDirectiveHandlers = () => {
       preset,
       attrs as unknown as Record<string, unknown>
     ) as ShapeAttrs & Record<string, unknown>
-    const props: Record<string, unknown> = { type: mergedAttrs.type }
-    if (typeof mergedAttrs.x === 'number') props.x = mergedAttrs.x
-    if (typeof mergedAttrs.y === 'number') props.y = mergedAttrs.y
-    if (typeof mergedAttrs.w === 'number') props.w = mergedAttrs.w
-    if (typeof mergedAttrs.h === 'number') props.h = mergedAttrs.h
-    if (typeof mergedAttrs.z === 'number') props.z = mergedAttrs.z
-    if (typeof mergedAttrs.rotate === 'number')
-      props.rotate = mergedAttrs.rotate
-    if (typeof mergedAttrs.scale === 'number') props.scale = mergedAttrs.scale
-    if (mergedAttrs.anchor) props.anchor = mergedAttrs.anchor
-    if (mergedAttrs.points) props.points = mergedAttrs.points
-    if (typeof mergedAttrs.x1 === 'number') props.x1 = mergedAttrs.x1
-    if (typeof mergedAttrs.y1 === 'number') props.y1 = mergedAttrs.y1
-    if (typeof mergedAttrs.x2 === 'number') props.x2 = mergedAttrs.x2
-    if (typeof mergedAttrs.y2 === 'number') props.y2 = mergedAttrs.y2
-    if (mergedAttrs.stroke) props.stroke = mergedAttrs.stroke
-    if (typeof mergedAttrs.strokeWidth === 'number')
-      props.strokeWidth = mergedAttrs.strokeWidth
-    if (mergedAttrs.fill) props.fill = mergedAttrs.fill
-    if (typeof mergedAttrs.radius === 'number')
-      props.radius = mergedAttrs.radius
-    if (typeof mergedAttrs.shadow === 'boolean')
-      props.shadow = mergedAttrs.shadow
-    const mergedStyle = getStyleAttr(
-      mergedAttrs as Record<string, unknown>,
+    const normRaw = normalizeStringAttrs(mergedRaw, gameData)
+    const normAttrs = normalizeStringAttrs(
+      mergedAttrs,
       gameData
-    )
-    if (mergedStyle) props.style = mergedStyle
-    const mergedClass = getClassAttr(
-      mergedAttrs as Record<string, unknown>,
-      gameData
-    )
-    if (mergedClass) props.className = mergedClass
-    if (mergedAttrs.layerClassName)
-      props.layerClassName = mergedAttrs.layerClassName
-    if (mergedAttrs.id) props.id = mergedAttrs.id
-    if (mergedAttrs.layerId) props.layerId = mergedAttrs.layerId
+    ) as ShapeAttrs & Record<string, unknown>
+    const props: Record<string, unknown> = { type: normAttrs.type }
+    if (typeof normAttrs.x === 'number') props.x = normAttrs.x
+    if (typeof normAttrs.y === 'number') props.y = normAttrs.y
+    if (typeof normAttrs.w === 'number') props.w = normAttrs.w
+    if (typeof normAttrs.h === 'number') props.h = normAttrs.h
+    if (typeof normAttrs.z === 'number') props.z = normAttrs.z
+    if (typeof normAttrs.rotate === 'number') props.rotate = normAttrs.rotate
+    if (typeof normAttrs.scale === 'number') props.scale = normAttrs.scale
+    if (normAttrs.anchor) props.anchor = normAttrs.anchor
+    if (normAttrs.points) props.points = normAttrs.points
+    if (typeof normAttrs.x1 === 'number') props.x1 = normAttrs.x1
+    if (typeof normAttrs.y1 === 'number') props.y1 = normAttrs.y1
+    if (typeof normAttrs.x2 === 'number') props.x2 = normAttrs.x2
+    if (typeof normAttrs.y2 === 'number') props.y2 = normAttrs.y2
+    if (normAttrs.stroke) props.stroke = normAttrs.stroke
+    if (typeof normAttrs.strokeWidth === 'number')
+      props.strokeWidth = normAttrs.strokeWidth
+    if (normAttrs.fill) props.fill = normAttrs.fill
+    if (typeof normAttrs.radius === 'number') props.radius = normAttrs.radius
+    if (typeof normAttrs.shadow === 'boolean') props.shadow = normAttrs.shadow
+    if (normAttrs.className) props.className = normAttrs.className
+    if (normAttrs.layerClassName)
+      props.layerClassName = normAttrs.layerClassName
+    if (normAttrs.style) props.style = normAttrs.style
+    if (normAttrs.id) props.id = normAttrs.id
+    if (normAttrs.layerId) props.layerId = normAttrs.layerId
     applyAdditionalAttributes(
-      mergedRaw,
+      normRaw,
       props,
       [
         'x',

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -1222,10 +1222,15 @@ export const useDirectiveHandlers = () => {
     if (typeof normAttrs.scale === 'number') props.scale = normAttrs.scale
     if (normAttrs.anchor) props.anchor = normAttrs.anchor
     if (normAttrs.alt) props.alt = normAttrs.alt
-    if (normAttrs.className) props.className = normAttrs.className
-    if (normAttrs.layerClassName)
-      props.layerClassName = normAttrs.layerClassName
-    if (normAttrs.style) props.style = normAttrs.style
+    const classAttr = getClassAttr({ className: normAttrs.className }, gameData)
+    if (classAttr) props.className = classAttr
+    const layerClassAttr = getClassAttr(
+      { className: normAttrs.layerClassName },
+      gameData
+    )
+    if (layerClassAttr) props.layerClassName = layerClassAttr
+    const styleAttr = getStyleAttr({ style: normAttrs.style }, gameData)
+    if (styleAttr) props.style = styleAttr
     if (normAttrs.id) props.id = normAttrs.id
     if (normAttrs.layerId) props.layerId = normAttrs.layerId
     applyAdditionalAttributes(
@@ -1320,10 +1325,15 @@ export const useDirectiveHandlers = () => {
     if (normAttrs.fill) props.fill = normAttrs.fill
     if (typeof normAttrs.radius === 'number') props.radius = normAttrs.radius
     if (typeof normAttrs.shadow === 'boolean') props.shadow = normAttrs.shadow
-    if (normAttrs.className) props.className = normAttrs.className
-    if (normAttrs.layerClassName)
-      props.layerClassName = normAttrs.layerClassName
-    if (normAttrs.style) props.style = normAttrs.style
+    const classAttr = getClassAttr({ className: normAttrs.className }, gameData)
+    if (classAttr) props.className = classAttr
+    const layerClassAttr = getClassAttr(
+      { className: normAttrs.layerClassName },
+      gameData
+    )
+    if (layerClassAttr) props.layerClassName = layerClassAttr
+    const styleAttr = getStyleAttr({ style: normAttrs.style }, gameData)
+    if (styleAttr) props.style = styleAttr
     if (normAttrs.id) props.id = normAttrs.id
     if (normAttrs.layerId) props.layerId = normAttrs.layerId
     applyAdditionalAttributes(

--- a/apps/campfire/src/utils/directiveHandlerUtils.ts
+++ b/apps/campfire/src/utils/directiveHandlerUtils.ts
@@ -48,6 +48,25 @@ export const getStyleAttr = (
   )
 
 /**
+ * Interpolates all string values within an attribute map.
+ *
+ * @param attrs - Attributes to process.
+ * @param data - Current game data for interpolation.
+ * @returns New attribute map with interpolated strings.
+ */
+export const normalizeStringAttrs = <T extends Record<string, unknown>>(
+  attrs: T,
+  data: Record<string, unknown>
+): T => {
+  const result: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(attrs)) {
+    result[key] =
+      typeof value === 'string' ? interpolateAttr(value, data) : value
+  }
+  return result as T
+}
+
+/**
  * Ensures a directive is used in leaf form. Logs an error and removes the node otherwise.
  *
  * @param directive - The directive to validate.

--- a/docs/spec/markdown-directives.md
+++ b/docs/spec/markdown-directives.md
@@ -34,7 +34,7 @@ General
 
 - Quoted or backticked values MUST be treated as strings; do not coerce or JSON-parse quoted strings even if they “look like” JSON.
 - Wrap literal strings in quotes or backticks unless referencing a state key.
-- To pass an object or array via an attribute, do not wrap the JSON in quotes, e.g., `:d{options={a:1}}` or valid JSON `:d{options={"a":1}}`.
+- All string attributes support `${...}` interpolation (e.g., `className`, `layerClassName`, `style`).
 - Safe attribute characters: attribute extraction only accepts values composed of safe characters to reduce injection risk.
 - New directive attributes must be exposed through their handlers and accompanied by directive tests verifying their behavior.
 


### PR DESCRIPTION
## Summary
- normalize attribute maps to interpolate all string values
- expand image and shape handlers and tests to cover broad attribute interpolation
- centralize directive interpolation docs and remove outdated JSON attribute guidance

## Testing
- `bun tsc`
- `bun test apps/campfire/src/hooks/__tests__/imageDirective.test.tsx apps/campfire/src/hooks/__tests__/shapeDirective.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ba4ec3bc608322a456a3f78cafabce