### PR TITLE
fix: group switch directive cases

### DIFF
--- a/apps/campfire/src/components/Deck/Slide/renderDirectiveMarkdown.ts
+++ b/apps/campfire/src/components/Deck/Slide/renderDirectiveMarkdown.ts
@@ -13,6 +13,7 @@ import { Show } from '@campfire/components/Passage/Show'
 import { Translate } from '@campfire/components/Passage/Translate'
 import { OnExit } from '@campfire/components/Passage/OnExit'
 import { Effect } from '@campfire/components/Passage/Effect'
+import { Switch } from '@campfire/components/Passage/Switch'
 import { Deck } from '@campfire/components/Deck/Deck'
 import { Slide } from './Slide'
 import { SlideReveal } from './SlideReveal'
@@ -46,6 +47,7 @@ export const renderDirectiveMarkdown = (
     translate: Translate,
     effect: Effect,
     onExit: OnExit,
+    switch: Switch,
     deck: Deck,
     slide: Slide,
     reveal: SlideReveal,

--- a/apps/campfire/src/hooks/__tests__/switchDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/switchDirective.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach } from 'bun:test'
+import { render } from '@testing-library/preact'
+import { Fragment } from 'preact/jsx-runtime'
+import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
+import { renderDirectiveMarkdown } from '@campfire/components/Deck/Slide'
+
+/**
+ * Component used in tests to render markdown with directive handlers.
+ *
+ * @param markdown - Markdown string that may include directive containers.
+ * @returns Nothing; renders directive output.
+ */
+const MarkdownRunner = ({ markdown }: { markdown: string }) => {
+  const handlers = useDirectiveHandlers()
+  const rendered = renderDirectiveMarkdown(markdown, handlers)
+  return <Fragment>{rendered}</Fragment>
+}
+
+beforeEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('switch directive', () => {
+  it('renders matching case', () => {
+    const md = [
+      ':::switch["red"]',
+      ':::case["red"]',
+      'Red',
+      ':::',
+      ':::case["blue"]',
+      'Blue',
+      ':::',
+      ':::default',
+      'No match',
+      ':::',
+      ':::'
+    ].join('\n')
+    render(<MarkdownRunner markdown={md} />)
+    expect(document.body.textContent?.replace(/\n/g, '')).toBe('Red')
+  })
+
+  it('renders default when no case matches', () => {
+    const md = [
+      ':::switch["green"]',
+      ':::case["red"]',
+      'Red',
+      ':::',
+      ':::case["blue"]',
+      'Blue',
+      ':::',
+      ':::default',
+      'No match',
+      ':::',
+      ':::'
+    ].join('\n')
+    render(<MarkdownRunner markdown={md} />)
+    expect(document.body.textContent?.replace(/\n/g, '')).toBe('No match')
+  })
+})

--- a/apps/campfire/src/hooks/handlers/controlFlowHandlers.ts
+++ b/apps/campfire/src/hooks/handlers/controlFlowHandlers.ts
@@ -120,6 +120,31 @@ export const createControlFlowHandlers = (ctx: ControlFlowHandlerContext) => {
     const container = directive as ContainerDirective
     const expr = extractExpressionFromDirective(container)
     const children = stripLabel(container.children as RootContent[])
+
+    // Collect sibling case/default directives until the closing marker.
+    let cursor = i + 1
+    while (cursor < p.children.length) {
+      const sibling = p.children[cursor]
+      if (isWhitespaceRootContent(sibling)) {
+        removeNode(p, cursor)
+        continue
+      }
+      if (isMarkerParagraph(sibling)) {
+        removeDirectiveMarker(p, cursor)
+        break
+      }
+      if (
+        sibling.type === 'containerDirective' &&
+        ((sibling as ContainerDirective).name === 'case' ||
+          (sibling as ContainerDirective).name === 'default')
+      ) {
+        children.push(sibling as RootContent)
+        removeNode(p, cursor)
+        continue
+      }
+      break
+    }
+
     const cases: { test: string; content: string }[] = []
     let fallbackNodes: RootContent[] | undefined
     for (const child of children) {


### PR DESCRIPTION
## Summary
- collect sibling case/default directives when handling switch blocks
- render Switch component in markdown processor
- add tests for switch directive matching and default behavior

## Testing
- `bun tsc && echo 'tsc completed'`
- `bun test >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68c6d79374fc8322bfe33528a8d04678