### PR TITLE
ci: pin bun to v1.2.22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: 1.2.14
+          bun-version: 1.2.22
       - name: Cache Bun dependencies
         if: ${{ steps.release.outputs.release_created }}
         uses: actions/cache@v4
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v1
         with:
-          bun-version: 1.2.14
+          bun-version: 1.2.22
       - uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v1
         with:
-          bun-version: 1.2.14
+          bun-version: 1.2.22
       - uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache


### PR DESCRIPTION
## Summary
- update GitHub Actions workflows to use Bun v1.2.22

## Testing
- bun tsc
- bun test
- bunx prettier . --write

------
https://chatgpt.com/codex/tasks/task_e_68dafb7ad16c8322b5d143cc574476a8