### PR TITLE
refactor: centralize preset attribute merging

### DIFF
--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -1259,30 +1259,31 @@ export const useDirectiveHandlers = () => {
     'from'
   ] as const
 
-  const resolvePresetAttributes = <
-    Namespace extends string,
+  type PresetAttributes<
     Raw extends Record<string, unknown>,
-    Attrs extends Record<string, unknown>,
-    AttrResult extends Record<string, unknown> = Attrs,
-    Preset extends Partial<Raw> & Partial<AttrResult> = Partial<Raw> &
-      Partial<AttrResult>
+    Attrs extends Record<string, unknown>
+  > = Partial<Raw> & Partial<Attrs>
+
+  const resolvePresetAttributes = <
+    Raw extends Record<string, unknown>,
+    Attrs extends Record<string, unknown>
   >(
-    namespace: Namespace,
+    namespace: string,
     raw: Raw,
     attrs: Attrs,
     from?: string | number
   ) => {
-    const presetKey = from ? String(from) : undefined
-    const preset = presetKey
-      ? (presetsRef.current[namespace]?.[presetKey] as Preset | undefined)
+    const presetKey = from != null ? String(from) : undefined
+    const namespacePresets = presetKey
+      ? presetsRef.current[namespace]
       : undefined
-    const mergedRaw = mergeAttrs<Raw>(preset as Partial<Raw> | undefined, raw)
-    const mergedAttrs = mergeAttrs<AttrResult>(
-      preset as Partial<AttrResult> | undefined,
-      attrs as AttrResult
-    )
-    const normRaw = interpolateAttrs<Raw>(mergedRaw, gameData)
-    const normAttrs = interpolateAttrs<AttrResult>(mergedAttrs, gameData)
+    const presetRecord =
+      presetKey && namespacePresets ? namespacePresets[presetKey] : undefined
+    const preset = presetRecord as PresetAttributes<Raw, Attrs> | undefined
+    const mergedRaw = mergeAttrs(preset, raw)
+    const mergedAttrs = mergeAttrs(preset, attrs)
+    const normRaw = interpolateAttrs(mergedRaw, gameData)
+    const normAttrs = interpolateAttrs(mergedAttrs, gameData)
     return { preset, mergedRaw, mergedAttrs, normRaw, normAttrs }
   }
 


### PR DESCRIPTION
## Summary
- add a reusable helper to merge and normalize preset attributes for directive handlers
- update text, embed, image, and shape handlers to use the shared helper

## Testing
- bun tsc
- bun test
- bunx prettier . --write

------
https://chatgpt.com/codex/tasks/task_e_68d010674c408322b9e159492c3d916d