### PR TITLE
feat: add allow landscape orientation directive

### DIFF
--- a/apps/campfire/src/components/Campfire/index.tsx
+++ b/apps/campfire/src/components/Campfire/index.tsx
@@ -12,6 +12,7 @@ import { EXIT, visit } from 'unist-util-visit'
 import { applyUserStyles } from '@campfire/components/Campfire/applyUserStyles'
 import { evaluateUserScript } from '@campfire/components/Campfire/evaluateUserScript'
 import { useOverlayProcessor } from '@campfire/hooks/useOverlayProcessor'
+import { useOrientationController } from '@campfire/hooks/useOrientationController'
 
 /**
  * React component that renders the main story interface.
@@ -36,6 +37,7 @@ export const Campfire = ({
   const setStoryData = useStoryDataStore.use.setStoryData()
 
   useOverlayProcessor()
+  useOrientationController()
 
   /**
    * Extracts the <tw-storydata> element from the given HAST tree and updates the story data store with its properties.

--- a/apps/campfire/src/hooks/__tests__/orientationController.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/orientationController.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test'
+import { render, act } from '@testing-library/preact'
+import type { LeafDirective } from 'mdast-util-directive'
+import type { Parent } from 'mdast'
+import { useOrientationController } from '@campfire/hooks/useOrientationController'
+import {
+  setAllowLandscape,
+  toggleAllowLandscape
+} from '@campfire/state/orientationState'
+import { createNavigationHandlers } from '@campfire/hooks/handlers/navigationHandlers'
+import type { DirectiveHandler } from '@campfire/remark-campfire'
+
+interface TestScreenOrientation extends ScreenOrientation {
+  lock: (orientation: OrientationLockType) => Promise<void>
+  unlock: () => void
+}
+
+const noop = () => {}
+
+/**
+ * Mounts a component that initializes the orientation controller hook.
+ */
+const renderController = () => {
+  /**
+   * Minimal component that activates the orientation controller.
+   */
+  const TestComponent = () => {
+    useOrientationController()
+    return null
+  }
+  return render(<TestComponent />)
+}
+
+describe('useOrientationController', () => {
+  let originalScreen: Screen | undefined
+  let orientation: TestScreenOrientation
+
+  beforeEach(() => {
+    originalScreen = globalThis.screen
+    orientation = {
+      angle: 0,
+      type: 'portrait-primary',
+      lock: () => Promise.resolve(),
+      unlock: noop,
+      onchange: null,
+      addEventListener:
+        noop as unknown as ScreenOrientation['addEventListener'],
+      removeEventListener:
+        noop as unknown as ScreenOrientation['removeEventListener'],
+      dispatchEvent: () => true
+    } as TestScreenOrientation
+    const screenMock = { orientation } as unknown as Screen
+    Object.defineProperty(globalThis, 'screen', {
+      configurable: true,
+      value: screenMock
+    })
+    setAllowLandscape(false)
+  })
+
+  afterEach(() => {
+    if (originalScreen) {
+      Object.defineProperty(globalThis, 'screen', {
+        configurable: true,
+        value: originalScreen
+      })
+    } else {
+      delete (globalThis as { screen?: Screen }).screen
+    }
+  })
+
+  it('locks orientation to portrait on mount by default', () => {
+    const lockSpy = spyOn(orientation, 'lock').mockResolvedValue()
+    const unlockSpy = spyOn(orientation, 'unlock').mockImplementation(noop)
+
+    const { unmount } = renderController()
+
+    expect(lockSpy).toHaveBeenCalledWith('portrait')
+    expect(unlockSpy).not.toHaveBeenCalled()
+
+    unmount()
+  })
+
+  it('unlocks orientation when ::allowLandscape directive runs', () => {
+    const lockSpy = spyOn(orientation, 'lock').mockResolvedValue()
+    const unlockSpy = spyOn(orientation, 'unlock').mockImplementation(noop)
+
+    const handlersRef = { current: {} as Record<string, DirectiveHandler> }
+    const navigationHandlers = createNavigationHandlers({
+      addError: noop,
+      setCurrentPassage: noop,
+      getPassageById: () => undefined,
+      getPassageByName: () => undefined,
+      getGameData: () => ({}),
+      handlersRef,
+      getIncludeDepth: () => 0,
+      incrementIncludeDepth: noop,
+      decrementIncludeDepth: noop,
+      toggleAllowLandscape
+    })
+
+    const directive: LeafDirective = {
+      type: 'leafDirective',
+      name: 'allowLandscape',
+      attributes: {},
+      children: []
+    }
+    const parent: Parent = {
+      type: 'root',
+      children: [directive]
+    }
+
+    const { unmount } = renderController()
+
+    lockSpy.mockClear()
+
+    act(() => {
+      navigationHandlers.allowLandscape(directive, parent, 0)
+    })
+
+    expect(unlockSpy).toHaveBeenCalled()
+    expect(lockSpy).not.toHaveBeenCalled()
+
+    unmount()
+  })
+})

