### PR TITLE
fix(layer): retain conditionals after layer directives

### DIFF
--- a/apps/campfire/src/hooks/__tests__/disabledDirectives.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/disabledDirectives.test.tsx
@@ -118,4 +118,39 @@ describe('disabled state directives', () => {
     expect(checkbox.disabled).toBe(true)
     expect(textarea.disabled).toBe(true)
   })
+
+  it('renders form controls defined with leaf directives', () => {
+    const md =
+      '::input[playerName]{placeholder="Hero"}\n' +
+      '::radio[playerClass]{value="Mage"}\n'
+    render(<MarkdownRunner markdown={md} />)
+    const input = document.querySelector(
+      '[data-testid="input"]'
+    ) as HTMLInputElement
+    const radio = document.querySelector(
+      '[data-testid="radio"]'
+    ) as HTMLButtonElement
+    expect(input).toBeTruthy()
+    expect(input.placeholder).toBe('Hero')
+    expect(radio).toBeTruthy()
+    expect(radio.getAttribute('data-state')).toBe('unchecked')
+  })
+
+  it('enables triggers once dependent radio selections are made', async () => {
+    const md =
+      '::radio[playerClass]{value="Warrior"}\n' +
+      '::radio[playerClass]{value="Mage"}\n' +
+      ':::trigger{label="Begin" disabled="!(playerClass && playerClass.trim())"}\n' +
+      '  ::goto["Next"]\n' +
+      ':::\n'
+    render(<MarkdownRunner markdown={md} />)
+    const trigger = document.querySelector(
+      '[data-testid="trigger-button"]'
+    ) as HTMLButtonElement
+    expect(trigger.disabled).toBe(true)
+    await act(() =>
+      useGameStore.getState().setGameData({ playerClass: 'Warrior' })
+    )
+    expect(trigger.disabled).toBe(false)
+  })
 })

--- a/apps/campfire/src/hooks/__tests__/ifDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/ifDirective.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach } from 'bun:test'
+import { render } from '@testing-library/preact'
+import { Fragment } from 'preact/jsx-runtime'
+import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
+import { renderDirectiveMarkdown } from '@campfire/components/Deck/Slide'
+
+/**
+ * Component used in tests to render markdown with directive handlers.
+ *
+ * @param markdown - Markdown string that may include directive containers.
+ * @returns Nothing; renders directive output.
+ */
+const MarkdownRunner = ({ markdown }: { markdown: string }) => {
+  const handlers = useDirectiveHandlers()
+  const rendered = renderDirectiveMarkdown(markdown, handlers)
+  return <Fragment>{rendered}</Fragment>
+}
+
+beforeEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('if directive', () => {
+  it('removes trailing directive markers after processing', () => {
+    const md = [
+      'Hello adventurer! Enter your name:',
+      '::input[playerName]{placeholder="Your name"}',
+      '',
+      ':::if[true]',
+      '  Ready to continue?',
+      ':::'
+    ].join('\n')
+
+    render(<MarkdownRunner markdown={md} />)
+
+    expect(document.querySelector('input')).toBeTruthy()
+    expect(document.body.innerHTML).not.toContain(':::')
+  })
+
+  it('strips marker paragraphs when conditionals follow leaf directives', () => {
+    const md = [
+      'Hello adventurer! Enter your name:',
+      '::input[playerName]{placeholder="Your name"}',
+      '',
+      ':::if[(playerName && playerName.trim())]',
+      '  :::trigger{label="Continue"}',
+      '    ::goto["ChooseClass"]',
+      '  :::',
+      ':::'
+    ].join('\n')
+
+    render(<MarkdownRunner markdown={md} />)
+
+    expect(document.body.innerHTML).not.toContain(':::')
+  })
+})

--- a/apps/campfire/src/hooks/__tests__/layerDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/layerDirective.test.tsx
@@ -3,6 +3,8 @@ import { render } from '@testing-library/preact'
 import type { ComponentChild } from 'preact'
 import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
 import { renderDirectiveMarkdown } from '@campfire/components/Deck/Slide'
