### PR TITLE
fix: skip npm dependency check when packaging the VS Code extension

### DIFF
--- a/docs/campfire-storybuilder.md
+++ b/docs/campfire-storybuilder.md
@@ -38,7 +38,7 @@ bun run --filter campfire-storybuilder watch
 
 ## Package the extension
 
-Create a distributable `.vsix` archive using the bundled `vsce` CLI:
+Create a distributable `.vsix` archive using the bundled `vsce` CLI. The packaging script passes `--no-dependencies` so that `vsce` skips `npm list` validation (our workspace is managed by Bun rather than `npm`).
 
 ```sh
 bun run --filter campfire-storybuilder package

--- a/projects/campfire-vscode-extension/package.json
+++ b/projects/campfire-vscode-extension/package.json
@@ -15,7 +15,7 @@
   "main": "./dist/extension.js",
   "scripts": {
     "build": "bun run tsc -p .",
-    "package": "bunx vsce package",
+    "package": "bunx vsce package --no-dependencies",
     "watch": "bun run tsc -p . --watch"
   },
   "contributes": {


### PR DESCRIPTION
## Summary
- run the VS Code packaging script with `--no-dependencies` to avoid npm workspace validation
- document the flag in the Storybuilder packaging guide so contributors know why it is required

## Testing
- bun tsc
- bun test
- bunx prettier . --write

------
https://chatgpt.com/codex/tasks/task_e_68d46e74e74c8322bea7ba6c1c401af2