### PR TITLE
feat(slide): enable vertical scrolling and auto-scroll reveals

### DIFF
--- a/apps/campfire/src/components/Deck/Slide/Slide.tsx
+++ b/apps/campfire/src/components/Deck/Slide/Slide.tsx
@@ -52,7 +52,7 @@ export const Slide = ({
   return (
     <SlideTransitionContext.Provider value={contextValue}>
       <div
-        className={`campfire-slide relative w-full h-full overflow-hidden ${
+        className={`campfire-slide relative w-full h-full overflow-x-hidden overflow-y-auto ${
           className ?? ''
         }`}
         data-transition={transition ? JSON.stringify(transition) : undefined}

--- a/apps/campfire/src/components/Deck/Slide/SlideReveal/__tests__/SlideReveal.test.tsx
+++ b/apps/campfire/src/components/Deck/Slide/SlideReveal/__tests__/SlideReveal.test.tsx
@@ -105,6 +105,58 @@ describe('SlideReveal', () => {
     expect(data.entered).toBe(true)
   })
 
+  it('scrolls into view when becoming visible', async () => {
+    const spy = spyOn(HTMLElement.prototype, 'scrollIntoView')
+    render(
+      <Deck>
+        <Slide>
+          <div style={{ height: '2000px' }}>Filler</div>
+          <SlideReveal at={1}>Reveal</SlideReveal>
+        </Slide>
+      </Deck>
+    )
+    expect(spy).not.toHaveBeenCalled()
+    await act(() => useDeckStore.getState().next())
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 0))
+    })
+    expect(spy).toHaveBeenCalledWith({
+      behavior: 'smooth',
+      block: 'nearest',
+      inline: 'nearest'
+    })
+    spy.mockRestore()
+  })
+
+  it('uses instant scroll when prefers reduced motion', async () => {
+    const spy = spyOn(HTMLElement.prototype, 'scrollIntoView')
+    const transition = await import('@campfire/components/transition')
+    const prefersSpy = spyOn(
+      transition,
+      'prefersReducedMotion'
+    ).mockReturnValue(true)
+    render(
+      <Deck>
+        <Slide>
+          <div style={{ height: '2000px' }}>Filler</div>
+          <SlideReveal at={1}>Reveal</SlideReveal>
+        </Slide>
+      </Deck>
+    )
+    expect(spy).not.toHaveBeenCalled()
+    await act(() => useDeckStore.getState().next())
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 0))
+    })
+    expect(spy).toHaveBeenCalledWith({
+      behavior: 'auto',
+      block: 'nearest',
+      inline: 'nearest'
+    })
+    prefersSpy.mockRestore()
+    spy.mockRestore()
+  })
+
   it.skip('toggles visibility at the configured steps', async () => {
     // @ts-expect-error override animate
     HTMLElement.prototype.animate = () => new StubAnimation()

--- a/apps/campfire/src/components/Deck/Slide/SlideReveal/index.tsx
+++ b/apps/campfire/src/components/Deck/Slide/SlideReveal/index.tsx
@@ -81,6 +81,20 @@ export const SlideReveal = ({
     prevVisibleRef.current = visible
   }, [visible, onEnter, runEnter])
 
+  const prevDisplayedRef = useRef(false)
+  useLayoutEffect(() => {
+    const el = ref.current
+    const displayed = visible && present
+    if (el && displayed && !prevDisplayedRef.current) {
+      el.scrollIntoView({
+        behavior: reduceMotion ? 'auto' : 'smooth',
+        block: 'nearest',
+        inline: 'nearest'
+      })
+    }
+    prevDisplayedRef.current = displayed
+  }, [visible, present, reduceMotion])
+
   useLayoutEffect(() => {
     const el = ref.current
     const enterT = enter ?? slideTransition.enter ?? defaultTransition

--- a/apps/campfire/src/components/Deck/Slide/__tests__/Slide.test.tsx
+++ b/apps/campfire/src/components/Deck/Slide/__tests__/Slide.test.tsx
@@ -44,6 +44,19 @@ describe('Slide', () => {
     expect(useDeckStore.getState().maxSteps).toBe(3)
   })
 
+  it('enables vertical scrolling when content overflows', () => {
+    render(
+      <Deck>
+        <Slide>
+          <div style={{ height: '2000px' }}>Tall</div>
+        </Slide>
+      </Deck>
+    )
+    const el = screen.getByTestId('slide')
+    expect(el.className).toContain('overflow-y-auto')
+    expect(el.className).toContain('overflow-x-hidden')
+  })
+
   it('exposes transition metadata without applying animations', () => {
     const slide = (
       <Slide transition={{ type: 'fade', duration: 300 }}>Slide 1</Slide>

--- a/apps/storybook/src/SlideReveal.stories.tsx
+++ b/apps/storybook/src/SlideReveal.stories.tsx
@@ -68,3 +68,23 @@ const render: StoryObj<typeof SlideReveal>['render'] = () => (
 )
 
 export const Basic: StoryObj<typeof SlideReveal> = { render }
+
+/**
+ * Demonstrates scrolling to a reveal positioned below the initial viewport.
+ *
+ * @returns The rendered deck.
+ */
+export const ScrollIntoView: StoryObj<typeof SlideReveal> = {
+  render: () => (
+    <Deck className='w-[400px] h-[300px]'>
+      <Slide className='bg-gray-100 dark:bg-gray-900'>
+        <div style={{ height: '600px' }} />
+        <SlideReveal at={1}>
+          <SlideText x={20} y={580} size={24}>
+            Bottom
+          </SlideText>
+        </SlideReveal>
+      </Slide>
+    </Deck>
+  )
+}


### PR DESCRIPTION
## Summary
- allow slides to scroll vertically when content overflows
- automatically scroll newly revealed content into view with smooth behavior that respects reduced-motion preferences
- document and test slide scrolling behavior

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68bcb1abc7648322b5f5ff001eb87983