### PR TITLE
docs: remove redundant directive grouping sentence

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ They come in leaf, text, or container form, each serving a different role.
   :::
   ```
 
-Directives are grouped by purpose.
-
 ### Example
 
 Here's a practical example showing how directives can be combined to create interactive content:


### PR DESCRIPTION
## Summary
- remove the sentence about directive grouping from the root README

## Testing
- bun tsc
- bun test
- bunx prettier . --write

------
https://chatgpt.com/codex/tasks/task_e_68dc357dc8bc83229c00ae0cf619c554