### PR TITLE
feat: add embed directive for video content (#699)

### DIFF
--- a/apps/campfire/src/components/Deck/Slide/SlideElements.tsx
+++ b/apps/campfire/src/components/Deck/Slide/SlideElements.tsx
@@ -33,6 +33,51 @@ export const SlideImage = createSlideElement<SlideImageProps>({
 })
 
 /**
+ * Props for the SlideEmbed element. Inherits `className` and `style` from
+ * {@link SlideLayerProps}.
+ */
+export interface SlideEmbedProps
+  extends Omit<SlideLayerProps, 'children' | 'as' | 'elementProps'> {
+  /** Embed source URL. */
+  src: string
+  /** Permissions applied to the iframe's `allow` attribute. */
+  allow?: string
+  /** Referrer policy for the iframe. */
+  referrerPolicy?: string
+  /** Enables fullscreen mode when true. */
+  allowFullScreen?: boolean
+}
+
+/**
+ * Renders external content within an iframe positioned on a slide.
+ *
+ * @param props - Configuration options for the embed element, including
+ * inherited `className` and `style` fields.
+ * @returns The rendered embed layer.
+ */
+export const SlideEmbed = createSlideElement<SlideEmbedProps>({
+  as: 'iframe',
+  testId: 'slideEmbed',
+  mapClassName: ({ className }) =>
+    ['campfire-slide-embed', className]
+      .filter(c => c != null && c !== '')
+      .join(' '),
+  mapElementProps: ({ src, allow, referrerPolicy, allowFullScreen }) => ({
+    src,
+    allow,
+    referrerPolicy,
+    allowFullScreen: allowFullScreen ? true : undefined
+  }),
+  mapLayerProps: ({
+    src,
+    allow,
+    referrerPolicy,
+    allowFullScreen,
+    ...layerProps
+  }) => layerProps
+})
+
+/**
  * Props for the SlideText element. Inherits `className` and `style` from
  * {@link SlideLayerProps}.
  */

--- a/apps/campfire/src/components/Deck/Slide/SlideEmbed/__tests__/SlideEmbed.test.tsx
+++ b/apps/campfire/src/components/Deck/Slide/SlideEmbed/__tests__/SlideEmbed.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'bun:test'
+import { render, screen } from '@testing-library/preact'
+import { SlideEmbed } from '@campfire/components/Deck/Slide'
+
+describe('SlideEmbed', () => {
+  it('renders an iframe with the given src', () => {
+    render(<SlideEmbed src='https://example.com/embed' />)
+    const wrapper = screen.getByTestId('slideEmbed') as HTMLElement
+    const iframe = wrapper.querySelector('iframe') as HTMLIFrameElement
+    expect(iframe.getAttribute('src')).toBe('https://example.com/embed')
+    expect(iframe.className).toContain('campfire-slide-embed')
+  })
+
+  it('handles allow and allowFullScreen props', () => {
+    render(
+      <SlideEmbed
+        src='https://example.com/embed'
+        allow='autoplay'
+        allowFullScreen
+      />
+    )
+    const iframe = screen
+      .getByTestId('slideEmbed')
+      .querySelector('iframe') as HTMLIFrameElement
+    expect(iframe.getAttribute('allow')).toBe('autoplay')
+    expect(iframe.hasAttribute('allowfullscreen')).toBe(true)
+  })
+
+  it('defaults allowFullScreen to false when not provided', () => {
+    render(<SlideEmbed src='https://example.com/embed' />)
+    const iframe = screen
+      .getByTestId('slideEmbed')
+      .querySelector('iframe') as HTMLIFrameElement
+    expect(iframe.hasAttribute('allowfullscreen')).toBe(false)
+  })
+})

--- a/apps/campfire/src/components/Deck/Slide/index.ts
+++ b/apps/campfire/src/components/Deck/Slide/index.ts
@@ -9,7 +9,7 @@ export type {
 } from './types'
 export { Slide }
 export { SlideReveal } from './SlideReveal'
-export { SlideText, SlideImage, SlideShape } from './SlideElements'
+export { SlideText, SlideImage, SlideShape, SlideEmbed } from './SlideElements'
 export { createSlideElement } from './createSlideElement'
 export { Layer } from './Layer'
 export type { LayerProps } from './Layer'

--- a/apps/campfire/src/components/Deck/Slide/renderDirectiveMarkdown.ts
+++ b/apps/campfire/src/components/Deck/Slide/renderDirectiveMarkdown.ts
@@ -17,7 +17,7 @@ import { Deck } from '@campfire/components/Deck/Deck'
 import { Slide } from './Slide'
 import { SlideReveal } from './SlideReveal'
 import { Layer } from './Layer'
-import { SlideText, SlideImage, SlideShape } from './SlideElements'
+import { SlideText, SlideImage, SlideShape, SlideEmbed } from './SlideElements'
 import { createMarkdownProcessor } from '@campfire/utils/createMarkdownProcessor'
 
 /**
@@ -52,7 +52,8 @@ export const renderDirectiveMarkdown = (
     layer: Layer,
     slideText: SlideText,
     slideImage: SlideImage,
-    slideShape: SlideShape
+    slideShape: SlideShape,
+    slideEmbed: SlideEmbed
   })
   const file = processor.processSync(markdown)
   return file.result as ComponentChild

--- a/apps/campfire/src/components/Passage/If.tsx
+++ b/apps/campfire/src/components/Passage/If.tsx
@@ -19,7 +19,8 @@ import { SlideReveal } from '@campfire/components/Deck/Slide/SlideReveal'
 import {
   SlideText,
   SlideImage,
-  SlideShape
+  SlideShape,
+  SlideEmbed
 } from '@campfire/components/Deck/Slide/SlideElements'
 import { rehypeSlideText } from '@campfire/utils/rehypeSlideText'
 
@@ -57,7 +58,8 @@ export const If = ({ test, content, fallback }: IfProps) => {
           reveal: SlideReveal,
           slideText: SlideText,
           slideImage: SlideImage,
-          slideShape: SlideShape
+          slideShape: SlideShape,
+          slideEmbed: SlideEmbed
         }
       })
     proc.parser = (_doc: unknown, file: Root) => ({

--- a/apps/campfire/src/components/Passage/Passage.tsx
+++ b/apps/campfire/src/components/Passage/Passage.tsx
@@ -36,6 +36,7 @@ import {
   SlideText,
   SlideImage,
   SlideShape,
+  SlideEmbed,
   Layer
 } from '@campfire/components/Deck/Slide'
 
@@ -105,7 +106,8 @@ export const Passage = () => {
           layer: Layer,
           slideText: SlideText,
           slideImage: SlideImage,
-          slideShape: SlideShape
+          slideShape: SlideShape,
+          slideEmbed: SlideEmbed
         },
         [remarkParagraphStyles, remarkHeadingStyles]
       ),

--- a/apps/campfire/src/components/index.ts
+++ b/apps/campfire/src/components/index.ts
@@ -23,6 +23,7 @@ export {
   Layer,
   SlideText,
   SlideImage,
-  SlideShape
+  SlideShape,
+  SlideEmbed
 } from '@campfire/components/Deck/Slide'
 export { Overlay } from '@campfire/components/Overlay'

--- a/apps/campfire/src/hooks/__tests__/embedDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/embedDirective.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach } from 'bun:test'
+import { render } from '@testing-library/preact'
+import type { ComponentChild } from 'preact'
+import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
+import { renderDirectiveMarkdown } from '@campfire/components/Deck/Slide'
+
+let output: ComponentChild | null = null
+
+/**
+ * Renders markdown with directive handlers for testing.
+ *
+ * @param markdown - Markdown string containing directives.
+ * @returns Rendered content via renderDirectiveMarkdown.
+ */
+const MarkdownRunner = ({ markdown }: { markdown: string }) => {
+  const handlers = useDirectiveHandlers()
+  output = renderDirectiveMarkdown(markdown, handlers)
+  return <>{output}</>
+}
+
+beforeEach(() => {
+  output = null
+  document.body.innerHTML = ''
+  ;(HTMLElement.prototype as any).animate = () => ({
+    finished: Promise.resolve(),
+    cancel: () => {},
+    finish: () => {}
+  })
+})
+
+describe('embed directive', () => {
+  it('renders a SlideEmbed component with props', () => {
+    const md =
+      ':::reveal\n::embed{src="https://www.youtube.com/embed/vid" allow="autoplay" allowFullScreen=true layerClassName="wrapper"}\n:::\n'
+    render(<MarkdownRunner markdown={md} />)
+    const el = document.querySelector(
+      '[data-testid="slideEmbed"]'
+    ) as HTMLElement
+    expect(el.className).toContain('campfire-layer')
+    expect(el.className).toContain('wrapper')
+    const iframe = el.querySelector('iframe') as HTMLIFrameElement
+    expect(iframe.getAttribute('src')).toBe('https://www.youtube.com/embed/vid')
+    expect(iframe.getAttribute('allow')).toBe('autoplay')
+    expect(iframe.hasAttribute('allowfullscreen')).toBe(true)
+  })
+
+  it('defaults allowFullScreen to false when omitted', () => {
+    const md =
+      ':::reveal\n::embed{src="https://www.youtube.com/embed/vid"}\n:::\n'
+    render(<MarkdownRunner markdown={md} />)
+    const iframe = document.querySelector(
+      '[data-testid="slideEmbed"] iframe'
+    ) as HTMLIFrameElement
+    expect(iframe.hasAttribute('allowfullscreen')).toBe(false)
+  })
+})

--- a/apps/campfire/src/hooks/useOverlayProcessor.tsx
+++ b/apps/campfire/src/hooks/useOverlayProcessor.tsx
@@ -25,6 +25,7 @@ import {
   SlideText,
   SlideImage,
   SlideShape,
+  SlideEmbed,
   Layer
 } from '@campfire/components/Deck/Slide'
 import {
@@ -94,7 +95,8 @@ export const useOverlayProcessor = (): void => {
         layer: Layer,
         slideText: SlideText,
         slideImage: SlideImage,
-        slideShape: SlideShape
+        slideShape: SlideShape,
+        slideEmbed: SlideEmbed
       }),
     [handlers]
   )

