### PR TITLE
fix: tidy global getStoryTitle registration

### DIFF
--- a/apps/campfire/src/state/useStoryDataStore/index.ts
+++ b/apps/campfire/src/state/useStoryDataStore/index.ts
@@ -80,5 +80,7 @@ export const getStoryTitle = (): string | undefined => {
 
   return title || undefined
 }
-;(globalThis as { getStoryTitle?: typeof getStoryTitle }).getStoryTitle =
-  getStoryTitle
+
+const globalScope = globalThis as { getStoryTitle?: typeof getStoryTitle }
+
+globalScope.getStoryTitle = getStoryTitle


### PR DESCRIPTION
## Summary
- remove the leading semicolon when exposing `getStoryTitle` on `globalThis`
- store the helper on a named `globalScope` variable for clarity

## Testing
- bun tsc
- bun test
- bunx prettier apps/campfire/src/state/useStoryDataStore/index.ts --write

------
https://chatgpt.com/codex/tasks/task_e_68d8aa7af89083229c6acf1980d82326