### PR TITLE
feat: add passage text helper utility

### DIFF
--- a/apps/campfire/src/components/Passage/Passage.tsx
+++ b/apps/campfire/src/components/Passage/Passage.tsx
@@ -1,6 +1,6 @@
 import { cloneElement, type ComponentChild, type VNode } from 'preact'
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
-import type { Text as HastText, Content } from 'hast'
+import type { Content } from 'hast'
 import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
 import {
   remarkHeadingStyles,
@@ -18,6 +18,7 @@ import {
 } from '@campfire/state/useStoryDataStore'
 import { useDeckStore } from '@campfire/state/useDeckStore'
 import { componentMap } from '@campfire/components/Passage/componentMap'
+import { getPassageText } from '@campfire/utils/core'
 
 /**
  * Builds a document title from story and passage names.
@@ -166,11 +167,7 @@ export const Passage = () => {
         return
       }
       const id = passage.properties?.pid as string | undefined
-      const text = passage.children
-        .map((child: Content) =>
-          child.type === 'text' ? (child as HastText).value : ''
-        )
-        .join('')
+      const text = getPassageText(passage.children as Content[])
       const cache = getPassageCache()
       const shouldCache = id && canCachePassage(text)
       const cached = shouldCache ? cache.get(id) : undefined

--- a/apps/campfire/src/hooks/handlers/navigationHandlers.ts
+++ b/apps/campfire/src/hooks/handlers/navigationHandlers.ts
@@ -8,9 +8,9 @@ import remarkCampfire, {
   remarkCampfireIndentation
 } from '@campfire/remark-campfire'
 import type { RootContent } from 'mdast'
-import type { ElementContent, Text as HastText } from 'hast'
+import type { Content, ElementContent } from 'hast'
 import i18next from 'i18next'
-import { QUOTE_PATTERN } from '@campfire/utils/core'
+import { QUOTE_PATTERN, getPassageText } from '@campfire/utils/core'
 import {
   removeNode,
   replaceWithIndentation
@@ -231,11 +231,7 @@ export const createNavigationHandlers = (ctx: NavigationHandlerContext) => {
 
     if (!passage) return removeNode(p, i)
 
-    const text = passage.children
-      .map((child: ElementContent) =>
-        child.type === 'text' ? (child as HastText).value : ''
-      )
-      .join('')
+    const text = getPassageText(passage.children as Content[])
 
     const processor = unified()
       .use(remarkParse)

--- a/apps/campfire/src/hooks/useOverlayProcessor.tsx
+++ b/apps/campfire/src/hooks/useOverlayProcessor.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo } from 'preact/hooks'
 import type { ComponentChild } from 'preact'
-import type { Content, Text as HastText } from 'hast'
+import type { Content } from 'hast'
 import { useDirectiveHandlers } from '@campfire/hooks/useDirectiveHandlers'
 import { createMarkdownProcessor } from '@campfire/utils/createMarkdownProcessor'
 import { useStoryDataStore } from '@campfire/state/useStoryDataStore'
@@ -13,6 +13,7 @@ import {
 import { componentMap } from '@campfire/components/Passage/componentMap'
 import { useOverlayDeckStore } from '@campfire/state/useOverlayDeckStore'
 import { normalizeDirectiveIndentation } from '@campfire/utils/normalizeDirectiveIndentation'
+import { getPassageText } from '@campfire/utils/core'
 
 /**
  * Processes overlay passages into persistent components rendered above passages.
@@ -64,13 +65,7 @@ export const useOverlayProcessor = (): void => {
         group?: string
       }[]
       for (const passage of overlays) {
-        const text = passage.children
-          .map((child: Content) =>
-            child.type === 'text' && typeof child.value === 'string'
-              ? (child as HastText).value
-              : ''
-          )
-          .join('')
+        const text = getPassageText(passage.children as Content[])
         const normalized = normalizeDirectiveIndentation(text)
         if (controller.signal.aborted) return
         const file = await processor.process(normalized)

--- a/apps/campfire/src/utils/__tests__/core.test.ts
+++ b/apps/campfire/src/utils/__tests__/core.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, afterEach } from 'bun:test'
+import type { Content } from 'hast'
 import {
   extractQuoted,
   getBaseUrl,
+  getPassageText,
   mergeClasses,
   parseDisabledAttr
 } from '@campfire/utils/core'
@@ -35,6 +37,24 @@ describe('mergeClasses', () => {
     expect(mergeClasses('a', undefined, 'a', ['b', '', 'c'], false)).toBe(
       'a b c'
     )
+  })
+})
+
+describe('getPassageText', () => {
+  it('joins direct text nodes and ignores non-text nodes', () => {
+    const children: Content[] = [
+      { type: 'text', value: 'Hello ' },
+      {
+        type: 'element',
+        tagName: 'span',
+        properties: {},
+        children: [{ type: 'text', value: 'nested' }]
+      } as Content,
+      { type: 'text', value: 'world' },
+      { type: 'comment', value: 'ignore me' }
+    ]
+
+    expect(getPassageText(children)).toBe('Hello world')
   })
 })
 

--- a/apps/campfire/src/utils/core.ts
+++ b/apps/campfire/src/utils/core.ts
@@ -1,4 +1,5 @@
 import { compile } from 'expression-eval'
+import type { Content, Text as HastText } from 'hast'
 import type { JSX } from 'preact'
 
 /**
@@ -205,3 +206,21 @@ export const getBaseUrl = (): string => {
   }
   return 'http://localhost'
 }
+
+/**
+ * Extracts concatenated text content from a collection of HAST child nodes.
+ *
+ * Only nodes with a `type` of `'text'` contribute to the output so the helper
+ * mirrors existing passage processing behavior.
+ *
+ * @param children - Child nodes potentially containing text values.
+ * @returns The joined text from all text nodes.
+ */
+export const getPassageText = (children: Content[]): string =>
+  children
+    .map(child =>
+      child.type === 'text' && typeof (child as HastText).value === 'string'
+        ? (child as HastText).value
+        : ''
+    )
+    .join('')

--- a/apps/campfire/src/utils/core.ts
+++ b/apps/campfire/src/utils/core.ts
@@ -1,5 +1,5 @@
 import { compile } from 'expression-eval'
-import type { Content, Text as HastText } from 'hast'
+import type { Content } from 'hast'
 import type { JSX } from 'preact'
 
 /**
@@ -219,8 +219,8 @@ export const getBaseUrl = (): string => {
 export const getPassageText = (children: Content[]): string =>
   children
     .map(child =>
-      child.type === 'text' && typeof (child as HastText).value === 'string'
-        ? (child as HastText).value
+      child.type === 'text' && typeof child.value === 'string'
+        ? child.value
         : ''
     )
     .join('')


### PR DESCRIPTION
## Summary
- add a reusable `getPassageText` helper for extracting top-level text nodes
- apply the helper across passage rendering, overlay processing, and navigation handlers
- cover the helper with a focused unit test to lock in behavior

## Testing
- bun tsc
- bun test
- bunx prettier . --write

------
https://chatgpt.com/codex/tasks/task_e_68dd947e449c8322823343d82996db85