### PR TITLE
feat: centralize asset loading in helper

### DIFF
--- a/apps/campfire/src/audio/AudioManager.ts
+++ b/apps/campfire/src/audio/AudioManager.ts
@@ -14,22 +14,32 @@ export class AudioManager extends AssetManager<HTMLAudioElement> {
   // reduce GC pressure. Handle user gesture requirements for autoplay.
 
   /**
+   * Creates a new audio element with automatic preloading.
+   *
+   * @returns A new HTMLAudioElement.
+   */
+  private createAudio = (): HTMLAudioElement => {
+    const audio = new Audio()
+    audio.preload = 'auto'
+    return audio
+  }
+
+  /**
    * Retrieves a cached audio element or creates one from the given source.
    *
    * @param id - Identifier for the audio track.
    * @param source - Optional source URL for the track.
    * @returns The audio element or undefined if no source was available.
    */
-  private getOrCreateAudio(
+  private getOrCreateAudio = (
     id: string,
     source?: string
-  ): HTMLAudioElement | undefined {
-    return this.getOrCreate(id, source, href => {
-      const audio = new Audio(href)
-      audio.preload = 'auto'
+  ): HTMLAudioElement | undefined =>
+    this.getOrCreate(id, source, href => {
+      const audio = this.createAudio()
+      audio.src = href
       return audio
     })
-  }
 
   /**
    * Preloads an audio file. If the id already exists, it will be ignored.
@@ -39,30 +49,15 @@ export class AudioManager extends AssetManager<HTMLAudioElement> {
    * @returns A promise that resolves when the audio is loaded.
    */
   load(id: string, src: string): Promise<void> {
-    const audio = this.getOrCreateAudio(id, src)
-    if (!audio) {
-      console.error(`Failed to load audio: ${id}`)
-      return Promise.reject(new Error(`Failed to load audio: ${id}`))
-    }
-    if (audio.readyState >= HTMLMediaElement.HAVE_ENOUGH_DATA)
-      return Promise.resolve()
-    return new Promise((resolve, reject) => {
-      const cleanup = () => {
-        audio.removeEventListener('canplaythrough', handleLoad)
-        audio.removeEventListener('error', handleError)
-      }
-      const handleLoad = () => {
-        cleanup()
-        resolve()
-      }
-      const handleError = (err: unknown) => {
-        cleanup()
-        reject(err)
-      }
-      audio.addEventListener('canplaythrough', handleLoad)
-      audio.addEventListener('error', handleError)
-      audio.load()
-    })
+    return super
+      .load(id, src, this.createAudio, {
+        start: (audio, href) => {
+          audio.src = href
+          audio.load()
+        },
+        loadEvent: 'canplaythrough'
+      })
+      .then(() => undefined)
   }
 
   /**

--- a/apps/campfire/src/utils/AssetManager.ts
+++ b/apps/campfire/src/utils/AssetManager.ts
@@ -5,11 +5,14 @@ import { getBaseUrl } from '@campfire/utils/core'
  *
  * @typeParam T - Type of asset handled by the manager.
  */
-export abstract class AssetManager<T> {
+export abstract class AssetManager<T extends EventTarget> {
   private static instances = new Map<Function, AssetManager<any>>()
 
   /** Cache of loaded assets keyed by identifier. */
   protected cache: Map<string, T> = new Map()
+
+  /** Map of in-flight load promises keyed by identifier. */
+  protected inFlight: Map<string, Promise<T>> = new Map()
 
   // TODO(campfire): Consider adding cache controls (max size/TTL/clear)
   // and metrics for hit/miss to guide preloading strategies.
@@ -65,6 +68,100 @@ export abstract class AssetManager<T> {
     asset = factory(href)
     this.cache.set(id, asset)
     return asset
+  }
+
+  /**
+   * Loads an asset, caching the result and deduping concurrent requests.
+   *
+   * @param id - Cache key for the asset.
+   * @param src - Source URL for the asset.
+   * @param create - Factory creating a blank asset instance.
+   * @param options - Load configuration.
+   * @returns A promise resolving with the loaded asset.
+   */
+  protected load(
+    id: string,
+    src: string,
+    create: () => T,
+    {
+      start,
+      loadEvent,
+      errorEvent = 'error'
+    }: {
+      /**
+       * Starts the load process after listeners are attached.
+       *
+       * @param asset - The asset to start loading.
+       * @param href - Resolved URL for the asset.
+       */
+      start: (asset: T, href: string) => void
+      /** Event fired when the asset has loaded. */
+      loadEvent: string
+      /** Event fired when the asset fails to load. */
+      errorEvent?: string
+    }
+  ): Promise<T> {
+    const cached = this.cache.get(id)
+    if (cached) return Promise.resolve(cached)
+    const pending = this.inFlight.get(id)
+    if (pending) return pending
+
+    let href: string
+    try {
+      href = this.resolve(src)
+    } catch (err) {
+      return Promise.reject(err)
+    }
+
+    const asset = create()
+
+    const promise = new Promise<T>((resolve, reject) => {
+      const onLoad = () => {
+        cleanup()
+        resolve(asset)
+      }
+      const onError = (err: unknown) => {
+        cleanup()
+        reject(err)
+      }
+      const cleanup = () => {
+        if ('addEventListener' in asset) {
+          asset.removeEventListener(loadEvent, onLoad as EventListener)
+          asset.removeEventListener(errorEvent, onError as EventListener)
+        } else {
+          ;(asset as unknown as { onload: null; onerror: null }).onload = null
+          ;(asset as unknown as { onload: null; onerror: null }).onerror = null
+        }
+      }
+      if ('addEventListener' in asset) {
+        asset.addEventListener(loadEvent, onLoad as EventListener)
+        asset.addEventListener(errorEvent, onError as EventListener)
+      } else {
+        ;(
+          asset as unknown as { onload: typeof onLoad; onerror: typeof onError }
+        ).onload = onLoad
+        ;(
+          asset as unknown as { onload: typeof onLoad; onerror: typeof onError }
+        ).onerror = onError
+      }
+      try {
+        start(asset, href)
+      } catch (err) {
+        cleanup()
+        reject(err)
+      }
+    })
+
+    let wrapped: Promise<T> = promise.then(result => {
+      if (this.inFlight.get(id) === wrapped) this.cache.set(id, result)
+      return result
+    })
+    wrapped = wrapped.finally(() => {
+      if (this.inFlight.get(id) === wrapped) this.inFlight.delete(id)
+    })
+
+    this.inFlight.set(id, wrapped)
+    return wrapped
   }
 }
 


### PR DESCRIPTION
## Summary
- add generic load helper with caching and event cleanup
- delegate audio and image loading to shared helper
- drop redundant promise tracking in asset managers

## Testing
- `bunx prettier . --write`
- `bun tsc`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_68c02d0557108322a14b98f0b38abb30