### PR TITLE
Refactor deck renderer to reuse passage component map

### DIFF
--- a/apps/campfire/src/components/Deck/Slide/renderDirectiveMarkdown.ts
+++ b/apps/campfire/src/components/Deck/Slide/renderDirectiveMarkdown.ts
@@ -1,25 +1,28 @@
 import type { ComponentChild } from 'preact'
 import type { DirectiveHandler } from '@campfire/remark-campfire'
-import { LinkButton } from '@campfire/components/Passage/LinkButton'
-import { TriggerButton } from '@campfire/components/Passage/TriggerButton'
-import { Input } from '@campfire/components/Passage/Input'
-import { Checkbox } from '@campfire/components/Passage/Checkbox'
-import { Radio } from '@campfire/components/Passage/Radio'
-import { Textarea } from '@campfire/components/Passage/Textarea'
-import { Select } from '@campfire/components/Passage/Select'
-import { Option } from '@campfire/components/Passage/Option'
-import { If } from '@campfire/components/Passage/If'
-import { Show } from '@campfire/components/Passage/Show'
-import { Translate } from '@campfire/components/Passage/Translate'
-import { OnExit } from '@campfire/components/Passage/OnExit'
-import { Effect } from '@campfire/components/Passage/Effect'
-import { Switch } from '@campfire/components/Passage/Switch'
+import componentMap from '@campfire/components/Passage/componentMap'
 import { Deck } from '@campfire/components/Deck/Deck'
 import { Slide } from './Slide'
 import { SlideReveal } from './SlideReveal'
 import { Layer } from './Layer'
 import { SlideText, SlideImage, SlideShape, SlideEmbed } from './SlideElements'
+import { Effect } from '@campfire/components/Passage/Effect'
+import { OnExit } from '@campfire/components/Passage/OnExit'
 import { createMarkdownProcessor } from '@campfire/utils/createMarkdownProcessor'
+
+const {
+  deck: _deck,
+  slide: _slide,
+  reveal: _reveal,
+  layer: _layer,
+  slideText: _slideText,
+  slideImage: _slideImage,
+  slideShape: _slideShape,
+  slideEmbed: _slideEmbed,
+  effect: _effect,
+  onExit: _onExit,
+  ...passageComponents
+} = componentMap
 
 /**
  * Converts Markdown containing Campfire directives into Preact elements.
@@ -34,20 +37,9 @@ export const renderDirectiveMarkdown = (
   handlers: Record<string, DirectiveHandler>
 ): ComponentChild => {
   const processor = createMarkdownProcessor(handlers, {
-    button: LinkButton,
-    trigger: TriggerButton,
-    input: Input,
-    checkbox: Checkbox,
-    radio: Radio,
-    textarea: Textarea,
-    select: Select,
-    option: Option,
-    if: If,
-    show: Show,
-    translate: Translate,
+    ...passageComponents,
     effect: Effect,
     onExit: OnExit,
-    switch: Switch,
     deck: Deck,
     slide: Slide,
     reveal: SlideReveal,

--- a/apps/campfire/src/components/Passage/componentMap.ts
+++ b/apps/campfire/src/components/Passage/componentMap.ts
@@ -14,15 +14,15 @@ import { Translate } from '@campfire/components/Passage/Translate'
 import { OnExit } from '@campfire/components/Passage/OnExit'
 import { Effect } from '@campfire/components/Passage/Effect'
 import { Deck } from '@campfire/components/Deck/Deck'
+import { Slide } from '@campfire/components/Deck/Slide/Slide'
+import { SlideReveal } from '@campfire/components/Deck/Slide/SlideReveal'
+import { Layer } from '@campfire/components/Deck/Slide/Layer'
 import {
-  Slide,
-  SlideReveal,
   SlideText,
   SlideImage,
   SlideShape,
-  SlideEmbed,
-  Layer
-} from '@campfire/components/Deck/Slide'
+  SlideEmbed
+} from '@campfire/components/Deck/Slide/SlideElements'
 
 /**
  * Maps directive names to their corresponding Campfire components.


### PR DESCRIPTION
## Summary
- reuse the shared passage component map when building the slide markdown renderer
- continue overriding slide-specific components and the effect/onExit entries to preserve local behaviour
- update the passage component map to import slide pieces directly so the shared map can be reused without circular deps

## Testing
- bun tsc
- bun test
- bunx prettier . --write

------
https://chatgpt.com/codex/tasks/task_e_68dc3522eca8832298516e82be4e49b2