### PR TITLE
docs: clarify input directive forms

### DIFF
--- a/docs/directives/inputs-and-events.md
+++ b/docs/directives/inputs-and-events.md
@@ -8,12 +8,18 @@ Collect data or trigger actions directly in the passage.
 
 ### `input`
 
-Render a text input bound to a game state key. Use as a leaf or container. The container form can include event directives. If the key already exists in game state, its value is used; otherwise, the optional `value` attribute sets the starting value.
+Render a text input bound to a game state key. Use as a leaf, inline text directive, or container. The container form can include event directives. If the key already exists in game state, its value is used; otherwise, the optional `value` attribute sets the starting value.
 
 Leaf form:
 
 ```md
-:input[name]{placeholder="Your name"}
+::input[name]{placeholder="Your name"}
+```
+
+Inline form (within text):
+
+```md
+Enter your name: :input[name]{placeholder="Your name"}
 ```
 
 Container form:


### PR DESCRIPTION
## Summary
- document that the input directive supports leaf, inline, and container forms
- fix the leaf example to use the :: leaf syntax and add an inline usage example

## Testing
- bun tsc
- bun test
- bunx prettier . --write

------
https://chatgpt.com/codex/tasks/task_e_68d596d3ba3c8322ab912e32fd55eed9