### PR TITLE
fix(storybook): render twine story markup via h

### DIFF
--- a/apps/storybook/src/TwineElements.tsx
+++ b/apps/storybook/src/TwineElements.tsx
@@ -1,0 +1,29 @@
+import { h } from 'preact'
+import type { ComponentChildren, JSX } from 'preact'
+
+/**
+ * Shared props for Twine custom elements rendered via Preact.
+ */
+type TwineElementProps = JSX.HTMLAttributes<HTMLElement> & {
+  children?: ComponentChildren
+}
+
+/**
+ * Renders a `<tw-storydata>` element using Preact's `h` helper to ensure the
+ * custom element is created correctly when Storybook compiles the story.
+ *
+ * @param props - Attributes and children passed to the `tw-storydata` element.
+ * @returns The rendered Twine story data element.
+ */
+export const TwStorydata = ({ children, ...props }: TwineElementProps) =>
+  h('tw-storydata', props, children)
+
+/**
+ * Renders a `<tw-passagedata>` element via Preact's `h` helper so that Twine
+ * story passages are consistently emitted in Storybook builds.
+ *
+ * @param props - Attributes and children passed to the `tw-passagedata`.
+ * @returns The rendered Twine passage data element.
+ */
+export const TwPassagedata = ({ children, ...props }: TwineElementProps) =>
+  h('tw-passagedata', props, children)

--- a/apps/storybook/src/TwineElements.tsx
+++ b/apps/storybook/src/TwineElements.tsx
@@ -9,13 +9,35 @@ type TwineElementProps = JSX.HTMLAttributes<HTMLElement> & {
 }
 
 /**
+ * Props accepted by the {@link TwStorydata} helper for the `tw-storydata`
+ * element.
+ */
+type TwStorydataProps = TwineElementProps & {
+  /**
+   * Identifier for the passage that should render first when the story loads.
+   */
+  startnode?: string
+}
+
+/**
+ * Props accepted by the {@link TwPassagedata} helper for the
+ * `tw-passagedata` element.
+ */
+type TwPassagedataProps = TwineElementProps & {
+  /**
+   * Unique passage identifier referenced by other passages and directives.
+   */
+  pid?: string
+}
+
+/**
  * Renders a `<tw-storydata>` element using Preact's `h` helper to ensure the
  * custom element is created correctly when Storybook compiles the story.
  *
  * @param props - Attributes and children passed to the `tw-storydata` element.
  * @returns The rendered Twine story data element.
  */
-export const TwStorydata = ({ children, ...props }: TwineElementProps) =>
+export const TwStorydata = ({ children, ...props }: TwStorydataProps) =>
   h('tw-storydata', props, children)
 
 /**
@@ -25,5 +47,5 @@ export const TwStorydata = ({ children, ...props }: TwineElementProps) =>
  * @param props - Attributes and children passed to the `tw-passagedata`.
  * @returns The rendered Twine passage data element.
  */
-export const TwPassagedata = ({ children, ...props }: TwineElementProps) =>
+export const TwPassagedata = ({ children, ...props }: TwPassagedataProps) =>
   h('tw-passagedata', props, children)

--- a/apps/storybook/src/TwineElements.tsx
+++ b/apps/storybook/src/TwineElements.tsx
@@ -17,6 +17,14 @@ type TwStorydataProps = TwineElementProps & {
    * Identifier for the passage that should render first when the story loads.
    */
   startnode?: string
+  /**
+   * Human-readable title for the story displayed in the Twine UI.
+   */
+  name?: string
+  /**
+   * Space-separated list of story options (for example `debug`).
+   */
+  options?: string
 }
 
 /**
@@ -28,6 +36,10 @@ type TwPassagedataProps = TwineElementProps & {
    * Unique passage identifier referenced by other passages and directives.
    */
   pid?: string