+import { useGameStore } from '@campfire/state/useGameStore'
+import { resetStores } from '@campfire/test-utils/helpers'
 
 let output: ComponentChild | null = null
 
@@ -21,6 +23,7 @@ const MarkdownRunner = ({ markdown }: { markdown: string }) => {
 beforeEach(() => {
   output = null
   document.body.innerHTML = ''
+  resetStores()
 })
 
 describe('layer directive', () => {
@@ -116,5 +119,51 @@ describe('layer directive', () => {
         '[data-testid="layer"] + [data-testid="wrapper"]'
       ) === null
     ).toBe(true)
+  })
+
+  it('supports leaf radio directives inside wrappers', () => {
+    const md =
+      '::preset{type="wrapper" name="choice" as="label" className="flex items-center gap-2"}\n' +
+      ':::layer{className="space-y-3"}\n' +
+      '  :::wrapper{from="choice"}\n' +
+      '    ::radio[playerClass]{value="Warrior"}\n' +
+      '    Warrior\n' +
+      '  :::\n' +
+      '  :::wrapper{from="choice"}\n' +
+      '    ::radio[playerClass]{value="Mage"}\n' +
+      '    Mage\n' +
+      '  :::\n' +
+      ':::\n'
+    render(<MarkdownRunner markdown={md} />)
+    const layerEl = document.querySelector(
+      '[data-testid="layer"]'
+    ) as HTMLElement
+    const radios = layerEl.querySelectorAll('[data-testid="radio"]')
+    expect(radios.length).toBe(2)
+    expect(layerEl.innerHTML).not.toContain(':::')
+  })
+
+  it('preserves conditional siblings after layer directives', () => {
+    useGameStore.setState({ gameData: { playerClass: 'Mage' } })
+    const md = [
+      ':::layer{className="space-y-2"}',
+      '  :::wrapper{as="div"}',
+      '    ::radio[playerClass]{value="Mage"}',
+      '    Mage',
+      '  :::',
+      ':::',
+      '',
+      ':::if[(playerClass && playerClass.trim())]',
+      '  :::trigger{label="Begin"}',
+      '    ::goto["Next"]',
+      '  :::',
+      ':::'
+    ].join('\n')
+    render(<MarkdownRunner markdown={md} />)
+    const trigger = document.querySelector(
+      '[data-testid="trigger-button"]'
+    ) as HTMLButtonElement
+    expect(trigger).toBeTruthy()
+    expect(trigger.disabled).toBe(false)
   })
 })

--- a/apps/campfire/src/hooks/__tests__/textDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/textDirective.test.tsx
@@ -126,4 +126,20 @@ Hi
     expect(style).toContain('font-size: 32px')
     expect(style).toContain('color: red')
   })
+
+  it('applies text presets defined with leaf directives', () => {
+    const md =
+      '::preset{type="text" name="headline" x=12 y=24 size=28 color="blue"}\n' +
+      ':::text{from="headline" size=36}\nHello\n:::'
+    render(<MarkdownRunner markdown={md} />)
+    const el = document.querySelector(
+      '[data-testid="slideText"]'
+    ) as HTMLElement
+    const inner = el.firstElementChild as HTMLElement
+    const style = inner.getAttribute('style') || ''
+    expect(style).toContain('left: 12px')
+    expect(style).toContain('top: 24px')
+    expect(style).toContain('font-size: 36px')
+    expect(style).toContain('color: blue')
+  })
 })

