### PR TITLE
fix: guard currentPassageId selector in directive handlers

### DIFF
--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -119,7 +119,11 @@ export const useDirectiveHandlers = () => {
   const loadCheckpointFn = useGameStore.use.loadCheckpoint()
   const setLoading = useGameStore.use.setLoading()
   const addError = useGameStore.use.addError()
-  const currentPassageId = useStoryDataStore.use.currentPassageId!() as string
+  const currentPassageIdSelector = useStoryDataStore.use.currentPassageId
+  if (!currentPassageIdSelector) {
+    addError('currentPassageId selector is undefined')
+  }
+  const currentPassageId = currentPassageIdSelector?.() ?? ''
   const setCurrentPassage = useStoryDataStore.use.setCurrentPassage()
   const getPassageById = useStoryDataStore.use.getPassageById()
   const getPassageByName = useStoryDataStore.use.getPassageByName()


### PR DESCRIPTION
## Summary
- guard `currentPassageId` selector before calling it to avoid runtime errors

## Testing
- `bun tsc`
- `bun test`
- `bunx prettier . --write`


------
https://chatgpt.com/codex/tasks/task_e_68bb055fedc08322a133cdad9bb8e76f