### PR TITLE
fix: restore unset directive handler guard

### DIFF
--- a/apps/campfire/src/hooks/__tests__/unsetDirective.test.tsx
+++ b/apps/campfire/src/hooks/__tests__/unsetDirective.test.tsx
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it } from 'bun:test'
+import type { Root, Text } from 'mdast'
+import type { ContainerDirective, LeafDirective } from 'mdast-util-directive'
+import { createStateHandlers } from '@campfire/hooks/handlers/stateHandlers'
+import { createStateManager } from '@campfire/state/stateManager'
+import { useGameStore } from '@campfire/state/useGameStore'
+import { resetStores } from '@campfire/test-utils/helpers'
+
+describe('unset directive handler', () => {
+  beforeEach(() => {
+    resetStores()
+  })
+
+  const createContext = () => {
+    const manager = createStateManager<Record<string, unknown>>()
+    const errors: string[] = []
+    let refreshCount = 0
+    const ctx = {
+      getState: () => manager,
+      getGameData: () => useGameStore.getState().gameData,
+      refreshState: () => {
+        refreshCount += 1
+      },
+      addError: (msg: string) => {
+        errors.push(msg)
+      }
+    }
+    return { ctx, errors, getRefreshCount: () => refreshCount }
+  }
+
+  it('rejects non-leaf unset directives', () => {
+    const { ctx, errors } = createContext()
+    const { handlers } = createStateHandlers(ctx)
+    const directive: ContainerDirective = {
+      type: 'containerDirective',
+      name: 'unset',
+      attributes: {},
+      children: [],
+      data: {}
+    }
+    const parent: Root = { type: 'root', children: [directive] }
+
+    const result = handlers.unset(directive, parent, 0)
+
+    expect(result).toBe(0)
+    expect(parent.children).toHaveLength(0)
+    expect(errors).toContain('unset can only be used as a leaf directive')
+  })
+
+  it('derives keys from directive labels when attributes are missing', () => {
+    const { ctx, getRefreshCount } = createContext()
+    const { handlers, setValue } = createStateHandlers(ctx)
+    setValue('inventory.weapon', 'sword')
+    const before = getRefreshCount()
+
+    const directive: LeafDirective = {
+      type: 'leafDirective',
+      name: 'unset',
+      attributes: {},
+      children: [],
+      data: {},
+      label: 'inventory.weapon'
+    }
+    const parent: Root = { type: 'root', children: [directive] }
+
+    const result = handlers.unset(directive, parent, 0)
+
+    expect(result).toBe(0)
+    expect(useGameStore.getState().gameData.inventory).toEqual({})
+    expect(getRefreshCount()).toBe(before + 1)
+  })
+
+  it('falls back to directive text content for key derivation', () => {
+    const { ctx, getRefreshCount } = createContext()
+    const { handlers, setValue } = createStateHandlers(ctx)
+    setValue('player.hp', 10)
+    const before = getRefreshCount()
+
+    const directive: LeafDirective = {
+      type: 'leafDirective',
+      name: 'unset',
+      attributes: {},
+      children: [
+        {
+          type: 'text',
+          value: 'player.hp'
+        } as Text
+      ],
+      data: {}
+    }
+    const parent: Root = { type: 'root', children: [directive] }
+
+    const result = handlers.unset(directive, parent, 0)
+
+    expect(result).toBe(0)
+    expect(useGameStore.getState().gameData.player).toEqual({})
+    expect(getRefreshCount()).toBe(before + 1)
+  })
+})

--- a/apps/campfire/src/hooks/handlers/stateHandlers.ts
+++ b/apps/campfire/src/hooks/handlers/stateHandlers.ts
@@ -633,9 +633,13 @@ export const createStateHandlers = (ctx: StateHandlerContext) => {
    */
   const handleUnset: DirectiveHandler = (directive, parent, index) => {
     const invalid = requireLeafDirective(directive, parent, index, addError)
-    bindings: {},
-      chain.push(cursor)
-    chain.reverse()
+    if (invalid !== undefined) return invalid
+    const attrs = directive.attributes || {}
+    const key = ensureKey(
+      (attrs as Record<string, unknown>).key ??
+        (hasLabel(directive) ? directive.label : toString(directive)),
+      parent,
+      index
     )
     if (!key) return index
 

--- a/apps/campfire/src/hooks/handlers/stateHandlers.ts
+++ b/apps/campfire/src/hooks/handlers/stateHandlers.ts
@@ -634,13 +634,12 @@ export const createStateHandlers = (ctx: StateHandlerContext) => {
   const handleUnset: DirectiveHandler = (directive, parent, index) => {
     const invalid = requireLeafDirective(directive, parent, index, addError)
     if (invalid !== undefined) return invalid
-    const attrs = directive.attributes || {}
-    const key = ensureKey(
-      (attrs as Record<string, unknown>).key ??
-        (hasLabel(directive) ? directive.label : toString(directive)),
-      parent,
-      index
-    )
+
+    const attrs = (directive.attributes || {}) as Record<string, unknown>
+    const derivedKey =
+      (attrs.key as string | undefined) ??
+      (hasLabel(directive) ? directive.label : toString(directive))
+    const key = ensureKey(derivedKey, parent, index)
     if (!key) return index
 
     unsetValue(key)


### PR DESCRIPTION
## Summary
- restore the unset directive handler to validate leaf directives before processing
- ensure unset derives keys from attributes or directive text prior to removing state

## Testing
- bun tsc
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68dae0f9f6ec832287fe6fae11d6b8c7