### PR TITLE
Remove version sync steps from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,23 +41,6 @@ jobs:
       - name: Install dependencies
         if: ${{ steps.release.outputs.release_created }}
         run: bun install
-      - name: Sync package versions
-        if: ${{ steps.release.outputs.release_created }}
-        run: bun run sync-version
-      - name: Commit synced versions
-        if: ${{ steps.release.outputs.release_created }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          if [[ -n "$(git status --porcelain)" ]]; then
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add projects/campfire-vscode-extension/package.json apps/campfire/package.json
-            git commit -m "chore: sync release versions"
-            git push
-          else
-            echo "No version changes detected"
-          fi
       - name: Build Format
         if: ${{ steps.release.outputs.release_created }}
         run: bun run build


### PR DESCRIPTION
## Summary
- remove the sync-version script invocation from the release workflow so releases no longer run the version sync step
- remove the commit synced versions step from the release workflow so releases stop committing version changes

## Testing
- bun tsc
- bun test
- bunx prettier . --write

------
https://chatgpt.com/codex/tasks/task_e_68def41600f0832286759d3d74fdd2ab