+  /**
+   * Human-readable passage title used by links and debugging tools.
+   */
+  name?: string
 }
 
 /**

--- a/apps/storybook/src/directives/Checkbox.stories.tsx
+++ b/apps/storybook/src/directives/Checkbox.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/preact'
 import { Campfire } from '@campfire/components'
 import { DebugWindow } from '../DebugWindow'
+import { TwPassagedata, TwStorydata } from '../TwineElements'
 
 const meta: Meta = {
   title: 'Campfire/Directives/Checkbox'
@@ -16,13 +17,13 @@ export default meta
 export const Basic: StoryObj = {
   render: () => (
     <>
-      <tw-storydata startnode='1' options='debug'>
-        <tw-passagedata pid='1' name='Start'>
+      <TwStorydata startnode='1' options='debug'>
+        <TwPassagedata pid='1' name='Start'>
           {`
 :checkbox[agree]
 `}
-        </tw-passagedata>
-      </tw-storydata>
+        </TwPassagedata>
+      </TwStorydata>
       <Campfire />
       <DebugWindow />
     </>
@@ -37,13 +38,13 @@ export const Basic: StoryObj = {
 export const AsInput: StoryObj = {
   render: () => (
     <>
-      <tw-storydata startnode='1' options='debug'>
-        <tw-passagedata pid='1' name='Start'>
+      <TwStorydata startnode='1' options='debug'>
+        <TwPassagedata pid='1' name='Start'>
           {`
 :input[agree]{type='checkbox'}
 `}
-        </tw-passagedata>
-      </tw-storydata>
+        </TwPassagedata>
+      </TwStorydata>
       <Campfire />
       <DebugWindow />
     </>

--- a/apps/storybook/src/directives/DeckBasic.stories.tsx
+++ b/apps/storybook/src/directives/DeckBasic.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/preact'
 import { Campfire } from '@campfire/components'
 import { DebugWindow } from '../DebugWindow'
+import { TwPassagedata, TwStorydata } from '../TwineElements'
 
 const meta: Meta = {
   title: 'Campfire/Directives/Deck'
@@ -16,8 +17,8 @@ export default meta
 export const Basic: StoryObj = {
   render: () => (
     <>
-      <tw-storydata startnode='1' options='debug'>
-        <tw-passagedata pid={'2'} name={'overlay-1'} tags={'overlay'} hidden>
+      <TwStorydata startnode='1' options='debug'>
+        <TwPassagedata pid={'2'} name={'overlay-1'} tags={'overlay'} hidden>
           {`
 :::wrapper{className='bg-white/50 text-black absolute bottom-4 left-4 p-4 rounded shadow-lg'}
 Overlay Text
@@ -27,8 +28,8 @@ Overlay Text
 Overlay Text2
 :::
 `}
-        </tw-passagedata>
-        <tw-passagedata pid='1' name='Start'>
+        </TwPassagedata>
+        <TwPassagedata pid='1' name='Start'>
           {`
 :preset{type="text" name="title" x=80 y=80 as="p" size=36}
 
@@ -72,8 +73,8 @@ Overlay Text2
   :::
 :::
 `}
-        </tw-passagedata>
-      </tw-storydata>
+        </TwPassagedata>
+      </TwStorydata>
       <Campfire />
       <DebugWindow />
     </>

--- a/apps/storybook/src/directives/DeckMultiPassage.stories.tsx
+++ b/apps/storybook/src/directives/DeckMultiPassage.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/preact'
 import { Campfire } from '@campfire/components'
 import { DebugWindow } from '../DebugWindow'
+import { TwPassagedata, TwStorydata } from '../TwineElements'
 
 const meta: Meta = {
   title: 'Campfire/Directives/Deck'
@@ -16,8 +17,8 @@ export default meta
 export const MultiPassage: StoryObj = {
   render: () => (
     <>
-      <tw-storydata startnode='1' options='debug'>
-        <tw-passagedata pid='1' name='Start'>
+      <TwStorydata startnode='1' options='debug'>
+        <TwPassagedata pid='1' name='Start'>
           {`
 :::deck{size='1280x720'}
   :::slide
@@ -40,8 +41,8 @@ export const MultiPassage: StoryObj = {
   :::
 :::
 `}
-        </tw-passagedata>
-        <tw-passagedata pid='2' name='Second'>
+        </TwPassagedata>
+        <TwPassagedata pid='2' name='Second'>
           {`
 :::deck{size='1280x720'}
   :::slide
@@ -64,8 +65,8 @@ export const MultiPassage: StoryObj = {
   :::
 :::
 `}
-        </tw-passagedata>
-      </tw-storydata>
+        </TwPassagedata>
+      </TwStorydata>
       <Campfire data-testid='campfire' />
       <DebugWindow />
     </>

--- a/apps/storybook/src/directives/For.stories.tsx
+++ b/apps/storybook/src/directives/For.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/preact'
 import { Campfire } from '@campfire/components'
+import { TwPassagedata, TwStorydata } from '../TwineElements'
 import { DebugWindow } from '../DebugWindow'
 
 const meta: Meta = {
@@ -17,8 +18,8 @@ export default meta
 export const Numbers: StoryObj = {
   render: () => (
     <>
-      <tw-storydata startnode='1' options='debug'>
-        <tw-passagedata pid='1' name='Start'>
+      <TwStorydata startnode='1' options='debug'>
+        <TwPassagedata pid='1' name='Start'>
           {`
 :::for[x in [1,2,3]]
 
@@ -26,8 +27,8 @@ Value :show[x]{as="span" className="text-sky-600"}
 
 :::
           `}
-        </tw-passagedata>
-      </tw-storydata>
+        </TwPassagedata>
+      </TwStorydata>
       <Campfire />
       <DebugWindow />
     </>
@@ -43,8 +44,8 @@ Value :show[x]{as="span" className="text-sky-600"}
 export const Fruits: StoryObj = {
   render: () => (
     <>
-      <tw-storydata startnode='1' options='debug'>
-        <tw-passagedata pid='1' name='Start'>
+      <TwStorydata startnode='1' options='debug'>
+        <TwPassagedata pid='1' name='Start'>
           {`
 ::array[fruits=["apple","banana","cherry"]]
 
@@ -58,8 +59,8 @@ export const Fruits: StoryObj = {
 
 :::
           `}
-        </tw-passagedata>
-      </tw-storydata>
+        </TwPassagedata>
+      </TwStorydata>
       <Campfire />
       <DebugWindow />
     </>

--- a/apps/storybook/src/directives/If.stories.tsx
+++ b/apps/storybook/src/directives/If.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/preact'
 import { Campfire } from '@campfire/components'
 import { DebugWindow } from '../DebugWindow'
+import { TwPassagedata, TwStorydata } from '../TwineElements'
 
 const meta: Meta = {
   title: 'Campfire/Directives/If'
@@ -16,8 +17,8 @@ export default meta
 export const Truthy: StoryObj = {
   render: () => (
     <>
-      <tw-storydata startnode='1' options='debug'>
-        <tw-passagedata pid='1' name='Start'>
+      <TwStorydata startnode='1' options='debug'>
+        <TwPassagedata pid='1' name='Start'>
           {`
 ::set[flag=true]
 
@@ -31,8 +32,8 @@ Flag is false
 
 :::
           `}
-        </tw-passagedata>
-      </tw-storydata>
+        </TwPassagedata>
+      </TwStorydata>
       <Campfire />
       <DebugWindow />
     </>
@@ -47,8 +48,8 @@ Flag is false
 export const Falsy: StoryObj = {
   render: () => (
     <>
-      <tw-storydata startnode='1' options='debug'>
-        <tw-passagedata pid='1' name='Start'>
+      <TwStorydata startnode='1' options='debug'>
+        <TwPassagedata pid='1' name='Start'>
           {`
 ::set[flag=false]
 
@@ -62,8 +63,8 @@ Flag is false
 
 :::
           `}
-        </tw-passagedata>
-      </tw-storydata>
+        </TwPassagedata>
+      </TwStorydata>
       <Campfire />
       <DebugWindow />
     </>

--- a/apps/storybook/src/directives/Input.stories.tsx
+++ b/apps/storybook/src/directives/Input.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/preact'
 import { Campfire } from '@campfire/components'
 import { DebugWindow } from '../DebugWindow'
+import { TwPassagedata, TwStorydata } from '../TwineElements'
 
 const meta: Meta = {
   title: 'Campfire/Directives/Input'
@@ -16,16 +17,16 @@ export default meta
 export const Basic: StoryObj = {
   render: () => (
     <>
-      <tw-storydata startnode='1' options='debug'>
-        <tw-passagedata pid='1' name='Start'>
+      <TwStorydata startnode='1' options='debug'>
+        <TwPassagedata pid='1' name='Start'>
           {`
 :input[name]{placeholder="Type your name"}
 :::if[name]
   Hello, :show[name]{className="text-green-600"}!
 :::
 `}
-        </tw-passagedata>
-      </tw-storydata>
+        </TwPassagedata>
+      </TwStorydata>
       <Campfire />
       <DebugWindow />
     </>
@@ -40,8 +41,8 @@ export const Basic: StoryObj = {
 export const WithEvents: StoryObj = {
   render: () => (
     <>
-      <tw-storydata startnode='1' options='debug'>
-        <tw-passagedata pid='1' name='Start'>
+      <TwStorydata startnode='1' options='debug'>
+        <TwPassagedata pid='1' name='Start'>
           {`
 :::input[name]{placeholder="Hover or focus"}
   :::onFocus
@@ -60,8 +61,8 @@ export const WithEvents: StoryObj = {
   Hello, :show[name]{className="text-green-600"}!
 :::
           `}
-        </tw-passagedata>
-      </tw-storydata>
+        </TwPassagedata>
+      </TwStorydata>
       <Campfire />
       <DebugWindow />
     </>

--- a/apps/storybook/src/directives/Layer.stories.tsx
+++ b/apps/storybook/src/directives/Layer.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/preact'
 import { Campfire } from '@campfire/components'
 import { DebugWindow } from '../DebugWindow'
+import { TwPassagedata, TwStorydata } from '../TwineElements'
 
 const meta: Meta = {
   title: 'Campfire/Directives/Layer'
@@ -16,8 +17,8 @@ export default meta
 export const Basic: StoryObj = {
   render: () => (
     <>
-      <tw-storydata startnode='1' options='debug'>
-        <tw-passagedata pid='1' name='Start'>
+      <TwStorydata startnode='1' options='debug'>
+        <TwPassagedata pid='1' name='Start'>
           {`
 :::deck{size="800x600"}
   :::slide
@@ -27,8 +28,8 @@ export const Basic: StoryObj = {
   :::
 :::
 `}
-        </tw-passagedata>
-      </tw-storydata>
+        </TwPassagedata>
+      </TwStorydata>
       <Campfire />
       <DebugWindow />
     </>

--- a/apps/storybook/src/directives/Localization.stories.tsx
+++ b/apps/storybook/src/directives/Localization.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/preact'
 import { Campfire } from '@campfire/components'
 import { DebugWindow } from '../DebugWindow'
+import { TwPassagedata, TwStorydata } from '../TwineElements'
 
 const meta: Meta = {
   title: 'Campfire/Directives/Localization'
@@ -16,8 +17,8 @@ export default meta
 export const LanguageSelect: StoryObj = {
   render: () => (
     <>
-      <tw-storydata startnode='1' options='debug'>
-        <tw-passagedata pid='1' name='Start'>
+      <TwStorydata startnode='1' options='debug'>
+        <TwPassagedata pid='1' name='Start'>
           {`
 ::set[lang="en-US"]
 ::setLanguageLabel[en-US="English (US)"]
@@ -42,8 +43,8 @@ export const LanguageSelect: StoryObj = {
 
 :t[ui:greet]
           `}
-        </tw-passagedata>
-      </tw-storydata>
+        </TwPassagedata>
+      </TwStorydata>
       <Campfire />
       <DebugWindow />
     </>

--- a/apps/storybook/src/directives/Radio.stories.tsx
+++ b/apps/storybook/src/directives/Radio.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/preact'
 import { Campfire } from '@campfire/components'
 import { DebugWindow } from '../DebugWindow'
+import { TwPassagedata, TwStorydata } from '../TwineElements'
 
 const meta: Meta = {
   title: 'Campfire/Directives/Radio'
@@ -16,8 +17,8 @@ export default meta
 export const Basic: StoryObj = {
   render: () => (
     <>
-      <tw-storydata startnode='1' options='debug'>
-        <tw-passagedata pid='1' name='Start'>
+      <TwStorydata startnode='1' options='debug'>
+        <TwPassagedata pid='1' name='Start'>
           {`
 :preset{type="wrapper" name="radioLabel" as="div" className="flex items-center gap-2"}
 ::set[choice="b"]
@@ -36,8 +37,8 @@ export const Basic: StoryObj = {
   :::
 :::
 `}
-        </tw-passagedata>
-      </tw-storydata>
+        </TwPassagedata>
+      </TwStorydata>
       <Campfire />
       <DebugWindow />
     </>
@@ -52,8 +53,8 @@ export const Basic: StoryObj = {
 export const AsInput: StoryObj = {
   render: () => (
     <>
-      <tw-storydata startnode='1' options='debug'>
-        <tw-passagedata pid='1' name='Start'>
+      <TwStorydata startnode='1' options='debug'>
+        <TwPassagedata pid='1' name='Start'>
           {`
   :::layer{className="flex gap-[4px] items-center justify-center"}
     :input[choice]{type='radio' value='a'}
@@ -61,8 +62,8 @@ export const AsInput: StoryObj = {
     :input[choice]{type='radio' value='c' disabled='true'}
   :::
 `}
-        </tw-passagedata>
-      </tw-storydata>
+        </TwPassagedata>
+      </TwStorydata>
       <Campfire />
       <DebugWindow />
     </>

--- a/apps/storybook/src/directives/Select.stories.tsx
+++ b/apps/storybook/src/directives/Select.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/preact'
 import { Campfire } from '@campfire/components'
 import { DebugWindow } from '../DebugWindow'
+import { TwPassagedata, TwStorydata } from '../TwineElements'
 
 const meta: Meta = {
   title: 'Campfire/Directives/Select'
@@ -16,8 +17,8 @@ export default meta
 export const Basic: StoryObj = {
   render: () => (
     <>
-      <tw-storydata startnode='1' options='debug'>
-        <tw-passagedata pid='1' name='Start'>
+      <TwStorydata startnode='1' options='debug'>
+        <TwPassagedata pid='1' name='Start'>
           {`
 :::select[color]{label="Choose a color"}
 
@@ -46,8 +47,8 @@ You chose
 :::
 
     `}
-        </tw-passagedata>
-      </tw-storydata>
+        </TwPassagedata>
+      </TwStorydata>
       <Campfire />
       <DebugWindow />
     </>
@@ -62,8 +63,8 @@ You chose
 export const WithEvents: StoryObj = {
   render: () => (
     <>
-      <tw-storydata startnode='1' options='debug'>
-        <tw-passagedata pid='1' name='Start'>
+      <TwStorydata startnode='1' options='debug'>
+        <TwPassagedata pid='1' name='Start'>
           {`
 :::select[color]{label="Choose a color"}
 
@@ -104,8 +105,8 @@ You chose
 :::
 
             `}
-        </tw-passagedata>
-      </tw-storydata>
+        </TwPassagedata>
+      </TwStorydata>
       <Campfire />
       <DebugWindow />
     </>

--- a/apps/storybook/src/directives/Shape.stories.tsx
+++ b/apps/storybook/src/directives/Shape.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/preact'
 import { Campfire } from '@campfire/components'
 import { DebugWindow } from '../DebugWindow'
+import { TwPassagedata, TwStorydata } from '../TwineElements'
 
 const meta: Meta = {
   title: 'Campfire/Directives/Shape'
@@ -16,8 +17,8 @@ export default meta
 export const Basic: StoryObj = {
   render: () => (
     <>
-      <tw-storydata startnode='1' options='debug'>
-        <tw-passagedata pid='1' name='Start'>
+      <TwStorydata startnode='1' options='debug'>
+        <TwPassagedata pid='1' name='Start'>
           {`
 :::deck{size="800x600"}
   :::slide
@@ -26,8 +27,8 @@ export const Basic: StoryObj = {
   :::
 :::
           `}
-        </tw-passagedata>
-      </tw-storydata>
+        </TwPassagedata>
+      </TwStorydata>
       <Campfire />
       <DebugWindow />
     </>

--- a/apps/storybook/src/directives/Switch.stories.tsx
+++ b/apps/storybook/src/directives/Switch.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/preact'
 import { Campfire } from '@campfire/components'
 import { DebugWindow } from '../DebugWindow'
+import { TwPassagedata, TwStorydata } from '../TwineElements'
 
 const meta: Meta = {
   title: 'Campfire/Directives/Switch'
@@ -16,8 +17,8 @@ export default meta
 export const MatchingCase: StoryObj = {
   render: () => (
     <>
-      <tw-storydata startnode='1' options='debug'>
-        <tw-passagedata pid='1' name='Start'>
+      <TwStorydata startnode='1' options='debug'>
+        <TwPassagedata pid='1' name='Start'>
           {`
 ::set[color="red"]
 
@@ -33,8 +34,8 @@ No match
 :::
 :::
           `}
-        </tw-passagedata>
-      </tw-storydata>
+        </TwPassagedata>
+      </TwStorydata>
       <Campfire />
       <DebugWindow />
     </>
@@ -49,8 +50,8 @@ No match
 export const DefaultCase: StoryObj = {
   render: () => (
     <>
-      <tw-storydata startnode='1' options='debug'>
-        <tw-passagedata pid='1' name='Start'>
+      <TwStorydata startnode='1' options='debug'>
+        <TwPassagedata pid='1' name='Start'>
           {`
 ::set[color="green"]
 
@@ -66,8 +67,8 @@ No match
 :::
 :::
           `}
-        </tw-passagedata>
-      </tw-storydata>
+        </TwPassagedata>
+      </TwStorydata>
       <Campfire />
       <DebugWindow />
     </>

--- a/apps/storybook/src/directives/Textarea.stories.tsx
+++ b/apps/storybook/src/directives/Textarea.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/preact'
 import { Campfire } from '@campfire/components'
 import { DebugWindow } from '../DebugWindow'
+import { TwPassagedata, TwStorydata } from '../TwineElements'
 
 const meta: Meta = {
   title: 'Campfire/Directives/Textarea'
@@ -16,8 +17,8 @@ export default meta
 export const Basic: StoryObj = {
   render: () => (
     <>
-      <tw-storydata startnode='1' options='debug'>
-        <tw-passagedata pid='1' name='Start'>
+      <TwStorydata startnode='1' options='debug'>
+        <TwPassagedata pid='1' name='Start'>
           {`
 :textarea[bio]{placeholder="Enter bio"}
 :::if[bio]
@@ -26,8 +27,8 @@ You wrote: :show[bio]{className="text-purple-600"}
 
 :::
 `}
-        </tw-passagedata>
-      </tw-storydata>
+        </TwPassagedata>
+      </TwStorydata>
       <Campfire />
       <DebugWindow />
     </>
@@ -42,8 +43,8 @@ You wrote: :show[bio]{className="text-purple-600"}
 export const WithEvents: StoryObj = {
   render: () => (
     <>
-      <tw-storydata startnode='1' options='debug'>
-        <tw-passagedata pid='1' name='Start'>
+      <TwStorydata startnode='1' options='debug'>
+        <TwPassagedata pid='1' name='Start'>
           {`
 :::textarea[bio]{placeholder="Hover or focus"}
 :::onFocus
@@ -60,8 +61,8 @@ Focused!
 
 :::
           `}
-        </tw-passagedata>
-      </tw-storydata>
+        </TwPassagedata>
+      </TwStorydata>
       <Campfire />
       <DebugWindow />
     </>

--- a/apps/storybook/src/directives/Trigger.stories.tsx
+++ b/apps/storybook/src/directives/Trigger.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/preact'
 import { Campfire } from '@campfire/components'
 import { DebugWindow } from '../DebugWindow'
+import { TwPassagedata, TwStorydata } from '../TwineElements'
 
 const meta: Meta = {
   title: 'Campfire/Directives/Trigger'
@@ -16,8 +17,8 @@ export default meta
 export const Basic: StoryObj = {
   render: () => (
     <>
-      <tw-storydata startnode='1' options='debug'>
-        <tw-passagedata pid='1' name='Start'>
+      <TwStorydata startnode='1' options='debug'>
+        <TwPassagedata pid='1' name='Start'>
           {`
 ::set[test=true]
 
@@ -35,8 +36,8 @@ You clicked the button!
   ::unset[test]
 :::
 `}
-        </tw-passagedata>
-      </tw-storydata>
+        </TwPassagedata>
+      </TwStorydata>
       <Campfire />
       <DebugWindow />
     </>
@@ -51,8 +52,8 @@ You clicked the button!
 export const WithEvents: StoryObj = {
   render: () => (
     <>
-      <tw-storydata startnode='1' options='debug'>
-        <tw-passagedata pid='1' name='Start'>
+      <TwStorydata startnode='1' options='debug'>
+        <TwPassagedata pid='1' name='Start'>
           {`
 ::set[hover=false]
 
@@ -68,8 +69,8 @@ You hovered the button!
 
 :::
           `}
-        </tw-passagedata>
-      </tw-storydata>
+        </TwPassagedata>
+      </TwStorydata>
       <Campfire />
       <DebugWindow />
     </>
@@ -83,8 +84,8 @@ You hovered the button!
 export const WithWrapperLabel: StoryObj = {
   render: () => (
     <>
-      <tw-storydata startnode='1' options='debug'>
-        <tw-passagedata pid='1' name='Start'>
+      <TwStorydata startnode='1' options='debug'>
+        <TwPassagedata pid='1' name='Start'>
           {`
 ::set[clicked=false]
 
@@ -114,8 +115,8 @@ export const WithWrapperLabel: StoryObj = {
 
 :::
           `}
-        </tw-passagedata>
-      </tw-storydata>
+        </TwPassagedata>
+      </TwStorydata>
       <Campfire />
       <DebugWindow />
     </>

--- a/apps/storybook/src/directives/Wrapper.stories.tsx
+++ b/apps/storybook/src/directives/Wrapper.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/preact'
 import { Campfire } from '@campfire/components'
 import { DebugWindow } from '../DebugWindow'
+import { TwPassagedata, TwStorydata } from '../TwineElements'
 
 const meta: Meta = {
   title: 'Campfire/Directives/Wrapper'
@@ -16,8 +17,8 @@ export default meta
 export const Basic: StoryObj = {
   render: () => (
     <>
-      <tw-storydata startnode='1' options='debug'>
-        <tw-passagedata pid='1' name='Start'>
+      <TwStorydata startnode='1' options='debug'>
+        <TwPassagedata pid='1' name='Start'>
           {`
 :::deck{size="800x600"}
   :::slide
@@ -29,8 +30,8 @@ export const Basic: StoryObj = {
   :::
 :::
           `}
-        </tw-passagedata>
-      </tw-storydata>
+        </TwPassagedata>
+      </TwStorydata>
       <Campfire />
       <DebugWindow />
     </>

--- a/apps/storybook/src/examples/AdventureGame.stories.tsx
+++ b/apps/storybook/src/examples/AdventureGame.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/preact'
 import { Campfire } from '@campfire/components'
 import { DebugWindow } from '../DebugWindow'
+import { TwPassagedata, TwStorydata } from '../TwineElements'
 
 const meta: Meta = {
   title: 'Campfire/Examples/AdventureGame'
@@ -17,8 +18,8 @@ export default meta
 export const AdventureGame: StoryObj = {
   render: () => (
     <>
-      <tw-storydata startnode='1' options='debug'>
-        <tw-passagedata pid='1' name='Start'>
+      <TwStorydata startnode='1' options='debug'>
+        <TwPassagedata pid='1' name='Start'>
           {`
 Hello adventurer! Enter your name:
 ::input[playerName]{placeholder="Your name"}
@@ -29,8 +30,8 @@ Hello adventurer! Enter your name:
   :::
 :::
 `}
-        </tw-passagedata>
-        <tw-passagedata pid='2' name='ChooseClass'>
+        </TwPassagedata>
+        <TwPassagedata pid='2' name='ChooseClass'>
           {`
 ::preset{type="wrapper" name="classChoice" as="label" className="flex items-center gap-2"}
 
@@ -55,8 +56,8 @@ Greetings, :show[playerName]{className="font-semibold"}! Choose your class:
   :::
 :::
 `}
-        </tw-passagedata>
-        <tw-passagedata pid='3' name='Adventure'>
+        </TwPassagedata>
+        <TwPassagedata pid='3' name='Adventure'>
           {`
 :::if[(!hpInitialized)]
   ::setOnce[hpInitialized=true]
@@ -79,8 +80,8 @@ Two paths beckon:
   ::goto["Cave"]
 :::
 `}
-        </tw-passagedata>
-        <tw-passagedata pid='4' name='Forest'>
+        </TwPassagedata>
+        <TwPassagedata pid='4' name='Forest'>
           {`
 :::if[(!forestDamageApplied)]
   ::set[forestDamageApplied=true]
@@ -115,8 +116,8 @@ Current HP: :show[hp.value]{className="font-bold"}
   ::unset[forestDamageApplied]
 :::
 `}
-        </tw-passagedata>
-        <tw-passagedata pid='5' name='Herbs'>
+        </TwPassagedata>
+        <TwPassagedata pid='5' name='Herbs'>
           {`
 :::if[(!herbsCollected)]
   ::set[herbsCollected=true]
@@ -133,8 +134,8 @@ You gather fragrant herbs and bandage your wounds before returning.
   ::unset[herbsCollected]
 :::
 `}
-        </tw-passagedata>
-        <tw-passagedata pid='6' name='Cave'>
+        </TwPassagedata>
+        <TwPassagedata pid='6' name='Cave'>
           {`
 :::if[(!caveTrapTriggered)]
   ::set[caveTrapTriggered=true]
@@ -179,8 +180,8 @@ Current HP: :show[hp.value]{className="font-bold"}
   :::
 :::
 `}
-        </tw-passagedata>
-        <tw-passagedata pid='7' name='Dead'>
+        </TwPassagedata>
+        <TwPassagedata pid='7' name='Dead'>
           {`
 :::layer{className="space-y-3"}
   :::wrapper
@@ -209,8 +210,8 @@ Current HP: :show[hp.value]{className="font-bold"}
   :::
 :::
 `}
-        </tw-passagedata>
-      </tw-storydata>
+        </TwPassagedata>
+      </TwStorydata>
       <Campfire />
       <DebugWindow />
     </>


### PR DESCRIPTION
## Summary
- add TwStorydata and TwPassagedata helpers that render the Twine tags through preact's `h`
- replace the raw `tw-storydata` and `tw-passagedata` elements in directive and example stories with the new helpers

## Testing
- bun tsc
- bun test
- bunx prettier . --write

------
https://chatgpt.com/codex/tasks/task_e_68d444414da88322921e6b071b699d61