### PR TITLE
refactor: centralize directive component map

### DIFF
--- a/apps/campfire/src/components/Passage/Passage.tsx
+++ b/apps/campfire/src/components/Passage/Passage.tsx
@@ -16,29 +16,7 @@ import {
   type StoryDataState
 } from '@campfire/state/useStoryDataStore'
 import { useDeckStore } from '@campfire/state/useDeckStore'
-import { LinkButton } from '@campfire/components/Passage/LinkButton'
-import { TriggerButton } from '@campfire/components/Passage/TriggerButton'
-import { Input } from '@campfire/components/Passage/Input'
-import { Checkbox } from '@campfire/components/Passage/Checkbox'
-import { Radio } from '@campfire/components/Passage/Radio'
-import { Textarea } from '@campfire/components/Passage/Textarea'
-import { Select } from '@campfire/components/Passage/Select'
-import { Option } from '@campfire/components/Passage/Option'
-import { If } from '@campfire/components/Passage/If'
-import { Show } from '@campfire/components/Passage/Show'
-import { Translate } from '@campfire/components/Passage/Translate'
-import { OnExit } from '@campfire/components/Passage/OnExit'
-import { Effect } from '@campfire/components/Passage/Effect'
-import { Deck } from '@campfire/components/Deck/Deck'
-import {
-  Slide,
-  SlideReveal,
-  SlideText,
-  SlideImage,
-  SlideShape,
-  SlideEmbed,
-  Layer
-} from '@campfire/components/Deck/Slide'
+import { componentMap } from '@campfire/components/Passage/componentMap'
 
 const DIRECTIVE_MARKER_PATTERN = '(:::[^\\n]*|:[^\\n]*|<<)'
 
