### PR TITLE
ci: sync release package versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,23 @@ jobs:
       - name: Install dependencies
         if: ${{ steps.release.outputs.release_created }}
         run: bun install
+      - name: Sync package versions
+        if: ${{ steps.release.outputs.release_created }}
+        run: bun run sync-version
+      - name: Commit synced versions
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add projects/campfire-vscode-extension/package.json apps/campfire/package.json
+            git commit -m "chore: sync release versions"
+            git push
+          else
+            echo "No version changes detected"
+          fi
       - name: Build Format
         if: ${{ steps.release.outputs.release_created }}
         run: bun run build


### PR DESCRIPTION
## Summary
- run the version sync script during automated releases
- auto-commit VS Code extension and story format package version updates when needed before building

## Testing
- bun tsc
- bun test
- bunx prettier . --write

------
https://chatgpt.com/codex/tasks/task_e_68dc0751b48883228d3deb348d8324de