### PR TITLE
refactor: consolidate attribute interpolation helper

### DIFF
--- a/apps/campfire/src/hooks/handlers/formHandlers.ts
+++ b/apps/campfire/src/hooks/handlers/formHandlers.ts
@@ -18,8 +18,7 @@ import {
 } from '@campfire/utils/directiveUtils'
 import {
   applyAdditionalAttributes,
-  getClassAttr,
-  getStyleAttr,
+  interpolateAttrs,
   removeDirectiveMarker,
   isMarkerParagraph,
   ensureParentIndex
@@ -96,8 +95,10 @@ export const createFormHandlers = (ctx: FormHandlerContext) => {
         console.error(msg)
         addError(msg)
       }
-      const classAttr = getClassAttr(attrs, getGameData())
-      const styleAttr = getStyleAttr(attrs, getGameData())
+      const { className: classAttr = '', style: styleAttr } = interpolateAttrs(
+        attrs,
+        getGameData()
+      )
       const placeholder =
         typeof attrs.placeholder === 'string' ? attrs.placeholder : undefined
       const initialValue =
@@ -134,8 +135,10 @@ export const createFormHandlers = (ctx: FormHandlerContext) => {
         console.error(msg)
         addError(msg)
       }
-      const classAttr = getClassAttr(attrs, getGameData())
-      const styleAttr = getStyleAttr(attrs, getGameData())
+      const { className: classAttr = '', style: styleAttr } = interpolateAttrs(
+        attrs,
+        getGameData()
+      )
       const placeholder =
         typeof attrs.placeholder === 'string' ? attrs.placeholder : undefined
       const initialValue =
@@ -218,8 +221,10 @@ export const createFormHandlers = (ctx: FormHandlerContext) => {
         console.error(msg)
         addError(msg)
       }
-      const classAttr = getClassAttr(attrs, getGameData())
-      const styleAttr = getStyleAttr(attrs, getGameData())
+      const { className: classAttr = '', style: styleAttr } = interpolateAttrs(
+        attrs,
+        getGameData()
+      )
       const initialValue =
         typeof attrs.value === 'string'
           ? attrs.value
@@ -256,8 +261,10 @@ export const createFormHandlers = (ctx: FormHandlerContext) => {
         console.error(msg)
         addError(msg)
       }
-      const classAttr = getClassAttr(attrs, getGameData())
-      const styleAttr = getStyleAttr(attrs, getGameData())
+      const { className: classAttr = '', style: styleAttr } = interpolateAttrs(
+        attrs,
+        getGameData()
+      )
       const initialValue =
         typeof attrs.value === 'string'
           ? attrs.value
@@ -339,8 +346,10 @@ export const createFormHandlers = (ctx: FormHandlerContext) => {
         console.error(msg)
         addError(msg)
       }
-      const classAttr = getClassAttr(attrs, getGameData())
-      const styleAttr = getStyleAttr(attrs, getGameData())
+      const { className: classAttr = '', style: styleAttr } = interpolateAttrs(
+        attrs,
+        getGameData()
+      )
       const valueAttr = typeof attrs.value === 'string' ? attrs.value : ''
       const initialValue =
         typeof attrs.defaultValue === 'string'
@@ -381,8 +390,10 @@ export const createFormHandlers = (ctx: FormHandlerContext) => {
         console.error(msg)
         addError(msg)
       }
-      const classAttr = getClassAttr(attrs, getGameData())
-      const styleAttr = getStyleAttr(attrs, getGameData())
+      const { className: classAttr = '', style: styleAttr } = interpolateAttrs(
+        attrs,
+        getGameData()
+      )
       const valueAttr = typeof attrs.value === 'string' ? attrs.value : ''
       const initialValue =
         typeof attrs.defaultValue === 'string'
@@ -466,8 +477,10 @@ export const createFormHandlers = (ctx: FormHandlerContext) => {
         console.error(msg)
         addError(msg)
       }
-      const classAttr = getClassAttr(attrs, getGameData())
-      const styleAttr = getStyleAttr(attrs, getGameData())
+      const { className: classAttr = '', style: styleAttr } = interpolateAttrs(
+        attrs,
+        getGameData()
+      )
       const placeholder =
         typeof attrs.placeholder === 'string' ? attrs.placeholder : undefined
       const initialValue =
@@ -505,8 +518,10 @@ export const createFormHandlers = (ctx: FormHandlerContext) => {
         console.error(msg)
         addError(msg)
       }
-      const classAttr = getClassAttr(attrs, getGameData())
-      const styleAttr = getStyleAttr(attrs, getGameData())
+      const { className: classAttr = '', style: styleAttr } = interpolateAttrs(
+        attrs,
+        getGameData()
+      )
       const placeholder =
         typeof attrs.placeholder === 'string' ? attrs.placeholder : undefined
       const initialValue =
@@ -604,8 +619,10 @@ export const createFormHandlers = (ctx: FormHandlerContext) => {
       console.error(msg)
       addError(msg)
     }
-    const classAttr = getClassAttr(attrs, getGameData())
-    const styleAttr = getStyleAttr(attrs, getGameData())
+    const { className: classAttr = '', style: styleAttr } = interpolateAttrs(
+      attrs,
+      getGameData()
+    )
     const props: Record<string, unknown> = { value: String(value) }
     if (classAttr) props.className = classAttr.split(/\s+/).filter(Boolean)
     if (styleAttr) props.style = styleAttr
@@ -669,8 +686,10 @@ export const createFormHandlers = (ctx: FormHandlerContext) => {
       console.error(msg)
       addError(msg)
     }
-    const classAttr = getClassAttr(attrs, getGameData())
-    const styleAttr = getStyleAttr(attrs, getGameData())
+    const { className: classAttr = '', style: styleAttr } = interpolateAttrs(
+      attrs,
+      getGameData()
+    )
     const initialValue =
       typeof attrs.value === 'string'
         ? attrs.value
@@ -752,9 +771,11 @@ export const createFormHandlers = (ctx: FormHandlerContext) => {
             | undefined)
         : rawLabel
     const defaultLabel = evaluatedLabel ?? getLabel(container)
-    const classAttr = getClassAttr(attrs, getGameData())
+    const { className: classAttr = '', style: styleAttr } = interpolateAttrs(
+      attrs,
+      getGameData()
+    )
     const disabledAttr = attrs.disabled
-    const styleAttr = getStyleAttr(attrs, getGameData())
     const processedForLabel = runDirectiveBlock(
       expandIndentedCode(container.children as RootContent[]),
       { wrapper: handleWrapper }
@@ -818,7 +839,10 @@ export const createFormHandlers = (ctx: FormHandlerContext) => {
       } else {
         const first = wrappersRaw[0]
         const wattrs = (first.attributes || {}) as Record<string, unknown>
-        const classAttr = getClassAttr(wattrs, getGameData())
+        const { className: classAttr = '' } = interpolateAttrs(
+          wattrs,
+          getGameData()
+        )
         const labelEl: Parent = {
           type: 'paragraph',
           children: (first.children as RootContent[]) || [],

--- a/apps/campfire/src/hooks/handlers/i18nHandlers.ts
+++ b/apps/campfire/src/hooks/handlers/i18nHandlers.ts
@@ -14,8 +14,7 @@ import {
   replaceWithIndentation
 } from '@campfire/utils/directiveUtils'
 import {
-  getClassAttr,
-  getStyleAttr,
+  interpolateAttrs,
   requireLeafDirective,
   ensureParentIndex
 } from '@campfire/utils/directiveHandlerUtils'
@@ -234,8 +233,10 @@ export const createI18nHandlers = (ctx: I18nHandlerContext) => {
       { state: gameData }
     )
     if (attrs.ns) ns = attrs.ns
-    const classAttr = getClassAttr(attrs, gameData)
-    const styleAttr = getStyleAttr(attrs, gameData)
+    const { className: classAttr = '', style: styleAttr } = interpolateAttrs(
+      attrs,
+      gameData
+    )
     const keyPattern = /^[A-Za-z_$][A-Za-z0-9_$]*(?::[A-Za-z0-9_.$-]+)?$/
     let props: Properties
     if (key || keyPattern.test(raw)) {

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -33,6 +33,7 @@ import {
   interpolateAttrs,
   ensureParentIndex
 } from '@campfire/utils/directiveHandlerUtils'
+import { interpolateString } from '@campfire/utils/core'
 import type {
   Transition,
   Direction
@@ -868,15 +869,13 @@ export const useDirectiveHandlers = () => {
       props['data-testid'] = 'layer'
       let classAttr = ''
       if (typeof attrs.className === 'string') {
-        ;({ className: classAttr = '' } = interpolateAttrs(
-          { className: attrs.className },
-          gameData
-        ))
+        classAttr = attrs.className.includes('${')
+          ? interpolateString(attrs.className, gameData)
+          : attrs.className
       } else if (typeof mergedRaw.className === 'string') {
-        ;({ className: classAttr = '' } = interpolateAttrs(
-          { className: mergedRaw.className },
-          gameData
-        ))
+        classAttr = mergedRaw.className.includes('${')
+          ? interpolateString(mergedRaw.className, gameData)
+          : mergedRaw.className
       }
       if (classAttr) props.className = classAttr
       if (attrs.id) props.id = attrs.id
@@ -1152,11 +1151,10 @@ export const useDirectiveHandlers = () => {
     const rawStyle = mergedRaw.style
     if (rawStyle) {
       if (typeof rawStyle === 'string') {
-        const { style: styleAttr } = interpolateAttrs(
-          { style: rawStyle },
-          gameData
-        )
-        if (styleAttr) style.push(styleAttr as string)
+        const styleAttr = rawStyle.includes('${')
+          ? interpolateString(rawStyle, gameData)
+          : rawStyle
+        if (styleAttr) style.push(styleAttr)
       } else if (typeof rawStyle === 'object') {
         const entries = Object.entries(rawStyle as Record<string, unknown>).map(
           ([k, v]) => `${k}:${v}`

--- a/apps/campfire/src/utils/directiveHandlerUtils.ts
+++ b/apps/campfire/src/utils/directiveHandlerUtils.ts
@@ -9,44 +9,6 @@ import { DEFAULT_DECK_HEIGHT, DEFAULT_DECK_WIDTH } from '@campfire/constants'
 const DIRECTIVE_MARKER = ':::'
 const ASPECT_RATIO_THRESHOLD = 100
 
-const interpolateAttr = (
-  value: string | undefined,
-  data: Record<string, unknown>
-): string | undefined =>
-  value && value.includes('${') ? interpolateString(value, data) : value
-
-/**
- * Retrieves and interpolates the `className` attribute from a directive.
- *
- * @param attrs - Attribute map from the directive.
- * @param data - Current game data for interpolation.
- * @returns The processed class string, or an empty string when absent.
- */
-export const getClassAttr = (
-  attrs: Record<string, unknown>,
-  data: Record<string, unknown>
-): string =>
-  interpolateAttr(
-    typeof attrs.className === 'string' ? attrs.className : undefined,
-    data
-  ) || ''
-
-/**
- * Retrieves and interpolates the `style` attribute from a directive.
- *
- * @param attrs - Attribute map from the directive.
- * @param data - Current game data for interpolation.
- * @returns The processed style string, or undefined when absent.
- */
-export const getStyleAttr = (
-  attrs: Record<string, unknown>,
-  data: Record<string, unknown>
-): string | undefined =>
-  interpolateAttr(
-    typeof attrs.style === 'string' ? attrs.style : undefined,
-    data
-  )
-
 /**
  * Interpolates all string values within an attribute map.
  *
@@ -54,14 +16,16 @@ export const getStyleAttr = (
  * @param data - Current game data for interpolation.
  * @returns New attribute map with interpolated strings.
  */
-export const normalizeStringAttrs = <T extends Record<string, unknown>>(
+export const interpolateAttrs = <T extends Record<string, unknown>>(
   attrs: T,
   data: Record<string, unknown>
 ): T => {
   const result: Record<string, unknown> = {}
   for (const [key, value] of Object.entries(attrs)) {
     result[key] =
-      typeof value === 'string' ? interpolateAttr(value, data) : value
+      typeof value === 'string' && value.includes('${')
+        ? interpolateString(value, data)
+        : value
   }
   return result as T
 }


### PR DESCRIPTION
## Summary
- replace specialized class/style helpers with generalized `interpolateAttrs`
- update directive handlers to destructure interpolated attributes
- drop old `interpolateAttr` utility

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68c024a3479c832295c304ab6f1c2d14