### PR TITLE
refactor: reuse extractQuoted in navigation handlers

### DIFF
--- a/apps/campfire/src/hooks/handlers/navigationHandlers.ts
+++ b/apps/campfire/src/hooks/handlers/navigationHandlers.ts
@@ -10,7 +10,7 @@ import remarkCampfire, {
 import type { RootContent } from 'mdast'
 import type { Content, ElementContent } from 'hast'
 import i18next from 'i18next'
-import { QUOTE_PATTERN, getPassageText } from '@campfire/utils/core'
+import { extractQuoted, getPassageText } from '@campfire/utils/core'
 import {
   removeNode,
   replaceWithIndentation
@@ -75,17 +75,6 @@ export const createNavigationHandlers = (ctx: NavigationHandlerContext) => {
   } = ctx
 
   /**
-   * Extracts the content of a string wrapped in matching quotes or backticks.
-   *
-   * @param value - The raw string to inspect.
-   * @returns The inner string if quoted, otherwise undefined.
-   */
-  const getQuotedValue = (value: string): string | undefined => {
-    const match = value.trim().match(QUOTE_PATTERN)
-    return match ? match[2] : undefined
-  }
-
-  /**
    * Retrieves a string or numeric value from the game state by key.
    *
    * @param key - The game state key to read.
@@ -115,15 +104,16 @@ export const createNavigationHandlers = (ctx: NavigationHandlerContext) => {
     attrs: Record<string, unknown>
   ): string | undefined => {
     if (rawText) {
-      return (
-        getQuotedValue(rawText) ??
-        (NUMERIC_PATTERN.test(rawText) ? rawText : undefined)
-      )
+      const trimmed = rawText.trim()
+      const quoted = extractQuoted(trimmed)
+      if (quoted) return quoted
+      return NUMERIC_PATTERN.test(trimmed) ? trimmed : undefined
     }
-    const attr =
-      typeof attrs.passage === 'string' ? attrs.passage.trim() : undefined
-    if (!attr) return undefined
-    const quoted = getQuotedValue(attr)
+    const attrRaw =
+      typeof attrs.passage === 'string' ? attrs.passage : undefined
+    if (!attrRaw) return undefined
+    const attr = attrRaw.trim()
+    const quoted = extractQuoted(attr)
     if (quoted) return quoted
     if (NUMERIC_PATTERN.test(attr)) return attr
     return getStateValue(attr, getGameData())
@@ -181,7 +171,7 @@ export const createNavigationHandlers = (ctx: NavigationHandlerContext) => {
     if (invalid !== undefined) return invalid
     if (getIncludeDepth() > 0) return removeNode(parent, index)
     const raw = toString(directive).trim()
-    const title = getQuotedValue(raw)
+    const title = extractQuoted(raw)
     if (title) {
       document.title = i18next.t(title)
       markTitleOverridden()


### PR DESCRIPTION
## Summary
- reuse the shared `extractQuoted` helper in the navigation handlers
- trim directive text before resolving quoted or numeric passage targets

## Testing
- bun tsc
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68de824dbb1883228840777b1df8af6d