### PR TITLE
feat: remove Campfire else directive

### DIFF
--- a/apps/campfire/package.json
+++ b/apps/campfire/package.json
@@ -1,6 +1,6 @@
 {
   "name": "campfire-storyformat",
-  "version": "1.106.0",
+  "version": "1.107.1",
   "private": true,
   "type": "module",
   "main": "dist/format.js",

--- a/apps/campfire/src/components/Campfire/__tests__/Campfire.test.tsx
+++ b/apps/campfire/src/components/Campfire/__tests__/Campfire.test.tsx
@@ -144,41 +144,19 @@ not open
     expect(screen.queryByText(':::')).toBeNull()
   })
 
-  it('executes only the matching branch when else is present', async () => {
-    document.body.innerHTML = `
-<tw-storydata name="Story" startnode="1">
-  <tw-passagedata pid="1" name="Start">\n::set[open=true]
-
-:::if[open]
-::set[yes=true]
-:::else
-::set[no=true]
-:::
-  </tw-passagedata>
-</tw-storydata>
-    `
-    render(<Campfire />)
-    await waitFor(() => expect(useGameStore.getState().gameData.yes).toBe(true))
-    expect(useGameStore.getState().gameData.no).toBeUndefined()
-    expect(screen.queryByText(':::')).toBeNull()
-  })
-
-  it('renders else block when condition is false', async () => {
+  it('skips the block when the condition is false', async () => {
     document.body.innerHTML = `
 <tw-storydata name="Story" startnode="1">
   <tw-passagedata pid="1" name="Start">::set[open=false]
 
 :::if[open]
 ::set[yes=true]
-:::else
-::set[no=true]
 :::
   </tw-passagedata>
 </tw-storydata>
     `
     render(<Campfire />)
-    await waitFor(() => expect(useGameStore.getState().gameData.no).toBe(true))
+    await waitFor(() => expect(screen.queryByText(':::')).toBeNull())
     expect(useGameStore.getState().gameData.yes).toBeUndefined()
-    expect(screen.queryByText(':::')).toBeNull()
   })
 })

--- a/apps/campfire/src/components/Passage/If.tsx
+++ b/apps/campfire/src/components/Passage/If.tsx
@@ -27,15 +27,13 @@ import { rehypeSlideText } from '@campfire/utils/rehypeSlideText'
 interface IfProps {
   test: string
   content: string
-  fallback?: string
 }
 
 /**
  * Evaluates a JavaScript expression against game data and renders
- * serialized nodes when the expression is truthy or an optional
- * fallback when it is falsy.
+ * serialized nodes when the expression is truthy.
  */