--- a/apps/campfire/src/hooks/handlers/controlFlowHandlers.ts
+++ b/apps/campfire/src/hooks/handlers/controlFlowHandlers.ts
@@ -18,6 +18,7 @@ import {
 import {
   removeDirectiveMarker,
   isMarkerParagraph,
+  isMarkerText,
   ensureParentIndex
 } from '@campfire/utils/directiveHandlerUtils'
 import { evalExpression } from '@campfire/utils/core'
@@ -124,14 +125,14 @@ export const createControlFlowHandlers = (ctx: ControlFlowHandlerContext) => {
     // Collect sibling case/default directives until the closing marker.
     let cursor = i + 1
     while (cursor < p.children.length) {
-      const sibling = p.children[cursor]
+      const sibling = p.children[cursor] as RootContent
+      if (isMarkerParagraph(sibling) || isMarkerText(sibling)) {
+        removeDirectiveMarker(p, cursor)
+        break
+      }
       if (isWhitespaceRootContent(sibling)) {
         removeNode(p, cursor)
         continue
-      }
-      if (isMarkerParagraph(sibling)) {
-        removeDirectiveMarker(p, cursor)
-        break
       }
       if (
         sibling.type === 'containerDirective' &&
@@ -189,13 +190,14 @@ export const createControlFlowHandlers = (ctx: ControlFlowHandlerContext) => {
     ])
     let markerIndex = newIndex + 1
     while (markerIndex < p.children.length) {
-      const sibling = p.children[markerIndex]
+      const sibling = p.children[markerIndex] as RootContent
+      if (isMarkerParagraph(sibling) || isMarkerText(sibling)) {
+        removeDirectiveMarker(p, markerIndex)
+        break
+      }
       if (isWhitespaceRootContent(sibling)) {
         markerIndex++
         continue
-      }
-      if (isMarkerParagraph(sibling)) {
-        removeDirectiveMarker(p, markerIndex)
       }
       break
     }
@@ -298,13 +300,14 @@ export const createControlFlowHandlers = (ctx: ControlFlowHandlerContext) => {
     // Remove closing directive markers after the if block, skipping whitespace-only nodes
     let markerIndex = newIndex + 1
     while (markerIndex < p.children.length) {
-      const sibling = p.children[markerIndex]
+      const sibling = p.children[markerIndex] as RootContent
+      if (isMarkerParagraph(sibling) || isMarkerText(sibling)) {
+        removeDirectiveMarker(p, markerIndex)
+        break
+      }
       if (isWhitespaceRootContent(sibling)) {
         markerIndex++
         continue
-      }
-      if (isMarkerParagraph(sibling)) {
-        removeDirectiveMarker(p, markerIndex)
       }
       break
     }

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -943,9 +943,12 @@ export const useDirectiveHandlers = () => {
                 (child as MdText).value.includes(DIRECTIVE_MARKER)
             )
             if (idxText !== -1) last.children.splice(idxText, 1)
+            const hasDirectiveOutput =
+              typeof (last as Parent).data?.hName === 'string'
             if (
-              last.children.length === 0 ||
-              last.children.every(isWhitespaceNode)
+              !hasDirectiveOutput &&
+              (last.children.length === 0 ||
+                last.children.every(isWhitespaceNode))
             )
               processed.pop()
           }

--- a/apps/campfire/src/hooks/useDirectiveHandlers.ts
+++ b/apps/campfire/src/hooks/useDirectiveHandlers.ts
@@ -179,6 +179,7 @@ export const useDirectiveHandlers = () => {
     refreshState,
     addError
   })
+  const stateDirectiveNames = new Set(Object.keys(stateDirectiveHandlers))
 
   /**
    * Inserts a Show component that displays the value for a key or the result
@@ -300,7 +301,8 @@ export const useDirectiveHandlers = () => {
     },
     isTextNode,
     allowedBatchDirectives: ALLOWED_BATCH_DIRECTIVES,
-    bannedBatchDirectives: BANNED_BATCH_DIRECTIVES
+    bannedBatchDirectives: BANNED_BATCH_DIRECTIVES,
+    stateDirectiveNames
   })
 
   /**

--- a/apps/campfire/src/utils/directiveHandlerUtils.ts
+++ b/apps/campfire/src/utils/directiveHandlerUtils.ts
@@ -121,6 +121,20 @@ export const isMarkerParagraph = (node: RootContent): boolean => {
 }
 
 /**
+ * Determines if a node is a text node containing only directive markers.
+ *
+ * @param node - Node to inspect.
+ * @returns True if the text consists solely of directive markers.
+ */
+export const isMarkerText = (node: RootContent): boolean => {
+  if (node.type !== 'text') return false
+  const stripped = (node as MdText).value.replace(/\s+/g, '')
+  if (!stripped) return false
+  const parts = stripped.split(DIRECTIVE_MARKER)
+  return parts.every(part => part === '')
+}
+
+/**
  * Parses a deck size string such as "1920x1080" or an aspect ratio like "16x9".
  * Aspect ratios assume a default width of {@link DEFAULT_DECK_WIDTH} pixels.
  *

--- a/apps/storybook/src/DebugWindow.tsx
+++ b/apps/storybook/src/DebugWindow.tsx
@@ -107,6 +107,10 @@ export const DebugWindow = () => {
   const [minimized, setMinimized] = useState(false)
   const [tab, setTab] = useState<Tab>(TAB_GAME)
   const containerRef = useRef<HTMLDivElement>(null)
+  const serializedGameData = useMemo(
+    () => JSON.stringify(gameData ?? {}, null, 2),
+    [gameData]
+  )
 
   const debugEnabled = storyData?.options === DEBUG_OPTION
 
@@ -126,6 +130,15 @@ export const DebugWindow = () => {
    */
   const handleCopyJsx = (): void => {
     void navigator.clipboard?.writeText(jsxPassage)
+  }
+
+  /**
+   * Copies the serialized game state to the clipboard.
+   *
+   * @returns {void}
+   */
+  const handleCopyGameData = (): void => {
+    void navigator.clipboard?.writeText(serializedGameData)
   }
 
   useEffect(() => {
@@ -238,9 +251,19 @@ export const DebugWindow = () => {
           </div>
           <div className='p-2'>
             {tab === TAB_GAME ? (
-              <pre className='whitespace-pre-wrap'>
-                {JSON.stringify(gameData, null, 2)}
-              </pre>
+              <div>
+                <button
+                  type='button'
+                  data-testid='copy-game'
+                  onClick={e => {
+                    e.stopPropagation()
+                    handleCopyGameData()
+                  }}
+                >
+                  Copy Game Data
+                </button>
+                <pre className='whitespace-pre-wrap'>{serializedGameData}</pre>
+              </div>
             ) : tab === TAB_STORY ? (
               <div>
                 <pre className='whitespace-pre-wrap'>

--- a/apps/storybook/src/examples/AdventureGame.stories.tsx
+++ b/apps/storybook/src/examples/AdventureGame.stories.tsx
@@ -82,7 +82,10 @@ Two paths beckon:
         </tw-passagedata>
         <tw-passagedata pid='4' name='Forest'>
           {`
-::setRange[hp=(hp.value-2)]
+:::if[(!forestDamageApplied)]
+  ::set[forestDamageApplied=true]
+  ::setRange[hp=(hp.value-2)]
+:::
 
 A snarling wolf lunges from the underbrush!
 
@@ -107,29 +110,46 @@ Current HP: :show[hp.value]{className="font-bold"}
     ::goto["Dead"]
   :::
 :::
+
+:::onExit
+  ::unset[forestDamageApplied]
+:::
 `}
         </tw-passagedata>
         <tw-passagedata pid='5' name='Herbs'>
           {`
-::push{key=inventory value="Herbs"}
+:::if[(!herbsCollected)]
+  ::set[herbsCollected=true]
+  ::push{key=inventory value="Herbs"}
+:::
 
 You gather fragrant herbs and bandage your wounds before returning.
 
 :::trigger{label="Back to the crossroads"}
   ::goto["Adventure"]
 :::
+
+:::onExit
+  ::unset[herbsCollected]
+:::
 `}
         </tw-passagedata>
         <tw-passagedata pid='6' name='Cave'>
           {`
-::setRange[hp=(hp.value-3)]
+:::if[(!caveTrapTriggered)]
+  ::set[caveTrapTriggered=true]
+  ::setRange[hp=(hp.value-3)]
+:::
 
 A hidden trap releases a volley of darts as you step inside the cave!
 
 Current HP: :show[hp.value]{className="font-bold"}
 
 :::if[(hp.value>0)]
-  ::push{key=inventory value="Gold"}
+  :::if[(!caveLootGranted)]
+    ::set[caveLootGranted=true]
+    ::push{key=inventory value="Gold"}
+  :::
   The trap spent, a cache of glittering coins remains.
 
   Your pack now holds:
@@ -148,6 +168,11 @@ Current HP: :show[hp.value]{className="font-bold"}
   :::trigger{label="Fall to your fate"}
     ::goto["Dead"]
   :::
+:::
+
+:::onExit
+  ::unset[caveTrapTriggered]
+  ::unset[caveLootGranted]
 :::
 `}
         </tw-passagedata>

--- a/apps/storybook/src/examples/AdventureGame.stories.tsx
+++ b/apps/storybook/src/examples/AdventureGame.stories.tsx
@@ -178,10 +178,24 @@ Current HP: :show[hp.value]{className="font-bold"}
         </tw-passagedata>
         <tw-passagedata pid='7' name='Dead'>
           {`
-Your vision fades as the world slips away.
+:::layer{className="space-y-3"}
+  Your vision fades as the world slips away.
 
-:::trigger{label="Begin anew"}
-  ::goto["Start"]
+  :::trigger{label="Begin anew"}
+    ::goto["Start"]
+  :::
+
+  :::onExit
+    ::unset[playerName]
+    ::unset[playerClass]
+    ::unset[hp]
+    ::unset[hpInitialized]
+    ::unset[inventory]
+    ::unset[forestDamageApplied]
+    ::unset[herbsCollected]
+    ::unset[caveTrapTriggered]
+    ::unset[caveLootGranted]
+  :::
 :::
 `}
         </tw-passagedata>

--- a/apps/storybook/src/examples/AdventureGame.stories.tsx
+++ b/apps/storybook/src/examples/AdventureGame.stories.tsx
@@ -1,0 +1,168 @@
+import type { Meta, StoryObj } from '@storybook/preact'
+import { Campfire } from '@campfire/components'
+import { DebugWindow } from '../DebugWindow'
+
+const meta: Meta = {
+  title: 'Campfire/Examples/AdventureGame'
+}
+
+export default meta
+
+/**
+ * Interactive adventure game showcasing multiple Campfire directives working
+ * together within a branching narrative.
+ *
+ * @returns Story configuration for the adventure game example.
+ */
+export const AdventureGame: StoryObj = {
+  render: () => (
+    <>
+      <tw-storydata startnode='1' options='debug'>
+        <tw-passagedata pid='1' name='Start'>
+          {`
+Hello adventurer! Enter your name:
+::input[playerName]{placeholder="Your name"}
+
+:::if[(playerName && playerName.trim())]
+  :::trigger{label="Continue"}
+    ::goto["ChooseClass"]
+  :::
+:::
+`}
+        </tw-passagedata>
+        <tw-passagedata pid='2' name='ChooseClass'>
+          {`
+::preset{type="wrapper" name="classChoice" as="label" className="flex items-center gap-2"}
+
+Greetings, :show[playerName]{className="font-semibold"}! Choose your class:
+
+:::layer{className="flex flex-col gap-3 mt-4"}
+  :::wrapper{from="classChoice"}
+    ::radio[playerClass]{value="Warrior"}
+    Warrior
+  :::
+  :::wrapper{from="classChoice"}
+    ::radio[playerClass]{value="Mage"}
+    Mage
+  :::
+:::
+
+:::if[(playerClass && playerClass.trim())]
+  You have chosen the path of the :show[playerClass]{className="font-semibold"}.
+
+  :::trigger{label="Begin your adventure"}
+    ::goto["Adventure"]
+  :::
+:::
+`}
+        </tw-passagedata>
+        <tw-passagedata pid='3' name='Adventure'>
+          {`
+:::if[(!hpInitialized)]
+  ::setOnce[hpInitialized=true]
+  ::createRange[hp=10]{min=0 max=10}
+:::
+
+::arrayOnce[inventory=[]]
+
+:show[playerName]{className="font-semibold"}, the :show[playerClass]{className="font-semibold"}, stands at an ancient crossroads.
+
+Current HP: :show[hp.value]{className="font-bold"} / :show[hp.max]
+
+Two paths beckon:
+
+:::trigger{label="Enter the forest"}
+  ::goto["Forest"]
+:::
+
+:::trigger{label="Explore the cave"}
+  ::goto["Cave"]
+:::
+`}
+        </tw-passagedata>
+        <tw-passagedata pid='4' name='Forest'>
+          {`
+::setRange[hp=(hp.value-2)]
+
+A snarling wolf lunges from the underbrush!
+
+Current HP: :show[hp.value]{className="font-bold"}
+
+:::if[(hp.value>0)]
+  Bloodied but unbroken, you scan the forest floor.
+
+  :::trigger{label="Collect healing herbs"}
+    ::goto["Herbs"]
+  :::
+
+  :::trigger{label="Retreat to the crossroads"}
+    ::goto["Adventure"]
+  :::
+:::
+
+:::if[(hp.value<=0)]
+  The beast's fangs prove fatal.
+
+  :::trigger{label="Succumb to the darkness"}
+    ::goto["Dead"]
+  :::
+:::
+`}
+        </tw-passagedata>
+        <tw-passagedata pid='5' name='Herbs'>
+          {`
+::push{key=inventory value="Herbs"}
+
+You gather fragrant herbs and bandage your wounds before returning.
+
+:::trigger{label="Back to the crossroads"}
+  ::goto["Adventure"]
+:::
+`}
+        </tw-passagedata>
+        <tw-passagedata pid='6' name='Cave'>
+          {`
+::setRange[hp=(hp.value-3)]
+
+A hidden trap releases a volley of darts as you step inside the cave!
+
+Current HP: :show[hp.value]{className="font-bold"}
+
+:::if[(hp.value>0)]
+  ::push{key=inventory value="Gold"}
+  The trap spent, a cache of glittering coins remains.
+
+  Your pack now holds:
+  :::for[item in inventory]
+    - :show[item]
+  :::
+
+  :::trigger{label="Return to the crossroads"}
+    ::goto["Adventure"]
+  :::
+:::
+
+:::if[(hp.value<=0)]
+  The darts strike true. Darkness closes in.
+
+  :::trigger{label="Fall to your fate"}
+    ::goto["Dead"]
+  :::
+:::
+`}
+        </tw-passagedata>
+        <tw-passagedata pid='7' name='Dead'>
+          {`
+Your vision fades as the world slips away.
+
+:::trigger{label="Begin anew"}
+  ::goto["Start"]
+:::
+`}
+        </tw-passagedata>
+      </tw-storydata>
+      <Campfire />
+      <DebugWindow />
+    </>
+  )
+}

--- a/apps/storybook/src/examples/AdventureGame.stories.tsx
+++ b/apps/storybook/src/examples/AdventureGame.stories.tsx
@@ -179,22 +179,28 @@ Current HP: :show[hp.value]{className="font-bold"}
         <tw-passagedata pid='7' name='Dead'>
           {`
 :::layer{className="space-y-3"}
-  Your vision fades as the world slips away.
-
-  :::trigger{label="Begin anew"}
-    ::goto["Start"]
+  :::wrapper
+    Your vision fades as the world slips away.
   :::
 
-  :::onExit
-    ::unset[playerName]
-    ::unset[playerClass]
-    ::unset[hp]
-    ::unset[hpInitialized]
-    ::unset[inventory]
-    ::unset[forestDamageApplied]
-    ::unset[herbsCollected]
-    ::unset[caveTrapTriggered]
-    ::unset[caveLootGranted]
+  :::wrapper
+    :::trigger{label="Begin anew"}
+      ::goto["Start"]
+    :::
+  :::
+
+  :::wrapper
+    :::onExit
+      ::unset[playerName]
+      ::unset[playerClass]
+      ::unset[hp]
+      ::unset[hpInitialized]
+      ::unset[inventory]
+      ::unset[forestDamageApplied]
+      ::unset[herbsCollected]
+      ::unset[caveTrapTriggered]
+      ::unset[caveLootGranted]
+    :::
   :::
 :::
 `}


### PR DESCRIPTION
## Summary
- keep layer extra processing from discarding serialized directive output by recognizing directive paragraphs
- reset directive store state in layer tests and assert conditional triggers survive after a layer block

## Testing
- bun test
- bun tsc
- bunx prettier . --write

------
https://chatgpt.com/codex/tasks/task_e_68d0ada02640832296f5a243b439d419