### PR TITLE
refactor: extract shared field styles

### DIFF
--- a/apps/campfire/src/components/Passage/BoundFieldProps.ts
+++ b/apps/campfire/src/components/Passage/BoundFieldProps.ts
@@ -1,5 +1,9 @@
 import type { JSX } from 'preact'
 
+/** Base Tailwind CSS classes shared by form field components. */
+export const fieldBaseStyles =
+  'placeholder:text-muted-foreground border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex w-full rounded-md border bg-transparent text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm'
+
 /**
  * Common props for form fields bound to a game state key.
  *

--- a/apps/campfire/src/components/Passage/Input.tsx
+++ b/apps/campfire/src/components/Passage/Input.tsx
@@ -2,10 +2,12 @@ import { useEffect } from 'preact/hooks'
 import { useDirectiveEvents } from '@campfire/hooks/useDirectiveEvents'
 import { mergeClasses, parseDisabledAttr } from '@campfire/utils/core'
 import { useGameStore } from '@campfire/state/useGameStore'
-import type { BoundFieldElementProps } from './BoundFieldProps'
+import { fieldBaseStyles, type BoundFieldElementProps } from './BoundFieldProps'
 
-const inputStyles =
-  'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive'
+const inputStyles = mergeClasses(
+  fieldBaseStyles,
+  'file:text-foreground selection:bg-primary selection:text-primary-foreground disabled:pointer-events-none min-w-0 h-9 px-3 py-1 file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium'
+)
 
 type InputProps = BoundFieldElementProps<HTMLInputElement, string>
 

--- a/apps/campfire/src/components/Passage/Select.tsx
+++ b/apps/campfire/src/components/Passage/Select.tsx
@@ -6,7 +6,7 @@ import { mergeClasses, parseDisabledAttr } from '@campfire/utils/core'
 import { useGameStore } from '@campfire/state/useGameStore'
 import type { OptionProps } from './Option'
 import { getOptionId } from './Option'
-import type { BoundFieldElementProps } from './BoundFieldProps'
+import { fieldBaseStyles, type BoundFieldElementProps } from './BoundFieldProps'
 
 /** Counter used to generate deterministic IDs. */
 let idCounter = 0
@@ -18,8 +18,10 @@ let idCounter = 0
  * @returns The generated ID.
  */
 const generateId = (prefix: string) => `${prefix}-${++idCounter}`
-const selectStyles =
-  'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-2 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive'
+const selectStyles = mergeClasses(
+  fieldBaseStyles,
+  'file:text-foreground selection:bg-primary selection:text-primary-foreground disabled:pointer-events-none min-w-0 h-9 px-2 py-1'
+)
 
 type SelectProps = Omit<
   BoundFieldElementProps<HTMLButtonElement, string>,

--- a/apps/campfire/src/components/Passage/Textarea.tsx
+++ b/apps/campfire/src/components/Passage/Textarea.tsx
@@ -2,10 +2,12 @@ import { useEffect } from 'preact/hooks'
 import { useDirectiveEvents } from '@campfire/hooks/useDirectiveEvents'
 import { mergeClasses, parseDisabledAttr } from '@campfire/utils/core'
 import { useGameStore } from '@campfire/state/useGameStore'
-import type { BoundFieldElementProps } from './BoundFieldProps'
+import { fieldBaseStyles, type BoundFieldElementProps } from './BoundFieldProps'
 
-const textareaStyles =
-  'border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm'
+const textareaStyles = mergeClasses(
+  fieldBaseStyles,
+  'field-sizing-content min-h-16 px-3 py-2'
+)
 
 type TextareaProps = BoundFieldElementProps<HTMLTextAreaElement, string>
 


### PR DESCRIPTION
## Summary
- add `fieldBaseStyles` shared Tailwind CSS classes
- compose `Input`, `Textarea`, and `Select` styles from the shared base

## Testing
- `bun tsc`
- `bun test`
- `bunx prettier . --write`


------
https://chatgpt.com/codex/tasks/task_e_68bb016aa3f483228f3e568e02841a07