-export const If = ({ test, content, fallback }: IfProps) => {
+export const If = ({ test, content }: IfProps) => {
   const handlers = useDirectiveHandlers()
   const processor = useMemo(() => {
     const proc = unified()
@@ -82,9 +80,8 @@ export const If = ({ test, content, fallback }: IfProps) => {
   } catch {
     condition = false
   }
-  const source = condition ? content : fallback
-  if (!source) return null
-  const nodes: RootContent[] = JSON.parse(source)
+  if (!condition) return null
+  const nodes: RootContent[] = JSON.parse(content)
   const root: Root = { type: 'root', children: nodes }
   const result = processor.processSync(root)
   const output = result.result

--- a/apps/campfire/src/components/Passage/__tests__/If.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/If.test.tsx
@@ -42,18 +42,7 @@ describe('If', () => {
     expect(screen.getByText('Hello')).toBeInTheDocument()
   })
 
-  it('renders fallback when condition is false', () => {
-    render(
-      <If
-        test='false'
-        content={makeContent('Content')}
-        fallback={makeContent('Fallback')}
-      />
-    )
-    expect(screen.getByText('Fallback')).toBeInTheDocument()
-  })
-
-  it('renders nothing when condition is false and no fallback', () => {
+  it('renders nothing when condition is false', () => {
     const { container } = render(
       <If test='false' content={makeContent('Nope')} />
     )

--- a/apps/campfire/src/components/Passage/__tests__/Passage.lifecycle.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Passage.lifecycle.test.tsx
@@ -67,7 +67,7 @@ describe('Passage lifecycle directives', () => {
     const root = unified()
       .use(remarkParse)
       .use(remarkDirective)
-      .parse(':::if[false]\n::set[a=1]\n:::else\n::set[b=2]\n:::') as Root
+      .parse(':::if[true]\n::set[a=1]\n:::') as Root
     const content = JSON.stringify(root.children)
     const { unmount } = render(<OnExit content={content} />)
     act(() => {
@@ -77,8 +77,7 @@ describe('Passage lifecycle directives', () => {
       await new Promise(resolve => setTimeout(resolve, 0))
     })
     const data = useGameStore.getState().gameData as Record<string, unknown>
-    expect(data.a).toBeUndefined()
-    expect(data.b).toBe(2)
+    expect(data.a).toBe(1)
     expect(useGameStore.getState().errors).toEqual([])
   })
 

--- a/apps/campfire/src/hooks/useSerializedDirectiveRunner.ts
+++ b/apps/campfire/src/hooks/useSerializedDirectiveRunner.ts
@@ -38,19 +38,7 @@ export const useSerializedDirectiveRunner = (content: string) => {
           condition = false
         }
         const children = stripLabel(container.children as RootContent[])
-        const elseIndex = children.findIndex(
-          child =>
-            child.type === 'containerDirective' &&
-            (child as ContainerDirective).name === 'else'
-        )
-        let branch: RootContent[] = []
-        if (condition) {
-          branch = elseIndex === -1 ? children : children.slice(0, elseIndex)
-        } else if (elseIndex !== -1) {
-          const elseNode = children[elseIndex] as ContainerDirective
-          branch = stripLabel(elseNode.children as RootContent[])
-        }
-        return resolveIf(branch, data)
+        return condition ? resolveIf(children, data) : []
       }
       return [node]
     })

--- a/apps/campfire/src/rehype-campfire/__tests__/index.test.ts
+++ b/apps/campfire/src/rehype-campfire/__tests__/index.test.ts
@@ -114,30 +114,6 @@ describe('rehypeCampfire', () => {
     expect(first.tagName).toBe('show')
   })
 
-  it('unwraps else directives from paragraphs', () => {
-    const tree: Root = {
-      type: 'root',
-      children: [
-        {
-          type: 'element',
-          tagName: 'p',
-          properties: {},
-          children: [
-            {
-              type: 'element',
-              tagName: 'else',
-              properties: { content: '[]' },
-              children: []
-            }
-          ]
-        }
-      ]
-    }
-    rehypeCampfire()(tree)
-    const first = tree.children[0] as any
-    expect(first.tagName).toBe('else')
-  })
-
   it('unwraps input directives from paragraphs', () => {
     const tree: Root = {
       type: 'root',
@@ -307,33 +283,5 @@ describe('rehypeCampfire', () => {
     expect(content).toHaveLength(2)
     expect(content[0].tagName).toBe('show')
     expect(content[1].value).toBe('.')
-  })
-
-  it('unwraps paragraphs inside if directive fallback', () => {
-    const tree: Root = {
-      type: 'root',
-      children: [
-        {
-          type: 'element',
-          tagName: 'if',
-          properties: {
-            test: 'false',
-            fallback: JSON.stringify([
-              {
-                type: 'paragraph',
-                children: [{ type: 'text', value: 'Flag is false' }]
-              }
-            ])
-          },
-          children: []
-        }
-      ]
-    }
-    rehypeCampfire()(tree)
-    const first = tree.children[0] as any
-    const fallback = JSON.parse(first.properties.fallback)
-    expect(fallback).toHaveLength(1)
-    expect(fallback[0].type).toBe('text')
-    expect(fallback[0].value).toBe('Flag is false')
   })
 })

--- a/apps/campfire/src/rehype-campfire/index.ts
+++ b/apps/campfire/src/rehype-campfire/index.ts
@@ -68,7 +68,6 @@ export default function rehypeCampfire(): (tree: Root) => void {
     isLinkButton(node) ||
     (node.type === 'element' &&
       (node.tagName === 'if' ||
-        node.tagName === 'else' ||
         node.tagName === 'show' ||
         node.tagName === 'option' ||
         node.tagName === 'input' ||

--- a/apps/storybook/src/directives/If.stories.tsx
+++ b/apps/storybook/src/directives/If.stories.tsx
@@ -26,10 +26,6 @@ export const Truthy: StoryObj = {
 
 Flag is true
 
-:::else
-
-Flag is false
-
 :::
           `}
         </TwPassagedata>
@@ -41,7 +37,7 @@ Flag is false
 }
 
 /**
- * Shows fallback content when the condition is false.
+ * Shows that nothing from the directive renders when the condition is false.
  *
  * @returns Campfire story demonstrating `if` with a falsy value.
  */
@@ -55,13 +51,11 @@ export const Falsy: StoryObj = {
 
 :::if[flag]
 
-Flag is true
-
-:::else
-
-Flag is false
+This never renders
 
 :::
+
+Flag remains false.
           `}
         </TwPassagedata>
       </TwStorydata>

--- a/docs/directives/conditional-logic-and-iteration.md
+++ b/docs/directives/conditional-logic-and-iteration.md
@@ -8,7 +8,7 @@ Run content only when conditions hold.
 
 ### `if`
 
-Render a block when a JavaScript expression against game data is truthy. Add an `else` container for fallback content.
+Render a block when a JavaScript expression against game data is truthy.
 
 Basic truthy check:
 
@@ -56,20 +56,6 @@ Type checking:
 :::if[typeof key_a !== "string"]
 
 CONTENT WHEN `key_a` IS NOT A STRING
-
-:::
-```
-
-Using with else block:
-
-```md
-:::if[some_key]
-
-TRUTHY CONTENT
-
-:::else
-
-FALLBACK CONTENT
 
 :::
 ```

--- a/projects/campfire-vscode-extension/README.md
+++ b/projects/campfire-vscode-extension/README.md
@@ -56,7 +56,7 @@ Campfire directives can be tedious to type by hand. The extension exposes comple
 
 - `::set`, `::setOnce`, `::createRange`, `::array`, and `::arrayOnce` state helpers.
 - Inline utilities such as `:random`, `:input`, and `:show` for dynamic content.
-- Container helpers including `:::if`, `:::else`, `:::input`, `::trigger`, `::select`, `:::deck`, `:::layer`, and `:::text`.
+- Container helpers including `:::if`, `:::input`, `::trigger`, `::select`, `:::deck`, `:::layer`, and `:::text`.
 
 Trigger completions with `:` and use the snippet placeholders to tab through each directive's attributes.
 

--- a/projects/campfire-vscode-extension/language-configuration.json
+++ b/projects/campfire-vscode-extension/language-configuration.json
@@ -43,7 +43,7 @@
     "lineComment": "//"
   },
   "indentationRules": {
-    "increaseIndentPattern": "^\\s*(:::+|::)\\s*(if|deck|slide|layer|trigger|wrapper|select|random|when|else if?)?\\b.*$",
+    "increaseIndentPattern": "^\\s*(:::+|::)\\s*(if|deck|slide|layer|trigger|wrapper|select|random|when)?\\b.*$",
     "decreaseIndentPattern": "^\\s*:::\\s*$"
   },
   "surroundingPairs": [

--- a/projects/campfire-vscode-extension/package.json
+++ b/projects/campfire-vscode-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "campfire-storybuilder",
   "displayName": "Campfire Storybuilder",
-  "version": "1.106.0",
+  "version": "1.107.1",
   "description": "Author Campfire stories in VS Code with syntax highlighting, snippets, and Campfire directive IntelliSense.",
   "categories": [
     "Programming Languages"

--- a/projects/campfire-vscode-extension/snippets/campfire.code-snippets
+++ b/projects/campfire-vscode-extension/snippets/campfire.code-snippets
@@ -81,11 +81,6 @@
     "body": [":::if[${1:condition}]", "$0", ":::"],
     "description": "Render content when an expression is truthy"
   },
-  "Else Block": {
-    "prefix": "cf-else",
-    "body": [":::else", "$0", ":::"],
-    "description": "Fallback content for a preceding if or switch"
-  },
   "Switch Block": {
     "prefix": "cf-switch",
     "body": [

--- a/projects/campfire-vscode-extension/src/extension.ts
+++ b/projects/campfire-vscode-extension/src/extension.ts
@@ -191,16 +191,8 @@ const directiveSnippets: DirectiveSnippet[] = [
     escapeAtColumnZero: true,
     detail: 'Conditional block',
     documentation:
-      'Wraps content that only renders when the expression is truthy. Pair with `:::else` for fallback content.',
-    body: ':::if[${1:expression}]\n  $0\n:::else\n  $2\n:::'
-  },
-  {
-    marker: ':::',
-    label: 'else',
-    escapeAtColumnZero: true,
-    detail: 'Else block',
-    documentation: 'Extends a prior `if` container with fallback content.',
-    body: ':::else\n  $0\n:::'
+      'Wraps content that only renders when the expression is truthy.',
+    body: ':::if[${1:expression}]\n  $0\n:::'
   },
   {
     marker: '::',

--- a/projects/campfire-vscode-extension/syntaxes/campfire.tmLanguage.json
+++ b/projects/campfire-vscode-extension/syntaxes/campfire.tmLanguage.json
@@ -99,7 +99,7 @@
       "patterns": [
         {
           "name": "meta.directive.container.campfire",
-          "begin": "^(\\\\s*)(:::)(?:allowLandscape|array|arrayOnce|batch|bgm|case|checkbox|checkpoint|clearCheckpoint|clearSave|concat|createRange|deck|default|effect|else|embed|for|goto|if|image|include|input|lang|layer|load|loadCheckpoint|onExit|option|pop|preloadAudio|preloadImage|push|radio|random|randomOnce|reveal|save|select|set|setLanguageLabel|setOnce|setRange|shape|shift|show|slide|sound|splice|switch|t|text|textarea|title|translations|trigger|unset|unshift|volume|wrapper)(?=\\\\b)",
+          "begin": "^(\\\\s*)(:::)(?:allowLandscape|array|arrayOnce|batch|bgm|case|checkbox|checkpoint|clearCheckpoint|clearSave|concat|createRange|deck|default|effect|embed|for|goto|if|image|include|input|lang|layer|load|loadCheckpoint|onExit|option|pop|preloadAudio|preloadImage|push|radio|random|randomOnce|reveal|save|select|set|setLanguageLabel|setOnce|setRange|shape|shift|show|slide|sound|splice|switch|t|text|textarea|title|translations|trigger|unset|unshift|volume|wrapper)(?=\\\\b)",
           "beginCaptures": {
             "2": {
               "name": "punctuation.definition.directive.campfire"
@@ -262,7 +262,7 @@
       "patterns": [
         {
           "name": "meta.directive.inline.campfire",
-          "begin": "(?<!:)(?<!\\\\w)(:)(?:allowLandscape|array|arrayOnce|batch|bgm|case|checkbox|checkpoint|clearCheckpoint|clearSave|concat|createRange|deck|default|effect|else|embed|for|goto|if|image|include|input|lang|layer|load|loadCheckpoint|onExit|option|pop|preloadAudio|preloadImage|push|radio|random|randomOnce|reveal|save|select|set|setLanguageLabel|setOnce|setRange|shape|shift|show|slide|sound|splice|switch|t|text|textarea|title|translations|trigger|unset|unshift|volume|wrapper)(?=\\\\b)",
+          "begin": "(?<!:)(?<!\\\\w)(:)(?:allowLandscape|array|arrayOnce|batch|bgm|case|checkbox|checkpoint|clearCheckpoint|clearSave|concat|createRange|deck|default|effect|embed|for|goto|if|image|include|input|lang|layer|load|loadCheckpoint|onExit|option|pop|preloadAudio|preloadImage|push|radio|random|randomOnce|reveal|save|select|set|setLanguageLabel|setOnce|setRange|shape|shift|show|slide|sound|splice|switch|t|text|textarea|title|translations|trigger|unset|unshift|volume|wrapper)(?=\\\\b)",
           "beginCaptures": {
             "1": {
               "name": "punctuation.definition.directive.campfire"
@@ -314,7 +314,7 @@
       "patterns": [
         {
           "name": "meta.directive.leaf.campfire",
-          "begin": "^(\\\\s*)(::)(?!:)(?:allowLandscape|array|arrayOnce|batch|bgm|case|checkbox|checkpoint|clearCheckpoint|clearSave|concat|createRange|deck|default|effect|else|embed|for|goto|if|image|include|input|lang|layer|load|loadCheckpoint|onExit|option|pop|preloadAudio|preloadImage|preset|push|radio|random|randomOnce|reveal|save|select|set|setLanguageLabel|setOnce|setRange|shape|shift|show|slide|sound|splice|switch|t|text|textarea|title|translations|trigger|unset|unshift|volume|wrapper)(?=\\\\b)",
+          "begin": "^(\\\\s*)(::)(?!:)(?:allowLandscape|array|arrayOnce|batch|bgm|case|checkbox|checkpoint|clearCheckpoint|clearSave|concat|createRange|deck|default|effect|embed|for|goto|if|image|include|input|lang|layer|load|loadCheckpoint|onExit|option|pop|preloadAudio|preloadImage|preset|push|radio|random|randomOnce|reveal|save|select|set|setLanguageLabel|setOnce|setRange|shape|shift|show|slide|sound|splice|switch|t|text|textarea|title|translations|trigger|unset|unshift|volume|wrapper)(?=\\\\b)",
           "beginCaptures": {
             "2": {
               "name": "punctuation.definition.directive.campfire"


### PR DESCRIPTION
## Summary
- drop :::else handling throughout the Campfire runtime so if directives only render truthy content
- refresh docs, stories, and tests to reflect the simplified conditional flow
- update the VS Code extension snippets and grammars to match the revised directive set

## Testing
- bun tsc
- bun test


------
https://chatgpt.com/codex/tasks/task_e_68d7017e333083229232e4307a66b83d