--- a/apps/campfire/tsconfig.json
+++ b/apps/campfire/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "types": ["bun", "preact", "../../matchers.d.ts"],
+    "types": ["bun", "preact", "matchers", "twine-jsx"],
     "noEmit": true,
     "baseUrl": ".",
     "paths": {

--- a/apps/storybook/src/SlideEmbed.stories.tsx
+++ b/apps/storybook/src/SlideEmbed.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/preact'
+import { Deck, Slide, SlideEmbed, SlideReveal } from '@campfire/components'
+
+const meta: Meta<typeof SlideEmbed> = {
+  component: SlideEmbed,
+  title: 'Campfire/Components/SlideEmbed'
+}
+
+export default meta
+
+/**
+ * Displays an embedded video centered on the slide at full width using the
+ * SlideEmbed component.
+ *
+ * @returns A Deck containing a single embedded video.
+ */
+export const Basic: StoryObj<typeof SlideEmbed> = {
+  render: () => (
+    <Deck className='w-[800px] h-[600px]' hideNavigation>
+      <Slide>
+        <SlideReveal at={0} className={'w-full h-full'}>
+          <SlideEmbed
+            layerClassName={'w-full h-full flex justify-center items-center'}
+            className={'aspect-video'}
+            src='https://www.youtube.com/embed/dQw4w9WgXcQ'
+            allow='autoplay; encrypted-media'
+            allowFullScreen
+          />
+        </SlideReveal>
+      </Slide>
+    </Deck>
+  )
+}

--- a/apps/storybook/tsconfig.json
+++ b/apps/storybook/tsconfig.json
@@ -1,7 +1,4 @@
 {
-  "compilerOptions": {
-    "types": ["../../twine-jsx"]
-  },
   "extends": "../../tsconfig.json",
   "include": ["**/*.ts", "**/*.tsx"]
 }

--- a/docs/directives/asset-management.md
+++ b/docs/directives/asset-management.md
@@ -50,6 +50,43 @@ Preload an image for later use.
 | `src`     | URL of the image file           |
 | `id`      | Unique identifier for the image |
 
+## Embeds
+
+### `embed`
+
+Embed external content such as YouTube videos within a slide.
+
+```md
+:::deck
+:::slide
+::embed{src='https://www.youtube.com/embed/dQw4w9WgXcQ' w=560 h=315 allow='autoplay' allowFullScreen=true}
+:::
+:::
+```
+
+Supports a `from` attribute to apply presets and uses `layerClassName` and `layerId` to customize the Layer wrapper.
+
+| Input           | Description                                        |
+| --------------- | -------------------------------------------------- |
+| x               | Horizontal position in pixels                      |
+| y               | Vertical position in pixels                        |
+| w               | Width in pixels                                    |
+| h               | Height in pixels                                   |
+| z               | z-index value                                      |
+| rotate          | Rotation in degrees                                |
+| scale           | Scale multiplier                                   |
+| anchor          | Transform origin (`top-left` by default)           |
+| src             | Embed source URL                                   |
+| allow           | Permissions applied to the `<iframe>` `allow` attr |
+| referrerPolicy  | Referrer policy for the `<iframe>`                 |
+| allowFullScreen | Enables fullscreen mode when `true`                |
+| style           | Inline styles applied to the `<iframe>`            |
+| className       | Classes applied to the `<iframe>`                  |
+| layerClassName  | Classes applied to the Layer wrapper               |
+| id              | Unique identifier for the `<iframe>`               |
+| layerId         | Unique identifier for the Layer wrapper            |
+| from            | Name of an embed preset to apply                   |
+
 ## Audio
 
 ### `preloadAudio`

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "files": ["./twine-jsx.d.ts", "./matchers.d.ts"],
   "compilerOptions": {
     "lib": ["ESNext", "DOM"],
     "target": "ESNext",
@@ -17,7 +18,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noPropertyAccessFromIndexSignature": false,
-    "types": ["bun", "preact", "./matchers.d.ts", "./twine-jsx.d.ts"],
+    "types": ["bun", "preact"],
     "resolveJsonModule": true,
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
* feat: add embed directive for video content

* docs(storybook): center SlideEmbed example

* docs: center embed story and use full width

* fix(tsconfig): load twine jsx types

* fix: expose twine JSX types via shared type roots

* fix(tsconfig): include twine jsx types in typecheck

* fix: update tsconfig to remove unused types and include necessary files

---------