### PR TITLE
fix: resolve storybook directive and passage type errors

### DIFF
--- a/apps/campfire/src/audio/AudioManager.ts
+++ b/apps/campfire/src/audio/AudioManager.ts
@@ -48,16 +48,14 @@ export class AudioManager extends AssetManager<HTMLAudioElement> {
    * @param src - Source URL of the audio file.
    * @returns A promise that resolves when the audio is loaded.
    */
-  load(id: string, src: string): Promise<void> {
-    return super
-      .load(id, src, this.createAudio, {
-        start: (audio, href) => {
-          audio.src = href
-          audio.load()
-        },
-        loadEvent: 'canplaythrough'
-      })
-      .then(() => undefined)
+  load(id: string, src: string): Promise<HTMLAudioElement> {
+    return super.load(id, src, this.createAudio, {
+      start: (audio, href) => {
+        audio.src = href
+        audio.load()
+      },
+      loadEvent: 'canplaythrough'
+    })
   }
 
   /**

--- a/apps/campfire/src/components/Deck/Slide/SlideReveal/index.tsx
+++ b/apps/campfire/src/components/Deck/Slide/SlideReveal/index.tsx
@@ -9,6 +9,7 @@ import {
 import { useDeckStore } from '@campfire/state/useDeckStore'
 import type { Transition } from '../types'
 import { SlideTransitionContext } from '../context'
+import type { SlideTransitionContextValue } from '../context'
 import {
   defaultTransition,
   prefersReducedMotion,
@@ -53,7 +54,9 @@ export const SlideReveal = ({
 }: SlideRevealProps): JSX.Element | null => {
   const currentStep = store(state => state.currentStep)
   const currentSlide = store(state => state.currentSlide)
-  const slideTransition = useContext(SlideTransitionContext)
+  const slideTransition = useContext<SlideTransitionContextValue>(
+    SlideTransitionContext
+  )
   const [present, setPresent] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
   const animationRef = useRef<Animation | null>(null)

--- a/apps/campfire/src/components/__tests__/LoadingScreen.test.tsx
+++ b/apps/campfire/src/components/__tests__/LoadingScreen.test.tsx
@@ -22,7 +22,7 @@ describe('LoadingScreen', () => {
     const audio = AudioManager.getInstance()
     const images = ImageManager.getInstance()
     const audioSpy = spyOn(audio, 'load').mockImplementation(() =>
-      Promise.resolve()
+      Promise.resolve(new Audio())
     )
     let resolveImage: (value: HTMLImageElement) => void = () => {}
     const imageSpy = spyOn(images, 'load').mockImplementation(

--- a/apps/campfire/src/hooks/handlers/formHandlers.ts
+++ b/apps/campfire/src/hooks/handlers/formHandlers.ts
@@ -108,7 +108,8 @@ export const createFormHandlers = (ctx: FormHandlerContext) => {
             ? attrs.defaultValue
             : undefined
       const props: Record<string, unknown> = { stateKey: key }
-      if (classAttr) props.className = classAttr.split(/\s+/).filter(Boolean)
+      if (classAttr)
+        props.className = (classAttr as string).split(/\s+/).filter(Boolean)
       if (styleAttr) props.style = styleAttr
       if (placeholder) props.placeholder = placeholder
       if (initialValue) props.initialValue = initialValue
@@ -175,7 +176,8 @@ export const createFormHandlers = (ctx: FormHandlerContext) => {
         Object.assign(events, extraEvents)
       }
       const props: Record<string, unknown> = { stateKey: key }
-      if (classAttr) props.className = classAttr.split(/\s+/).filter(Boolean)
+      if (classAttr)
+        props.className = (classAttr as string).split(/\s+/).filter(Boolean)
       if (styleAttr) props.style = styleAttr
       if (placeholder) props.placeholder = placeholder
       if (initialValue) props.initialValue = initialValue
@@ -234,7 +236,8 @@ export const createFormHandlers = (ctx: FormHandlerContext) => {
               ? attrs.checked
               : undefined
       const props: Record<string, unknown> = { stateKey: key }
-      if (classAttr) props.className = classAttr.split(/\s+/).filter(Boolean)
+      if (classAttr)
+        props.className = (classAttr as string).split(/\s+/).filter(Boolean)
       if (styleAttr) props.style = styleAttr
       if (initialValue) props.initialValue = initialValue
       applyAdditionalAttributes(
@@ -301,7 +304,8 @@ export const createFormHandlers = (ctx: FormHandlerContext) => {
         Object.assign(events, extraEvents)
       }
       const props: Record<string, unknown> = { stateKey: key }
-      if (classAttr) props.className = classAttr.split(/\s+/).filter(Boolean)
+      if (classAttr)
+        props.className = (classAttr as string).split(/\s+/).filter(Boolean)
       if (styleAttr) props.style = styleAttr
       if (initialValue) props.initialValue = initialValue
       if (events.onMouseEnter) props.onMouseEnter = events.onMouseEnter
@@ -361,7 +365,8 @@ export const createFormHandlers = (ctx: FormHandlerContext) => {
         stateKey: key,
         value: valueAttr
       }
-      if (classAttr) props.className = classAttr.split(/\s+/).filter(Boolean)
+      if (classAttr)
+        props.className = (classAttr as string).split(/\s+/).filter(Boolean)
       if (styleAttr) props.style = styleAttr
       if (initialValue) props.initialValue = initialValue
       applyAdditionalAttributes(
@@ -432,7 +437,8 @@ export const createFormHandlers = (ctx: FormHandlerContext) => {
         stateKey: key,
         value: valueAttr
       }
-      if (classAttr) props.className = classAttr.split(/\s+/).filter(Boolean)
+      if (classAttr)
+        props.className = (classAttr as string).split(/\s+/).filter(Boolean)
       if (styleAttr) props.style = styleAttr
       if (initialValue) props.initialValue = initialValue
       if (events.onMouseEnter) props.onMouseEnter = events.onMouseEnter
@@ -490,7 +496,8 @@ export const createFormHandlers = (ctx: FormHandlerContext) => {
             ? attrs.defaultValue
             : undefined
       const props: Record<string, unknown> = { stateKey: key }
-      if (classAttr) props.className = classAttr.split(/\s+/).filter(Boolean)
+      if (classAttr)
+        props.className = (classAttr as string).split(/\s+/).filter(Boolean)
       if (styleAttr) props.style = styleAttr
       if (placeholder) props.placeholder = placeholder
       if (initialValue) props.initialValue = initialValue
@@ -559,7 +566,8 @@ export const createFormHandlers = (ctx: FormHandlerContext) => {
       }
 
       const props: Record<string, unknown> = { stateKey: key }
-      if (classAttr) props.className = classAttr.split(/\s+/).filter(Boolean)
+      if (classAttr)
+        props.className = (classAttr as string).split(/\s+/).filter(Boolean)
       if (styleAttr) props.style = styleAttr
       if (placeholder) props.placeholder = placeholder
       if (initialValue) props.initialValue = initialValue
@@ -624,7 +632,8 @@ export const createFormHandlers = (ctx: FormHandlerContext) => {
       getGameData()
     )
     const props: Record<string, unknown> = { value: String(value) }
-    if (classAttr) props.className = classAttr.split(/\s+/).filter(Boolean)
+    if (classAttr)
+      props.className = (classAttr as string).split(/\s+/).filter(Boolean)
     if (styleAttr) props.style = styleAttr
     applyAdditionalAttributes(
       attrs,
@@ -726,7 +735,8 @@ export const createFormHandlers = (ctx: FormHandlerContext) => {
 
     const options = remaining.filter(node => !isWhitespaceRootContent(node))
     const props: Record<string, unknown> = { stateKey: key }
-    if (classAttr) props.className = classAttr.split(/\s+/).filter(Boolean)
+    if (classAttr)
+      props.className = (classAttr as string).split(/\s+/).filter(Boolean)
     if (styleAttr) props.style = styleAttr
     if (initialValue) props.initialValue = initialValue
     if (events.onMouseEnter) props.onMouseEnter = events.onMouseEnter
@@ -908,7 +918,7 @@ export const createFormHandlers = (ctx: FormHandlerContext) => {
       ...pendingFiltered
     ])
 
-    const classes = classAttr.split(/\s+/).filter(Boolean)
+    const classes = (classAttr as string).split(/\s+/).filter(Boolean)
     const hProps: Record<string, unknown> = {
       className: classes,
       content: JSON.stringify(finalContentNodes),

--- a/apps/campfire/src/state/stateManager.ts
+++ b/apps/campfire/src/state/stateManager.ts
@@ -18,6 +18,5 @@ export const createStateManager = <T extends Record<string, unknown>>() => {
 export type {
   StateManager as StateManagerType,
   SetOptions,
-  RangeValue,
   StateChanges
 } from './utils'

--- a/apps/campfire/tsconfig.json
+++ b/apps/campfire/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "types": ["bun", "preact", "matchers", "twine-jsx"],
     "noEmit": true,
     "baseUrl": ".",
     "paths": {
@@ -9,5 +8,11 @@
     "allowImportingTsExtensions": false
   },
   "extends": "../../tsconfig.json",
-  "include": ["src/**/*", "lib/**/*"]
+  "include": [
+    "src/**/*",
+    "lib/**/*",
+    "globals.d.ts",
+    "../../twine-jsx.d.ts",
+    "../../matchers.d.ts"
+  ]
 }

--- a/apps/storybook/tsconfig.json
+++ b/apps/storybook/tsconfig.json
@@ -1,4 +1,8 @@
 {
+  "files": ["../campfire/globals.d.ts", "../../twine-jsx.d.ts"],
+  "compilerOptions": {
+    "types": ["bun", "preact"]
+  },
   "extends": "../../tsconfig.json",
   "include": ["**/*.ts", "**/*.tsx"]
 }


### PR DESCRIPTION
## Summary
- include Twine JSX and global declarations in Storybook build
- tighten Passage and handler typings
- correct AudioManager load return value

## Testing
- `bun tsc -p apps/campfire/tsconfig.json`
- `bun tsc -p apps/storybook/tsconfig.json`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68c591b767008322a6fa76f9717af87a