### PR TITLE
Fix deck step tracking and restore autoplay coverage

### DIFF
--- a/apps/campfire/src/components/Deck/Deck.tsx
+++ b/apps/campfire/src/components/Deck/Deck.tsx
@@ -156,6 +156,7 @@ export const Deck = ({
   const prev = store(state => state.prev)
   const goTo = store(state => state.goTo)
   const setSlidesCount = store(state => state.setSlidesCount)
+  const setMaxSteps = store(state => state.setMaxSteps)
   const setStepsForSlide = store(state => state.setStepsForSlide)
   const reset = store(state => state.reset)
 
@@ -190,6 +191,12 @@ export const Deck = ({
   useLayoutEffect(() => {
     slideSteps.forEach((count, index) => setStepsForSlide(index, count))
   }, [slideSteps, setStepsForSlide])
+
+  useLayoutEffect(() => {
+    const stepsForCurrent = slideSteps[currentSlide]
+    if (stepsForCurrent === undefined) return
+    setMaxSteps(stepsForCurrent)
+  }, [currentSlide, setMaxSteps, slideSteps])
 
   /**
    * Type guard to determine whether props include a transition configuration.

--- a/apps/campfire/src/components/Deck/Slide/utils.ts
+++ b/apps/campfire/src/components/Deck/Slide/utils.ts
@@ -10,11 +10,13 @@ import { SlideReveal } from './SlideReveal'
  */
 export const getRevealMax = (children: ComponentChildren): number => {
   let max = 0
+  let hasReveal = false
   const walk = (nodes: ComponentChildren): void => {
     toChildArray(nodes).forEach(node => {
       if (typeof node === 'object' && node !== null && 'type' in node) {
         const child = node as VNode<any>
         if (child.type === SlideReveal) {
+          hasReveal = true
           const at = child.props.at ?? 0
           const exitAt = child.props.exitAt ?? at
           max = Math.max(max, at, exitAt)
@@ -26,7 +28,7 @@ export const getRevealMax = (children: ComponentChildren): number => {
     })
   }
   walk(children)
-  return max
+  return hasReveal && max <= 0 ? 1 : max
 }
 
 export default getRevealMax

--- a/apps/campfire/src/components/Deck/__tests__/Deck.test.tsx
+++ b/apps/campfire/src/components/Deck/__tests__/Deck.test.tsx
@@ -513,7 +513,7 @@ describe('Deck', () => {
     expect(screen.getByText('Page 1 of 2')).toBeInTheDocument()
   })
 
-  it.skip('sets max steps once for multiple SlideReveal elements', async () => {
+  it('sets max steps once for multiple SlideReveal elements', async () => {
     const original = useDeckStore.getState().setMaxSteps
     const calls: number[] = []
     useDeckStore.setState({
@@ -541,7 +541,7 @@ describe('Deck', () => {
     useDeckStore.setState({ setMaxSteps: original })
   })
 
-  it.skip('preloads steps to prevent HUD flicker between slides', () => {
+  it('preloads steps to prevent HUD flicker between slides', () => {
     render(
       <Deck>
         <Slide>
@@ -565,7 +565,7 @@ describe('Deck', () => {
     expect(useDeckStore.getState().maxSteps).toBe(1)
   })
 
-  it.skip('keeps autoplay paused after rewinding from the end', async () => {
+  it('keeps autoplay paused after rewinding from the end', async () => {
     render(
       <Deck autoAdvanceMs={20}>
         <div>Slide 1</div>
@@ -587,7 +587,7 @@ describe('Deck', () => {
     expect(useDeckStore.getState().currentSlide).toBe(0)
   })
 
-  it.skip('stops autoplay after the final reveal of the last slide', async () => {
+  it('stops autoplay after the final reveal of the last slide', async () => {
     render(
       <Deck autoAdvanceMs={20}>
         <Slide>Slide 1</Slide>


### PR DESCRIPTION
## Summary
- ensure the deck store updates max steps for the active slide only once per transition
- treat slides with reveals as having at least one step and remove test skips covering autoplay edge cases

## Testing
- bun tsc
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68ca198998608322a6247e828382ea0e