### PR TITLE
feat: add element and styling options to show directive

### DIFF
--- a/apps/campfire/src/components/Passage/Show.tsx
+++ b/apps/campfire/src/components/Passage/Show.tsx
@@ -1,4 +1,4 @@
-import type { JSX } from 'preact'
+import type { ComponentType, JSX } from 'preact'
 import { useGameStore } from '@campfire/state/useGameStore'
 import { isRange } from '@campfire/utils/directiveUtils'
 import {
@@ -12,18 +12,22 @@ interface ShowProps {
   'data-key'?: string
   /** Expression to evaluate and display */
   'data-expr'?: string
-  /** Additional CSS classes for the span element. */
+  /** Element or component tag to render. */
+  as?: keyof JSX.IntrinsicElements | ComponentType<any>
+  /** Additional CSS classes for the rendered element. */
   className?: string | string[]
-  /** Inline styles for the span element. */
+  /** Inline styles for the rendered element. */
   style?: string | JSX.CSSProperties
 }
 
 /**
  * Displays a value from the game store or the result of an expression.
  * Returns `null` when the referenced value is `null` or `undefined`.
+ * When `as` is provided, wraps the output with the specified element and
+ * applies `className` and `style`. Otherwise renders as a fragment.
  * Updates automatically when the underlying data changes.
  */
-export const Show = ({ className, style, ...props }: ShowProps) => {
+export const Show = ({ as: Tag, className, style, ...props }: ShowProps) => {
   const addError = useGameStore.use.addError()
   const gameData = useGameStore.use.gameData()
   const expr = props['data-expr']
@@ -40,15 +44,18 @@ export const Show = ({ className, style, ...props }: ShowProps) => {
       }
       if (result == null) return null
       const display = isRange(result) ? result.value : result
-      return (
-        <span
-          className={mergeClasses('campfire-show', className)}
-          style={mergedStyle}
-          data-testid='show'
-        >
-          {String(display)}
-        </span>
-      )
+      if (Tag) {
+        return (
+          <Tag
+            className={mergeClasses('campfire-show', className)}
+            style={mergedStyle}
+            data-testid='show'
+          >
+            {String(display)}
+          </Tag>
+        )
+      }
+      return <>{String(display)}</>
     } catch (error) {
       const msg = `Failed to evaluate show expression: ${expr}`
       console.error(msg, error)
@@ -62,13 +69,16 @@ export const Show = ({ className, style, ...props }: ShowProps) => {
     : undefined
   if (value == null) return null
   const displayValue = isRange(value) ? value.value : value
-  return (
-    <span
-      className={mergeClasses('campfire-show', className)}
-      style={mergedStyle}
-      data-testid='show'
-    >
-      {String(displayValue)}
-    </span>
-  )
+  if (Tag) {
+    return (
+      <Tag
+        className={mergeClasses('campfire-show', className)}
+        style={mergedStyle}
+        data-testid='show'
+      >
+        {String(displayValue)}
+      </Tag>
+    )
+  }
+  return <>{String(displayValue)}</>
 }

--- a/apps/campfire/src/components/Passage/__tests__/Passage.state.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Passage.state.test.tsx
@@ -967,8 +967,8 @@ describe('Passage game state directives', () => {
     render(<Passage />)
 
     await waitFor(() => {
-      const span = screen.getByText('7')
-      expect(span.closest('p')?.textContent?.replace(/\s+/g, '')).toBe('HP:7')
+      expect(screen.getByText('HP: 7')).toBeInTheDocument()
+      expect(screen.queryByTestId('show')).toBeNull()
     })
   })
 
@@ -1021,12 +1021,38 @@ describe('Passage game state directives', () => {
     render(<Passage />)
 
     await waitFor(() => {
-      const span = screen.getByText('X')
-      expect(span.closest('p')?.textContent?.replace(/\s+/g, '')).toBe('ValueX')
+      expect(screen.getByText('Value X')).toBeInTheDocument()
+      expect(screen.queryByTestId('show')).toBeNull()
     })
   })
 
   it('applies className and style attributes to show directive', async () => {
+    useGameStore.setState(state => ({
+      ...state,
+      gameData: { hp: 7 }
+    }))
+    const passage: Element = {
+      type: 'element',
+      tagName: 'tw-passagedata',
+      properties: { pid: '1', name: 'Start' },
+      children: [
+        {
+          type: 'text',
+          value: 'HP: :show[hp]{as="span" className="stat" style="color:blue"}'
+        }
+      ]
+    }
+    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
+    render(<Passage />)
+    await waitFor(() => {
+      const span = screen.getByText('7')
+      expect(span.className).toContain('stat')
+      expect(span).toHaveStyle('color: blue')
+      expect(span.closest('p')?.textContent?.replace(/\s+/g, '')).toBe('HP:7')
+    })
+  })
+
+  it('ignores className and style without as on show directive', async () => {
     useGameStore.setState(state => ({
       ...state,
       gameData: { hp: 7 }
@@ -1045,10 +1071,8 @@ describe('Passage game state directives', () => {
     useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
     render(<Passage />)
     await waitFor(() => {
-      const span = screen.getByText('7')
-      expect(span.className).toContain('stat')
-      expect(span).toHaveStyle('color: blue')
-      expect(span.closest('p')?.textContent?.replace(/\s+/g, '')).toBe('HP:7')
+      expect(screen.queryByTestId('show')).toBeNull()
+      expect(screen.getByText('HP: 7')).toBeInTheDocument()
     })
   })
 

--- a/apps/campfire/src/components/Passage/__tests__/Show.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Show.test.tsx
@@ -21,25 +21,23 @@ beforeEach(() => {
 describe('Show', () => {
   it('renders the value for a given key', () => {
     useGameStore.getState().setGameData({ hp: 5 })
-    render(<Show data-key='hp' />)
-    const el = screen.getByText('5') as HTMLElement
-    expect(el).toBeInTheDocument()
-    expect(el.className).toContain('campfire-show')
+    const { container } = render(<Show data-key='hp' />)
+    expect(container.textContent).toBe('5')
   })
 
   it('renders the value of range objects', () => {
     useGameStore.getState().setGameData({ hp: { min: 0, max: 10, value: 4 } })
-    render(<Show data-key='hp' />)
-    expect(screen.getByText('4')).toBeInTheDocument()
+    const { container } = render(<Show data-key='hp' />)
+    expect(container.textContent).toBe('4')
   })
 
   it('updates when the value changes', () => {
     useGameStore.getState().setGameData({ hp: 3 })
-    render(<Show data-key='hp' />)
+    const { container } = render(<Show data-key='hp' />)
     act(() => {
       useGameStore.getState().setGameData({ hp: 7 })
     })
-    expect(screen.getByText('7')).toBeInTheDocument()
+    expect(container.textContent).toBe('7')
   })
 
   it('renders nothing when the value is undefined', () => {
@@ -55,7 +53,27 @@ describe('Show', () => {
 
   it('renders the result of an expression', () => {
     useGameStore.getState().setGameData({ some_key: 2 })
-    render(<Show data-expr='some_key > 1 ? "X" : " "' />)
-    expect(screen.getByText('X')).toBeInTheDocument()
+    const { container } = render(<Show data-expr='some_key > 1 ? "X" : " "' />)
+    expect(container.textContent).toBe('X')
+  })
+
+  it('renders inside a custom element when `as` is provided', () => {
+    useGameStore.getState().setGameData({ hp: 10 })
+    render(
+      <Show as='span' data-key='hp' className='stat' style={{ color: 'red' }} />
+    )
+    const el = screen.getByTestId('show') as HTMLElement
+    expect(el.tagName).toBe('SPAN')
+    expect(el.className).toContain('campfire-show')
+    expect(el.className).toContain('stat')
+    expect((el as HTMLElement).style.color).toBe('red')
+  })
+
+  it('ignores className and style without `as`', () => {
+    useGameStore.getState().setGameData({ hp: 5 })
+    const { container } = render(
+      <Show data-key='hp' className='foo' style={{ color: 'red' }} />
+    )
+    expect(container.innerHTML).toBe('5')
   })
 })

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -190,17 +190,29 @@ export const useDirectiveHandlers = () => {
     const props: Record<string, unknown> = keyPattern.test(raw)
       ? { 'data-key': raw }
       : { 'data-expr': raw }
-    const attrs = (directive.attributes || {}) as Record<string, unknown>
+    const attrs = normalizeStringAttrs(
+      (directive.attributes || {}) as Record<string, unknown>,
+      gameData
+    )
     if (Object.prototype.hasOwnProperty.call(attrs, 'class')) {
       const msg = 'class is a reserved attribute. Use className instead.'
       console.error(msg)
       addError(msg)
     }
-    const classAttr = getClassAttr(attrs, gameData)
-    const styleAttr = getStyleAttr(attrs, gameData)
-    if (classAttr) props.className = classAttr
-    if (styleAttr) props.style = styleAttr
-    applyAdditionalAttributes(attrs, props, ['className', 'style'], addError)
+    const asAttr = typeof attrs.as === 'string' ? attrs.as : undefined
+    if (asAttr) props.as = asAttr
+    if (asAttr) {
+      const classAttr = getClassAttr(attrs, gameData)
+      const styleAttr = getStyleAttr(attrs, gameData)
+      if (classAttr) props.className = classAttr
+      if (styleAttr) props.style = styleAttr
+    }
+    applyAdditionalAttributes(
+      attrs,
+      props,
+      ['as', 'className', 'style'],
+      addError
+    )
     const node: MdText = {
       type: 'text',
       value: '',

--- a/apps/storybook/src/ForDirective.stories.tsx
+++ b/apps/storybook/src/ForDirective.stories.tsx
@@ -22,7 +22,7 @@ export const Numbers: StoryObj = {
           {`
 :::for[x in [1,2,3]]
 
-Value :show[x]{className="text-sky-600"}
+Value :show[x]{as="span" className="text-sky-600"}
 
 :::
           `}
@@ -52,7 +52,7 @@ export const Fruits: StoryObj = {
 
   :::if[fruit !== "banana"]
 
-  - :show[fruit]{className="text-rose-600"}
+  - :show[fruit]{as="span" className="text-rose-600"}
 
   :::
 

--- a/apps/storybook/src/InputDirective.stories.tsx
+++ b/apps/storybook/src/InputDirective.stories.tsx
@@ -21,7 +21,7 @@ export const Basic: StoryObj = {
           {`
 :input[name]{placeholder="Type your name"}
 :::if[name]
-  Hello, :show[name]{className="text-green-600"}!
+  Hello, :show[name]{as="span" className="text-green-600"}!
 :::
 `}
         </tw-passagedata>
@@ -57,7 +57,7 @@ export const WithEvents: StoryObj = {
 :::
 
 :::if[name]
-  Hello, :show[name]{className="text-green-600"}!
+  Hello, :show[name]{as="span" className="text-green-600"}!
 :::
           `}
         </tw-passagedata>

--- a/apps/storybook/src/SelectDirective.stories.tsx
+++ b/apps/storybook/src/SelectDirective.stories.tsx
@@ -35,13 +35,13 @@ You chose
 
   :::if[color === "red"]
 
-  :show[color]{style="color: var(--color-destructive-500)"}.
+  :show[color]{as="span" style="color: var(--color-destructive-500)"}.
 
 :::
 
   :::if[color === "blue"]
 
-  :show[color]{style="color: var(--color-primary-500)"}.
+  :show[color]{as="span" style="color: var(--color-primary-500)"}.
 
 :::
 
@@ -93,13 +93,13 @@ You chose
 
   :::if[color === "red"]
 
-  :show[color]{style="color: var(--color-destructive-500)"}.
+  :show[color]{as="span" style="color: var(--color-destructive-500)"}.
 
 :::
 
   :::if[color === "blue"]
 
-  :show[color]{style="color: var(--color-primary-500)"}.
+  :show[color]{as="span" style="color: var(--color-primary-500)"}.
 
 :::
 

--- a/apps/storybook/src/TextareaDirective.stories.tsx
+++ b/apps/storybook/src/TextareaDirective.stories.tsx
@@ -22,7 +22,7 @@ export const Basic: StoryObj = {
 :textarea[bio]{placeholder="Enter bio"}
 :::if[bio]
 
-You wrote: :show[bio]{className="text-purple-600"}
+You wrote: :show[bio]{as="span" className="text-purple-600"}
 
 :::
 `}

--- a/docs/directives/data-retrieval.md
+++ b/docs/directives/data-retrieval.md
@@ -14,13 +14,15 @@ Display a key's value, the result of an expression, or an interpolated string.
 
 Replace the content with a key, template string, or JavaScript expression to display.
 
-| Input     | Description                            |
-| --------- | -------------------------------------- |
-| key       | State key to display                   |
-| className | Additional classes applied to the span |
-| style     | Inline styles applied to the span      |
+| Input     | Description                                               |
+| --------- | --------------------------------------------------------- |
+| key       | State key to display                                      |
+| as        | Element tag to wrap the output (defaults to fragment)     |
+| className | Additional classes applied to the element (requires `as`) |
+| style     | Inline styles applied to the element (requires `as`)      |
 
-The directive also supports `className` and `style` attributes for styling the rendered span.
+When `as` is omitted, the value is rendered without a wrapper. `className`
+and `style` only apply when `as` is defined.
 
 To read range data, access the range's properties with dot notation:
 


### PR DESCRIPTION
## Summary
- allow `show` directive to specify a wrapping element via an `as` attribute
- only apply `className` and `style` when a custom element is provided
- document and test new `show` directive attributes

## Testing
- `bun tsc && echo tsc-success`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_68bb0d048d5c83228128cde3cad1e4f2