@@ -84,33 +62,10 @@ export const Passage = () => {
   const handlers = useDirectiveHandlers()
   const processor = useMemo(
     () =>
-      createMarkdownProcessor(
-        handlers,
-        {
-          button: LinkButton,
-          trigger: TriggerButton,
-          input: Input,
-          checkbox: Checkbox,
-          radio: Radio,
-          textarea: Textarea,
-          select: Select,
-          option: Option,
-          if: If,
-          show: Show,
-          translate: Translate,
-          effect: Effect,
-          onExit: OnExit,
-          deck: Deck,
-          slide: Slide,
-          reveal: SlideReveal,
-          layer: Layer,
-          slideText: SlideText,
-          slideImage: SlideImage,
-          slideShape: SlideShape,
-          slideEmbed: SlideEmbed
-        },
-        [remarkParagraphStyles, remarkHeadingStyles]
-      ),
+      createMarkdownProcessor(handlers, componentMap, [
+        remarkParagraphStyles,
+        remarkHeadingStyles
+      ]),
     [handlers]
   )
   const passage = useStoryDataStore((state: StoryDataState) =>

--- a/apps/campfire/src/components/Passage/componentMap.ts
+++ b/apps/campfire/src/components/Passage/componentMap.ts
@@ -1,0 +1,53 @@
+import type { ComponentType } from 'preact'
+import { LinkButton } from '@campfire/components/Passage/LinkButton'
+import { TriggerButton } from '@campfire/components/Passage/TriggerButton'
+import { Input } from '@campfire/components/Passage/Input'
+import { Checkbox } from '@campfire/components/Passage/Checkbox'
+import { Radio } from '@campfire/components/Passage/Radio'
+import { Textarea } from '@campfire/components/Passage/Textarea'
+import { Select } from '@campfire/components/Passage/Select'
+import { Option } from '@campfire/components/Passage/Option'
+import { If } from '@campfire/components/Passage/If'
+import { Show } from '@campfire/components/Passage/Show'
+import { Translate } from '@campfire/components/Passage/Translate'
+import { OnExit } from '@campfire/components/Passage/OnExit'
+import { Effect } from '@campfire/components/Passage/Effect'
+import { Deck } from '@campfire/components/Deck/Deck'
+import {
+  Slide,
+  SlideReveal,
+  SlideText,
+  SlideImage,
+  SlideShape,
+  SlideEmbed,
+  Layer
+} from '@campfire/components/Deck/Slide'
+
+/**
+ * Maps directive names to their corresponding Campfire components.
+ */
+export const componentMap: Record<string, ComponentType<any>> = {
+  button: LinkButton,
+  trigger: TriggerButton,
+  input: Input,
+  checkbox: Checkbox,
+  radio: Radio,
+  textarea: Textarea,
+  select: Select,
+  option: Option,
+  if: If,
+  show: Show,
+  translate: Translate,
+  effect: Effect,
+  onExit: OnExit,
+  deck: Deck,
+  slide: Slide,
+  reveal: SlideReveal,
+  layer: Layer,
+  slideText: SlideText,
+  slideImage: SlideImage,
+  slideShape: SlideShape,
+  slideEmbed: SlideEmbed
+}
+
+export default componentMap

--- a/apps/campfire/src/hooks/useOverlayProcessor.tsx
+++ b/apps/campfire/src/hooks/useOverlayProcessor.tsx
@@ -3,35 +3,14 @@ import type { ComponentChild } from 'preact'
 import type { Content, Text as HastText } from 'hast'
 import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
 import { createMarkdownProcessor } from '@campfire/utils/createMarkdownProcessor'
-import {
-  useStoryDataStore,
-  type StoryDataState
-} from '@campfire/state/useStoryDataStore'
+import { useStoryDataStore } from '@campfire/state/useStoryDataStore'
 import { useOverlayStore } from '@campfire/state/useOverlayStore'
-import { LinkButton } from '@campfire/components/Passage/LinkButton'
-import { TriggerButton } from '@campfire/components/Passage/TriggerButton'
-import { Input } from '@campfire/components/Passage/Input'
-import { Textarea } from '@campfire/components/Passage/Textarea'
-import { Select } from '@campfire/components/Passage/Select'
-import { Option } from '@campfire/components/Passage/Option'
-import { If } from '@campfire/components/Passage/If'
-import { Show } from '@campfire/components/Passage/Show'
-import { Translate } from '@campfire/components/Passage/Translate'
-import { OnExit } from '@campfire/components/Passage/OnExit'
-import { Effect } from '@campfire/components/Passage/Effect'
 import { Deck, type DeckProps } from '@campfire/components/Deck/Deck'
-import {
-  Slide,
-  SlideText,
-  SlideImage,
-  SlideShape,
-  SlideEmbed,
-  Layer
-} from '@campfire/components/Deck/Slide'
 import {
   SlideReveal,
   type SlideRevealProps
 } from '@campfire/components/Deck/Slide/SlideReveal'
+import { componentMap } from '@campfire/components/Passage/componentMap'
 import { useOverlayDeckStore } from '@campfire/state/useOverlayDeckStore'
 
 const DIRECTIVE_MARKER_PATTERN = '(:::[^\\n]*|:[^\\n]*|<<)'
@@ -76,25 +55,9 @@ export const useOverlayProcessor = (): void => {
   const processor = useMemo(
     () =>
       createMarkdownProcessor(handlers, {
-        button: LinkButton,
-        trigger: TriggerButton,
-        input: Input,
-        textarea: Textarea,
-        select: Select,
-        option: Option,
-        if: If,
-        show: Show,
-        translate: Translate,
-        effect: Effect,
-        onExit: OnExit,
+        ...componentMap,
         deck: OverlayDeck,
-        slide: Slide,
-        reveal: OverlayReveal,
-        layer: Layer,
-        slideText: SlideText,
-        slideImage: SlideImage,
-        slideShape: SlideShape,
-        slideEmbed: SlideEmbed
+        reveal: OverlayReveal
       }),
     [handlers]
   )


### PR DESCRIPTION
## Summary
- add `componentMap` shared mapping for directives to components
- use shared mapping in `Passage` and overlay processor

## Testing
- `bun tsc`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68c0c454d5d08322baa5736b5246d3ec