### PR TITLE
fix: correct deck snippet placeholders

### DIFF
--- a/projects/campfire-vscode-extension/src/extension.ts
+++ b/projects/campfire-vscode-extension/src/extension.ts
@@ -189,7 +189,7 @@ const directiveSnippets: DirectiveSnippet[] = [
     escapeAtColumnZero: true,
     detail: 'Slide deck container',
     documentation: 'Groups multiple slides with navigation controls.',
-    body: ':::deck ${1:label}\n  ::slide ${2:label}\n    $3\n  :::\n  ::slide ${4:label}\n    $5\n  :::\n:::'
+    body: ':::deck\n  :::slide\n    ${1:Slide content}\n  :::\n  :::slide\n    ${2:More content}\n  :::\n:::'
   },
   {
     marker: ':::',


### PR DESCRIPTION
## Summary
- remove unused label placeholders from the deck directive completion snippet
- align slide markers in the snippet with the directive syntax

## Testing
- bun tsc
- bun test
- bunx prettier . --write

------
https://chatgpt.com/codex/tasks/task_e_68d66a261e7483229f17fba4392336b9