### PR TITLE
fix: stabilize happy dom registration

### DIFF
--- a/happydom.ts
+++ b/happydom.ts
@@ -1,8 +1,20 @@
 import { GlobalRegistrator } from '@happy-dom/global-registrator'
-import { afterAll } from 'bun:test'
+import { afterAll, beforeAll } from 'bun:test'
 
-GlobalRegistrator.register()
+const ensureRegistration = () => {
+  if (!GlobalRegistrator.isRegistered) {
+    GlobalRegistrator.register()
+  }
+}
+
+ensureRegistration()
+
+beforeAll(() => {
+  ensureRegistration()
+})
 
 afterAll(async () => {
-  await GlobalRegistrator.unregister()
+  if (GlobalRegistrator.isRegistered) {
+    await GlobalRegistrator.unregister()
+  }
 })


### PR DESCRIPTION
## Summary
- ensure the happy-dom global registrator is active before each test suite
- guard cleanup so the DOM is only unregistered when it was previously registered

## Testing
- bun tsc
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68daeed6d9488322b26affaa57ccac85