--- a/apps/campfire/src/hooks/handlers/navigationHandlers.ts
+++ b/apps/campfire/src/hooks/handlers/navigationHandlers.ts
@@ -50,6 +50,8 @@ export interface NavigationHandlerContext {
   incrementIncludeDepth: () => void
   /** Decrements the include depth. */
   decrementIncludeDepth: () => void
+  /** Toggles whether landscape orientation is allowed. */
+  toggleAllowLandscape: () => void
 }
 
 /**
@@ -68,7 +70,8 @@ export const createNavigationHandlers = (ctx: NavigationHandlerContext) => {
     handlersRef,
     getIncludeDepth,
     incrementIncludeDepth,
-    decrementIncludeDepth
+    decrementIncludeDepth,
+    toggleAllowLandscape
   } = ctx
 
   /**
@@ -258,5 +261,25 @@ export const createNavigationHandlers = (ctx: NavigationHandlerContext) => {
     ]
   }
 
-  return { goto: handleGoto, title: handleTitle, include: handleInclude }
+  /**
+   * Handles the `::allowLandscape` directive, toggling whether landscape orientation is permitted.
+   *
+   * @param directive - The directive node representing the allowLandscape directive.
+   * @param parent - The parent AST node containing this directive.
+   * @param index - The index of the directive node within its parent.
+   * @returns The new index after replacement.
+   */
+  const handleAllowLandscape: DirectiveHandler = (directive, parent, index) => {
+    const invalid = requireLeafDirective(directive, parent, index, addError)
+    if (invalid !== undefined) return invalid
+    toggleAllowLandscape()
+    return removeNode(parent, index)
+  }
+
+  return {
+    goto: handleGoto,
+    title: handleTitle,
+    include: handleInclude,
+    allowLandscape: handleAllowLandscape
+  }
 }

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -50,6 +50,7 @@ import { createMediaHandlers } from './handlers/mediaHandlers'
 import { createPersistenceHandlers } from './handlers/persistenceHandlers'
 import { createI18nHandlers } from './handlers/i18nHandlers'
 import { isWhitespaceRootContent } from '@campfire/utils/nodePredicates'
+import { toggleAllowLandscape } from '@campfire/state/orientationState'
 
 const NUMERIC_PATTERN = /^\d+$/
 const ALLOWED_ONEXIT_DIRECTIVES = new Set([
@@ -1060,7 +1061,8 @@ export const useDirectiveHandlers = () => {
     },
     decrementIncludeDepth: () => {
       includeDepth--
-    }
+    },
+    toggleAllowLandscape
   })
 
   const mediaHandlers = createMediaHandlers({ addError })

--- a/apps/campfire/src/hooks/useOrientationController.ts
+++ b/apps/campfire/src/hooks/useOrientationController.ts
@@ -1,0 +1,114 @@
+import { useEffect } from 'preact/hooks'
+import {
+  isLandscapeAllowed,
+  subscribeAllowLandscape,
+  setAllowLandscape
+} from '@campfire/state/orientationState'
+
+interface LegacyScreen extends Screen {
+  lockOrientation?: (orientation: OrientationLockType) => unknown
+  unlockOrientation?: () => unknown
+}
+
+interface OrientationControl {
+  lock?: (orientation: OrientationLockType) => void
+  unlock?: () => void
+}
+
+/**
+ * Safely invokes a function and swallows promise rejections.
+ *
+ * @param fn - Function to execute.
+ * @param args - Arguments to pass to the function.
+ */
+const safeInvoke = <T extends unknown[]>(
+  fn: ((...args: T) => unknown) | undefined,
+  ...args: T
+) => {
+  if (typeof fn !== 'function') return
+  try {
+    const result = fn(...args)
+    if (
+      result &&
+      typeof (result as PromiseLike<unknown>).then === 'function' &&
+      typeof (result as PromiseLike<unknown>).catch === 'function'
+    ) {
+      ;(result as PromiseLike<unknown>).catch(() => {})
+    }
+  } catch {
+    // ignore failures to avoid breaking unsupported browsers
+  }
+}
+
+/**
+ * Retrieves orientation lock/unlock helpers with graceful fallbacks.
+ *
+ * @returns Orientation control helpers when supported.
+ */
+const createOrientationControl = (): OrientationControl => {
+  const screenObject = globalThis.screen as LegacyScreen | undefined
+  if (!screenObject) return {}
+  const orientation = screenObject.orientation
+  const lockCandidate =
+    orientation && typeof orientation.lock === 'function'
+      ? orientation.lock.bind(orientation)
+      : typeof screenObject.lockOrientation === 'function'
+        ? screenObject.lockOrientation.bind(screenObject)
+        : undefined
+  const unlockCandidate =
+    orientation && typeof orientation.unlock === 'function'
+      ? orientation.unlock.bind(orientation)
+      : typeof screenObject.unlockOrientation === 'function'
+        ? screenObject.unlockOrientation.bind(screenObject)
+        : undefined
+  return {
+    lock:
+      lockCandidate &&
+      ((value: OrientationLockType) => {
+        safeInvoke(
+          lockCandidate as (value: OrientationLockType) => unknown,
+          value
+        )
+      }),
+    unlock:
+      unlockCandidate &&
+      (() => {
+        safeInvoke(unlockCandidate as () => unknown)
+      })
+  }
+}
+
+/**
+ * Controls screen orientation by locking to portrait on mount and toggling to
+ * landscape when the corresponding directive flag is set.
+ */
+export const useOrientationController = () => {
+  useEffect(() => {
+    const control = createOrientationControl()
+    const applyOrientation = (allow: boolean) => {
+      if (allow) {
+        if (control.unlock) {
+          control.unlock()
+        } else {
+          control.lock?.('landscape')
+        }
+      } else {
+        control.lock?.('portrait')
+      }
+    }
+
+    // Default to portrait lock on mount.
+    applyOrientation(false)
+
+    if (isLandscapeAllowed()) {
+      applyOrientation(true)
+    }
+
+    const unsubscribe = subscribeAllowLandscape(applyOrientation)
+    return () => {
+      unsubscribe()
+      control.unlock?.()
+      setAllowLandscape(false)
+    }
+  }, [])
+}

