### PR TITLE
fix: guard option access in select

### DIFF
--- a/apps/campfire/src/components/Passage/Select.tsx
+++ b/apps/campfire/src/components/Passage/Select.tsx
@@ -153,10 +153,11 @@ export const Select = ({
         if (opt) handleSelect(opt.props.value)
       }
     }
-  const activeId =
-    open && activeIndex !== null
-      ? getOptionId(optionNodes[activeIndex]!.props.value)
-      : undefined
+  const activeOption =
+    open && activeIndex !== null ? optionNodes[activeIndex] : undefined
+  const activeId = activeOption
+    ? getOptionId(activeOption.props.value)
+    : undefined
   return (
     <div ref={containerRef} className='inline-block relative'>
       <button


### PR DESCRIPTION
## Summary
- guard option lookup in Select component before calling getOptionId

## Testing
- `bun tsc`
- `bun test`
- `bunx prettier . --write`


------
https://chatgpt.com/codex/tasks/task_e_68bb055e666c83228def6e37599d0098