### PR TITLE
fix: stabilize CI by pinning Bun version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: latest
+          bun-version: 1.2.14
       - name: Cache Bun dependencies
         if: ${{ steps.release.outputs.release_created }}
         uses: actions/cache@v4
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v1
         with:
-          bun-version: latest
+          bun-version: 1.2.14
       - uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v1
         with:
-          bun-version: latest
+          bun-version: 1.2.14
       - uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache


### PR DESCRIPTION
## Summary
- pin the GitHub Actions test workflow to Bun 1.2.14 so CI runs the known-good release
- align the release and Storybook workflows to use the same pinned Bun version

## Testing
- bun tsc
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68daf8eacc108322a047e598f438d1fd