--- a/apps/campfire/src/state/orientationState.ts
+++ b/apps/campfire/src/state/orientationState.ts
@@ -1,0 +1,58 @@
+/**
+ * Listener invoked when the landscape allowance flag changes.
+ */
+type OrientationListener = (allowLandscape: boolean) => void
+
+/** Current state indicating whether landscape orientation is allowed. */
+let allowLandscape = false
+
+/** Registered orientation listeners notified on state changes. */
+const listeners = new Set<OrientationListener>()
+
+/**
+ * Notifies all registered listeners of the current landscape allowance state.
+ */
+const notifyListeners = () => {
+  for (const listener of listeners) {
+    listener(allowLandscape)
+  }
+}
+
+/**
+ * Indicates whether landscape orientation is currently allowed.
+ *
+ * @returns True when landscape orientation is permitted.
+ */
+export const isLandscapeAllowed = () => allowLandscape
+
+/**
+ * Sets the landscape allowance flag to a specific value.
+ *
+ * @param value - Desired landscape allowance state.
+ */
+export const setAllowLandscape = (value: boolean) => {
+  if (allowLandscape === value) return
+  allowLandscape = value
+  notifyListeners()
+}
+
+/**
+ * Toggles the stored landscape allowance flag and notifies listeners.
+ */
+export const toggleAllowLandscape = () => {
+  allowLandscape = !allowLandscape
+  notifyListeners()
+}
+
+/**
+ * Subscribes to landscape allowance changes.
+ *
+ * @param listener - Callback invoked with the updated allowance state.
+ * @returns Cleanup function removing the listener.
+ */
+export const subscribeAllowLandscape = (listener: OrientationListener) => {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}

--- a/docs/directives/navigation-composition.md
+++ b/docs/directives/navigation-composition.md
@@ -56,6 +56,24 @@ separated by a colon. Customize this behavior by adding attributes to the
 | ----- | ----------------------------------- |
 | text  | Title text displayed in the browser |
 
+### `allowLandscape`
+
+Toggle the mobile orientation lock. Use as a leaf directive with no value.
+
+```md
+::allowLandscape
+```
+
+Campfire locks the viewport to portrait mode when the story loads. Running
+`::allowLandscape` flips an internal flag, causing the orientation controller to
+unlock the screen (or lock to landscape when unlock support is unavailable).
+Run the directive again later to restore the portrait lock.
+
+Orientation locking requires browsers that implement the Screen Orientation
+API. On unsupported platforms or when the API rejects the request (for example
+outside a user gesture on some mobile browsers), the directive safely degrades
+with no visible effect.
+
 ### `deck`
 
 Present content as a series of slides.


### PR DESCRIPTION
## Summary
- add a shared orientation state and controller hook that locks portrait by default and releases when landscape is allowed
- register an `::allowLandscape` navigation handler and wire the directive through the runtime
- document the new directive and cover the orientation flow with unit tests

## Testing
- bun tsc
- bun test
- bunx prettier . --write

------
https://chatgpt.com/codex/tasks/task_e_68d0832518388322841ac6f26c7fe55a