### PR TITLE
fix: dedupe preact modules in storybook dev config

### DIFF
--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -19,6 +19,11 @@ const config: StorybookConfig = {
       ...(config.resolve.alias ?? {}),
       '@campfire': path.resolve(__dirname, '../../campfire/src')
     }
+    config.resolve.dedupe = [
+      ...(config.resolve.dedupe ?? []),
+      'preact',
+      'preact/hooks'
+    ]
     config.build ??= {}
     config.build.sourcemap = true
     return config


### PR DESCRIPTION
## Summary
- dedupe preact modules in the Storybook Vite config so dev mode uses a single hooks runtime

## Testing
- bun tsc
- bun test
- bunx prettier . --write

------
https://chatgpt.com/codex/tasks/task_e_68dedb97dca8832285fec7d8500fb2b8