### PR TITLE
docs: discourage manual changelog edits

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -72,5 +72,6 @@ If a container directive nests another container and is followed by an inline di
 - Visual components must include `data-testid` attributes and a default `campfire-{name}` class with no associated styles.
 - Trust these instructions and search the repository only if information is missing or incorrect.
 - Define colors using `oklch()` notation instead of hex or other color formats.
+- Never directly edit `CHANGELOG.md`; it is managed automatically.
 - Ensure tests cover both truthy and falsey paths for conditional logic.
 - Tag `@codex` in any comment.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@
 - Ensure every visual component includes a default `campfire-{name}` class with no associated styles.
 - Use Conventional Commits for all commit messages.
 - Define colors using `oklch()` notation instead of hex or other color formats.
+- Never directly edit `CHANGELOG.md`; it is managed automatically.
 - If this `AGENTS.md` file is updated, also update `.github/copilot-instructions.md` to reflect the changes.
 - If you update the `template.ejs` file, also update the Storybook preview template to keep them in sync.
 - If you update React components, add or update corresponding Storybook stories to reflect the changes.


### PR DESCRIPTION
## Summary
- forbid manual edits to `CHANGELOG.md` in repository guidelines
- mirror changelog editing rule in Copilot instructions

## Testing
- `bun run typecheck`
- `bun test`
- `bunx prettier . --write`


------
https://chatgpt.com/codex/tasks/task_e_68c4f75575cc8322a3c6259085f1ba5a