### PR TITLE
test: reuse container directive helper

### DIFF
--- a/apps/campfire/src/components/Passage/__tests__/Checkbox.directive.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Checkbox.directive.test.tsx
@@ -5,6 +5,7 @@ import { Passage } from '@campfire/components/Passage/Passage'
 import { useStoryDataStore } from '@campfire/state/useStoryDataStore'
 import { useGameStore } from '@campfire/state/useGameStore'
 import { resetStores } from '@campfire/test-utils/helpers'
+import { expectContainerDirectiveBehavior } from '@campfire/test-utils/formFieldTests'
 
 /**
  * Tests for Checkbox directive attributes.
@@ -34,45 +35,11 @@ describe('Checkbox directive', () => {
   })
 
   it('runs event directives when used as a container', async () => {
-    const passage: Element = {
-      type: 'element',
-      tagName: 'tw-passagedata',
-      properties: { pid: '1', name: 'Start' },
-      children: [
-        {
-          type: 'text',
-          value:
-            ':::checkbox[agree]\n:::onFocus\n::set[focused=true]\n:::\n:::onMouseEnter\n::set[hovered=true]\n:::\n:::\n'
-        }
-      ]
-    }
-    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
-    render(<Passage />)
-    const button = await screen.findByTestId('checkbox')
-    act(() => {
-      ;(button as HTMLButtonElement).focus()
+    await expectContainerDirectiveBehavior({
+      directiveName: 'checkbox',
+      directiveConfig: '[agree]',
+      testId: 'checkbox'
     })
-    expect(useGameStore.getState().gameData.focused).toBe(true)
-    fireEvent.mouseEnter(button)
-    expect(useGameStore.getState().gameData.hovered).toBe(true)
-  })
-
-  it('removes directive markers for container checkboxes', async () => {
-    const passage: Element = {
-      type: 'element',
-      tagName: 'tw-passagedata',
-      properties: { pid: '1', name: 'Start' },
-      children: [
-        {
-          type: 'text',
-          value: ':::checkbox[agree]\n:::\n'
-        }
-      ]
-    }
-    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
-    render(<Passage />)
-    await screen.findByTestId('checkbox')
-    expect(document.body.textContent).not.toContain(':::')
   })
 
   it('initializes state from value attribute', async () => {

--- a/apps/campfire/src/components/Passage/__tests__/Input.directive.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Input.directive.test.tsx
@@ -5,6 +5,7 @@ import { Passage } from '@campfire/components/Passage/Passage'
 import { useStoryDataStore } from '@campfire/state/useStoryDataStore'
 import { useGameStore } from '@campfire/state/useGameStore'
 import { resetStores } from '@campfire/test-utils/helpers'
+import { expectContainerDirectiveBehavior } from '@campfire/test-utils/formFieldTests'
 
 /**
  * Tests for Input directive attributes.
@@ -38,45 +39,11 @@ describe('Input directive', () => {
   })
 
   it('runs event directives when used as a container', async () => {
-    const passage: Element = {
-      type: 'element',
-      tagName: 'tw-passagedata',
-      properties: { pid: '1', name: 'Start' },
-      children: [
-        {
-          type: 'text',
-          value:
-            ':::input[name]\n:::onFocus\n::set[focused=true]\n:::\n:::onMouseEnter\n::set[hovered=true]\n:::\n:::\n'
-        }
-      ]
-    }
-    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
-    render(<Passage />)
-    const input = await screen.findByTestId('input')
-    act(() => {
-      ;(input as HTMLInputElement).focus()
+    await expectContainerDirectiveBehavior({
+      directiveName: 'input',
+      directiveConfig: '[name]',
+      testId: 'input'
     })
-    expect(useGameStore.getState().gameData.focused).toBe(true)
-    fireEvent.mouseEnter(input)
-    expect(useGameStore.getState().gameData.hovered).toBe(true)
-  })
-
-  it('removes directive markers for container inputs', async () => {
-    const passage: Element = {
-      type: 'element',
-      tagName: 'tw-passagedata',
-      properties: { pid: '1', name: 'Start' },
-      children: [
-        {
-          type: 'text',
-          value: ':::input[name]\n:::\n'
-        }
-      ]
-    }
-    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
-    render(<Passage />)
-    await screen.findByTestId('input')
-    expect(document.body.textContent).not.toContain(':::')
   })
 
   it('initializes state from value attribute', async () => {

--- a/apps/campfire/src/components/Passage/__tests__/Radio.directive.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Radio.directive.test.tsx
@@ -5,6 +5,7 @@ import { Passage } from '@campfire/components/Passage/Passage'
 import { useStoryDataStore } from '@campfire/state/useStoryDataStore'
 import { useGameStore } from '@campfire/state/useGameStore'
 import { resetStores } from '@campfire/test-utils/helpers'
+import { expectContainerDirectiveBehavior } from '@campfire/test-utils/formFieldTests'
 
 /**
  * Tests for Radio directive attributes.
@@ -48,45 +49,11 @@ describe('Radio directive', () => {
   })
 
   it('runs event directives when used as a container', async () => {
-    const passage: Element = {
-      type: 'element',
-      tagName: 'tw-passagedata',
-      properties: { pid: '1', name: 'Start' },
-      children: [
-        {
-          type: 'text',
-          value:
-            ':::radio[choice]{value="a"}\n:::onFocus\n::set[focused=true]\n:::\n:::onMouseEnter\n::set[hovered=true]\n:::\n:::\n:radio[choice]{value="b"}\n'
-        }
-      ]
-    }
-    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
-    render(<Passage />)
-    const buttons = await screen.findAllByTestId('radio')
-    act(() => {
-      ;(buttons[0] as HTMLButtonElement).focus()
+    await expectContainerDirectiveBehavior({
+      directiveName: 'radio',
+      directiveConfig: '[choice]{value="a"}',
+      testId: 'radio'
     })
-    expect(useGameStore.getState().gameData.focused).toBe(true)
-    fireEvent.mouseEnter(buttons[0])
-    expect(useGameStore.getState().gameData.hovered).toBe(true)
-  })
-
-  it('removes directive markers for container radios', async () => {
-    const passage: Element = {
-      type: 'element',
-      tagName: 'tw-passagedata',
-      properties: { pid: '1', name: 'Start' },
-      children: [
-        {
-          type: 'text',
-          value: ':::radio[choice]{value="a"}\n:::\n:radio[choice]{value="b"}\n'
-        }
-      ]
-    }
-    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
-    render(<Passage />)
-    await screen.findAllByTestId('radio')
-    expect(document.body.textContent).not.toContain(':::')
   })
 
   it('initializes state from checked attribute', async () => {

--- a/apps/campfire/src/components/Passage/__tests__/Textarea.directive.test.tsx
+++ b/apps/campfire/src/components/Passage/__tests__/Textarea.directive.test.tsx
@@ -11,6 +11,7 @@ import { Passage } from '@campfire/components/Passage/Passage'
 import { useStoryDataStore } from '@campfire/state/useStoryDataStore'
 import { useGameStore } from '@campfire/state/useGameStore'
 import { resetStores } from '@campfire/test-utils/helpers'
+import { expectContainerDirectiveBehavior } from '@campfire/test-utils/formFieldTests'
 
 /**
  * Tests for Textarea directive attributes.
@@ -44,45 +45,11 @@ describe('Textarea directive', () => {
   })
 
   it('runs event directives when used as a container', async () => {
-    const passage: Element = {
-      type: 'element',
-      tagName: 'tw-passagedata',
-      properties: { pid: '1', name: 'Start' },
-      children: [
-        {
-          type: 'text',
-          value:
-            ':::textarea[bio]\n:::onFocus\n::set[focused=true]\n:::\n:::onMouseEnter\n::set[hovered=true]\n:::\n:::\n'
-        }
-      ]
-    }
-    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
-    render(<Passage />)
-    const textarea = await screen.findByTestId('textarea')
-    act(() => {
-      ;(textarea as HTMLTextAreaElement).focus()
+    await expectContainerDirectiveBehavior({
+      directiveName: 'textarea',
+      directiveConfig: '[bio]',
+      testId: 'textarea'
     })
-    expect(useGameStore.getState().gameData.focused).toBe(true)
-    fireEvent.mouseEnter(textarea)
-    expect(useGameStore.getState().gameData.hovered).toBe(true)
-  })
-
-  it('removes directive markers for container textareas', async () => {
-    const passage: Element = {
-      type: 'element',
-      tagName: 'tw-passagedata',
-      properties: { pid: '1', name: 'Start' },
-      children: [
-        {
-          type: 'text',
-          value: ':::textarea[bio]\n:::\n'
-        }
-      ]
-    }
-    useStoryDataStore.setState({ passages: [passage], currentPassageId: '1' })
-    render(<Passage />)
-    await screen.findByTestId('textarea')
-    expect(document.body.textContent).not.toContain(':::')
   })
 
   it('initializes state from value attribute', async () => {


### PR DESCRIPTION
## Summary
- add a shared helper for container directive event assertions in form field tests
- refactor input, textarea, checkbox, and radio directive tests to reuse the helper

## Testing
- bun tsc
- bun test apps/campfire/src/components/Passage/__tests__/Input.directive.test.tsx
- bun test apps/campfire/src/components/Passage/__tests__/Textarea.directive.test.tsx
- bun test apps/campfire/src/components/Passage/__tests__/Checkbox.directive.test.tsx
- bun test apps/campfire/src/components/Passage/__tests__/Radio.directive.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dc3e579e7c8322b5a51c6fe2d203c9