### PR TITLE
fix: handle for loops skipping falsy items

### DIFF
--- a/apps/campfire/src/hooks/__tests__/forDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/forDirective.test.tsx
@@ -83,7 +83,7 @@ describe('for directive', () => {
       '',
       ':::if[fruit !== "banana"]',
       '',
-      '- :show[fruit]{className="text-rose-600"}',
+      '- :show[fruit]{className="text-red-600"}',
       '',
       ':::',
       '',

--- a/apps/campfire/src/hooks/__tests__/forDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/forDirective.test.tsx
@@ -75,4 +75,25 @@ describe('for directive', () => {
     render(<MarkdownRunner markdown={md} />)
     expect(document.body.textContent?.replace(/\n/g, '')).toBe('applecherry')
   })
+
+  it('skips list items when loop conditions fail', () => {
+    const md = [
+      '::array[fruits=["apple","banana","cherry"]]',
+      ':::for[fruit in fruits]',
+      '',
+      ':::if[fruit !== "banana"]',
+      '',
+      '- :show[fruit]{className="text-rose-600"}',
+      '',
+      ':::',
+      '',
+      ':::'
+    ].join('\n')
+    render(<MarkdownRunner markdown={md} />)
+    const items = Array.from(document.querySelectorAll('li'))
+    expect(document.querySelectorAll('ul')).toHaveLength(1)
+    expect(items).toHaveLength(2)
+    expect(items[0].textContent).toBe('apple')
+    expect(items[1].textContent).toBe('cherry')
+  })
 })

--- a/apps/storybook/src/ForDirective.stories.tsx
+++ b/apps/storybook/src/ForDirective.stories.tsx
@@ -22,7 +22,7 @@ export const Numbers: StoryObj = {
           {`
 :::for[x in [1,2,3]]
 
-Value :show[x]{className="text-sky-600"}
+Value :show[x]{as="span" className="text-sky-600"}
 
 :::
           `}
@@ -52,7 +52,7 @@ export const Fruits: StoryObj = {
 
   :::if[fruit !== "banana"]
 
-  - :show[fruit]{className="text-rose-600"}
+  - :show[fruit]{as="span" className="text-red-600"}
 
   :::
 


### PR DESCRIPTION
## Summary
- ensure the for directive only emits iterations with renderable content and merge adjacent lists
- precompute literal values for show directives inside loops so filtered iterations no longer leave empty list items
- add a regression test covering a list filtered by an if directive within a for loop

## Testing
- bun tsc
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68d08e9ad37c83228397bc957f1422d3