### PR TITLE
feat: refactor bound text field components

### DIFF
--- a/apps/campfire/src/components/Passage/BoundFieldProps.ts
+++ b/apps/campfire/src/components/Passage/BoundFieldProps.ts
@@ -207,7 +207,7 @@ export const createBoundTextField = <Tag extends 'input' | 'textarea'>({
       setValue(target.value)
     }
 
-    return h(ElementTag, {
+    const mergedProps = {
       'data-testid': testId,
       className: mergeClasses(...baseClassNames, className),
       value: value ?? '',
@@ -216,7 +216,9 @@ export const createBoundTextField = <Tag extends 'input' | 'textarea'>({
       ...elementProps,
       ...directiveEvents,
       onInput: handleInput
-    } as BoundTextFieldAttributes<Tag> & Record<string, unknown>)
+    } satisfies BoundTextFieldAttributes<Tag>
+
+    return h(ElementTag, mergedProps)
   }
 
   return BoundTextField

--- a/apps/campfire/src/components/Passage/Input.tsx
+++ b/apps/campfire/src/components/Passage/Input.tsx
@@ -1,7 +1,7 @@
 import { mergeClasses } from '@campfire/utils/core'
 import {
+  createBoundTextField,
   fieldBaseStyles,
-  useBoundField,
   type BoundFieldElementProps
 } from './BoundFieldProps'
 
@@ -10,58 +10,15 @@ const inputStyles = mergeClasses(
   'file:text-foreground selection:bg-primary selection:text-primary-foreground disabled:pointer-events-none min-w-0 h-9 px-3 py-1 file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium'
 )
 
-type InputProps = BoundFieldElementProps<HTMLInputElement, string>
+export type InputProps = BoundFieldElementProps<HTMLInputElement, string>
 
 /**
  * Text input bound to a game state key. Updates the key on user input.
- *
- * @param stateKey - Key in game state to store the value.
- * @param className - Optional additional classes.
- * @param onMouseEnter - Serialized directives to run on mouse enter.
- * @param onMouseLeave - Serialized directives to run on mouse leave.
- * @param onFocus - Serialized directives to run on focus.
- * @param onBlur - Serialized directives to run on blur.
- * @param rest - Additional input element attributes.
- * @returns The rendered input element.
  */
-export const Input = ({
-  stateKey,
-  className,
-  onMouseEnter,
-  onMouseLeave,
-  onFocus,
-  onBlur,
-  onInput,
-  initialValue,
-  disabled,
-  ...rest
-}: InputProps) => {
-  const { value, setValue, isDisabled, directiveEvents } =
-    useBoundField<string>({
-      stateKey,
-      initialValue: initialValue ?? '',
-      disabled,
-      onMouseEnter,
-      onMouseLeave,
-      onFocus,
-      onBlur
-    })
-  return (
-    <input
-      data-testid='input'
-      className={mergeClasses('campfire-input', inputStyles, className)}
-      value={value ?? ''}
-      disabled={isDisabled}
-      {...rest}
-      {...directiveEvents}
-      onInput={e => {
-        onInput?.(e)
-        if (e.defaultPrevented) return
-        const target = e.currentTarget as HTMLInputElement
-        setValue(target.value)
-      }}
-    />
-  )
-}
+export const Input = createBoundTextField<'input'>({
+  tag: 'input',
+  baseClassNames: ['campfire-input', inputStyles],
+  testId: 'input'
+})
 
 export default Input

--- a/apps/campfire/src/components/Passage/Textarea.tsx
+++ b/apps/campfire/src/components/Passage/Textarea.tsx
@@ -1,7 +1,7 @@
 import { mergeClasses } from '@campfire/utils/core'
 import {
+  createBoundTextField,
   fieldBaseStyles,
-  useBoundField,
   type BoundFieldElementProps
 } from './BoundFieldProps'
 
@@ -10,58 +10,15 @@ const textareaStyles = mergeClasses(
   'field-sizing-content min-h-16 px-3 py-2'
 )
 
-type TextareaProps = BoundFieldElementProps<HTMLTextAreaElement, string>
+export type TextareaProps = BoundFieldElementProps<HTMLTextAreaElement, string>
 
 /**
  * Textarea bound to a game state key. Updates the key on user input.
- *
- * @param stateKey - Key in game state to store the value.
- * @param className - Optional additional classes.
- * @param onMouseEnter - Serialized directives to run on mouse enter.
- * @param onMouseLeave - Serialized directives to run on mouse leave.
- * @param onFocus - Serialized directives to run on focus.
- * @param onBlur - Serialized directives to run on blur.
- * @param rest - Additional textarea element attributes.
- * @returns The rendered textarea element.
  */
-export const Textarea = ({
-  stateKey,
-  className,
-  onMouseEnter,
-  onMouseLeave,
-  onFocus,
-  onBlur,
-  onInput,
-  initialValue,
-  disabled,
-  ...rest
-}: TextareaProps) => {
-  const { value, setValue, isDisabled, directiveEvents } =
-    useBoundField<string>({
-      stateKey,
-      initialValue: initialValue ?? '',
-      disabled,
-      onMouseEnter,
-      onMouseLeave,
-      onFocus,
-      onBlur
-    })
-  return (
-    <textarea
-      data-testid='textarea'
-      className={mergeClasses('campfire-textarea', textareaStyles, className)}
-      value={value ?? ''}
-      disabled={isDisabled}
-      {...rest}
-      {...directiveEvents}
-      onInput={e => {
-        onInput?.(e)
-        if (e.defaultPrevented) return
-        const target = e.currentTarget as HTMLTextAreaElement
-        setValue(target.value)
-      }}
-    />
-  )
-}
+export const Textarea = createBoundTextField<'textarea'>({
+  tag: 'textarea',
+  baseClassNames: ['campfire-textarea', textareaStyles],
+  testId: 'textarea'
+})
 
 export default Textarea


### PR DESCRIPTION
## Summary
- add a createBoundTextField factory to share binding logic for form text fields
- refactor the Input and Textarea components to use the shared factory while keeping existing styles and exports

## Testing
- bun tsc
- bun test
- bunx prettier . --write

------
https://chatgpt.com/codex/tasks/task_e_68dea19e429c832293805701e873d4da